### PR TITLE
Rework how the virtual eclipse is produced

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -60,6 +60,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -254,8 +255,7 @@ public class SolexVideoProcessor implements Broadcaster {
 
     private EllipseFittingTask.Result performEllipseFitting(List<WorkflowState> imageList, ImageEmitterFactory imageEmitterFactory, ForkJoinContext executor) {
         var selected = imageList.stream()
-                .filter(i -> i.pixelShift() == processParams.spectrumParams().pixelShift())
-                .findFirst();
+                .min(Comparator.comparing(WorkflowState::pixelShift));
         if (selected.isPresent()) {
             var ellipseFittingTask = new EllipseFittingTask(this, selected.get().image(), .25d, processParams, imageEmitterFactory.newEmitter(this, executor, Constants.TYPE_DEBUG, outputDirectory)).withPrefilter();
             try {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
@@ -255,16 +255,9 @@ public class ProcessingWorkflow {
 
     private void produceCoronagraph(float blackPoint, ImageWrapper32 geometryFixed) {
         state.<GeometryCorrector.Result>findResult(WorkflowResults.GEOMETRY_CORRECTION).ifPresent(result -> {
-            Ellipse ellipse;
-            try {
-                ellipse = new EllipseFittingTask(broadcaster, result.corrected(), .35d)
-                        .call().ellipse();
-            } catch (Exception e) {
-                throw ProcessingException.wrap(e);
-            }
-            var diskEllipse = ellipse;
-            var produceVirtualEclipse = shouldProduce(GeneratedImageKind.VIRTUAL_ECLIPSE);
-            var produceMixed = shouldProduce(GeneratedImageKind.MIXED);
+            Ellipse diskEllipse = result.correctedCircle();
+            var produceVirtualEclipse = diskEllipse != null && shouldProduce(GeneratedImageKind.VIRTUAL_ECLIPSE);
+            var produceMixed = diskEllipse != null && shouldProduce(GeneratedImageKind.MIXED);
             if (produceVirtualEclipse || produceMixed) {
                 executor.submitAndThen(new CoronagraphTask(broadcaster, geometryFixed, diskEllipse, blackPoint), coronagraph -> {
                     processedImagesEmitter.newMonoImage(GeneratedImageKind.VIRTUAL_ECLIPSE, message("protus"), "protus", coronagraph, LinearStrechingStrategy.DEFAULT);


### PR DESCRIPTION
By performing an ellipse regression on corrected samples instead of doing edge detection and re-sampling on the corrected image.

Fixes #35