### PR TITLE
Add a background removal function

### DIFF
--- a/docs/src/docs/asciidoc/en/jsolex.adoc
+++ b/docs/src/docs/asciidoc/en/jsolex.adoc
@@ -213,6 +213,7 @@ NOTE: If you don't want to provide a custom black point value, you can use a pre
 
 - `autocrop` will perform a square cropping of the image. It makes use of the detected ellipse to center the image on the sun center. e.g `autocrop(img(0))`.
 - `colorize` triggers colorization of the image. It either takes 2 parameters, the image and a profile name, or 7 parameters. The profile name is the name of the color profile as found in the process parameters. For example: `colorize(img(0), "h-alpha"). The long version takes the image and for each RGB color channel, the "in" and "out" values determining the color curves, in the 0..255 range. e.g `colorize(img(0), 84, 139, 95, 20, 218, 65)` is strictly equivalent to the `h-alpha` version. It's worth noting that colorizing is highly sensitive to the source pixel values. It may be required to run an `asin_stretch` function before colorizing.
+- `remove_bg` performs background removal on an image. This can be used when the contrast is very low (e.g in helium processing) and that stretching the image also stretches the background. This process computes the average value of pixels outside the disk, then uses that to perform an adaptative suppression depending on the distance from the limb, in order to preserve light structures around the limb. For example: `remove_bg(stretched)`. Another variant lets you specify a tolerance value: `remove_bg(stretched, 0.2)`. The lower the tolerance, the weaker the correction will be.
 
 === ImageMath scripts
 

--- a/docs/src/docs/asciidoc/fr/jsolex.adoc
+++ b/docs/src/docs/asciidoc/fr/jsolex.adoc
@@ -207,6 +207,7 @@ Les autres fonctions disponibles sont:
 - `asinh_stretch` permet d'appliquer la fonction d'étirement par arcsinus hyperbolique. Elle prend 3 paramètres: l'image, le point noir et le coefficient de stretch. Par exemple, `asinh_stretch(img(0), 200, 100)`.
 - `linear_stretch` augmente la plage dynamique d'une image. Elle prend soit 1, soit 3 paramètres : l'image, puis optionellement les valeurs min et max des pixels (valeur comprise entre 0 et 65535). Par exemple: `linear_stretch(img(0))`
 - `fix_banding` permet d'appliquer l'algorithme de corrections de bandes (ou transversallium). Il prend 3 arguments: l'image, la largeur de bande et le nombre d'itérations. Par exemple, `fix_banding(img(0), 10, 5)`.
+- `remove_bg` permet de supprimer l'arrière plan d'une image. Ceci peut être utile lorsque le constraste est très faible (par exemple en raie hélium). Le processus calcule la valeur moyenne des pixels en dehors du disque, puis applique une suppression de l'arrière plan en fonction de la distance au limbe. Par exemple: `remove_bg(stretched)`. Une variante est disponible avec une tolerance: `remove_bg(stretched, 0.2)`. Plus la tolérance est proche de 0, moins la suppression est forte.
 
 NOTE: Si vous ne connaissez pas la valeur du point noir, vous pouvez utiliser la valeur estimée par JSol'Ex, disponible dans une variable prédéfinie `blackPoint`: `asinh_stretch(img(0), blackPoint, 100)`
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/BuiltinFunction.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/BuiltinFunction.java
@@ -18,19 +18,20 @@ package me.champeau.a4j.jsolex.expr;
 import java.util.Locale;
 
 public enum BuiltinFunction {
-    AVG,
+    ADJUST_CONTRAST,
+    ASINH_STRETCH,
     AUTOCROP,
+    AVG,
+    CLAHE,
+    COLORIZE,
     FIX_BANDING,
     IMG,
     INVERT,
+    LINEAR_STRETCH,
     MAX,
     MIN,
     RANGE,
-    LINEAR_STRETCH,
-    ASINH_STRETCH,
-    CLAHE,
-    ADJUST_CONTRAST,
-    COLORIZE;
+    REMOVE_BG;
 
     public String lowerCaseName() {
         return name().toLowerCase(Locale.US);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/BandingReduction.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/BandingReduction.java
@@ -19,6 +19,8 @@ import me.champeau.a4j.math.image.Image;
 import me.champeau.a4j.math.image.ImageMath;
 import me.champeau.a4j.math.regression.Ellipse;
 
+import static me.champeau.a4j.jsolex.processing.sun.ImageUtils.bilinearSmoothing;
+
 public class BandingReduction {
     private BandingReduction() {
     }
@@ -39,6 +41,9 @@ public class BandingReduction {
                     }
                 }
             }
+        }
+        if (ellipse != null) {
+            bilinearSmoothing(ellipse, width, height, data);
         }
     }
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/AnalysisUtils.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/AnalysisUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.sun.workflow;
+
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
+import me.champeau.a4j.math.regression.Ellipse;
+
+public class AnalysisUtils {
+    public static double estimateBlackPoint(ImageWrapper32 image, Ellipse ellipse) {
+        var width = image.width();
+        var height = image.height();
+        var buffer = image.data();
+        double blackEstimate = Double.MAX_VALUE;
+        int cpt = 0;
+        var cx = ellipse.center().a();
+        var cy = ellipse.center().b();
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                if (!ellipse.isWithin(x, y)) {
+                    var v = buffer[x + y * width];
+                    if (v > 0) {
+                        var offcenter = 2 * Math.sqrt((x - cx) * (x - cx) + (y - cy) * (y - cy)) / (width + height);
+                        blackEstimate = blackEstimate + (offcenter * v - blackEstimate) / (++cpt);
+                    }
+                }
+            }
+        }
+        return blackEstimate;
+    }
+
+    public static double estimateBackground(ImageWrapper32 image, Ellipse ellipse) {
+        var width = image.width();
+        var height = image.height();
+        var buffer = image.data();
+        double avg = Double.MAX_VALUE;
+        int cpt = 0;
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                if (!ellipse.isWithin(x, y)) {
+                    var v = buffer[x + y * width];
+                    if (v > 0) {
+                        avg = avg + (v - avg) / (++cpt);
+                    }
+                }
+            }
+        }
+        return avg;
+    }
+}

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/ImageExpressionEvaluatorTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/ImageExpressionEvaluatorTest.groovy
@@ -16,10 +16,13 @@
 package me.champeau.a4j.jsolex.processing.expr
 
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32
+import me.champeau.a4j.math.regression.Ellipse
+import me.champeau.a4j.math.tuples.DoubleSextuplet
 import spock.lang.Specification
 import spock.lang.Subject
 
 class ImageExpressionEvaluatorTest extends Specification {
+    public static final Ellipse DUMMY_ELLIPSE = Ellipse.ofCartesian(new DoubleSextuplet(0, 0, 0, 0, 0, 0))
     @Subject
     ImageExpressionEvaluator evaluator
 
@@ -79,5 +82,36 @@ class ImageExpressionEvaluatorTest extends Specification {
         then:
         evaluator.shifts ==~ [-2, -1, 0, 1, 2]
         list.size() == 2
+    }
+
+    def "can apply #function on a list of images"() {
+        given:
+        evaluator = new ShiftCollectingImageExpressionEvaluator(images::get)
+        evaluator.putInContext(Ellipse, DUMMY_ELLIPSE)
+
+        when:
+        var result = evaluator.evaluate("$function($parameters)")
+        resultType.isAssignableFrom(result.class)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        function          | parameters                  | resultType
+        "avg"             | "range(0,1)"                | ImageWrapper32
+        "min"             | "range(0,1)"                | ImageWrapper32
+        "max"             | "range(0,1)"                | ImageWrapper32
+        "colorize"        | "range(0,1), \"h-alpha\""   | List
+        "colorize"        | "range(0,1),0,0,0,0,0,0"    | List
+        "remove_bg"       | "range(0,1)"                | List
+        "remove_bg"       | "range(0,1),0.5"            | List
+        "invert"          | "range(0,1)"                | List
+        "fix_banding"     | "range(0,1), 10, 1"         | List
+        "linear_stretch"  | "range(0,1)"                | List
+        "ASINH_STRETCH"   | "range(0,1), 0, 10"         | List
+        "CLAHE"           | "range(0,1), 1.2"           | List
+        "CLAHE"           | "range(0,1), 128, 512, 1.2" | List
+        "ADJUST_CONTRAST" | "range(0,1), 0, 255"        | List
+        "autocrop"        | "range(0,1)"                | List
     }
 }


### PR DESCRIPTION
This function can be called with `remove_bg(img;tolerance)`. It will use the ellipse mask to determine pixels which are outside of the sun disk, then compute the average of the image outside of the disk. It will then attempt to remove the background while preserving areas which are close to the limb.