### PR TITLE
Make it possible to re-execute scripts when image shifts are missing

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/ShiftCollectingImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/ShiftCollectingImageExpressionEvaluator.java
@@ -16,8 +16,10 @@
 package me.champeau.a4j.jsolex.processing.expr;
 
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
@@ -26,6 +28,14 @@ public class ShiftCollectingImageExpressionEvaluator extends ImageExpressionEval
 
     private final Set<Integer> shifts = new TreeSet<>();
 
+    public static Function<Integer, ImageWrapper> zeroImages() {
+        var map = new HashMap<Integer, ImageWrapper>();
+        return (Integer idx) -> map.computeIfAbsent(idx, unused -> new ImageWrapper32(0, 0, new float[0]));
+    }
+
+    public ShiftCollectingImageExpressionEvaluator() {
+        this(zeroImages());
+    }
     public ShiftCollectingImageExpressionEvaluator(Function<Integer, ImageWrapper> imageFactory) {
         super(imageFactory);
     }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
@@ -520,7 +520,7 @@ public class JSolEx extends Application implements JSolExInterface {
             console.textProperty().set("");
             var interruptButton = addInterruptButton();
             var processingThread = new Thread(() -> cpuExecutor.blocking(() ->
-                    processSingleFile(cpuExecutor, params, selectedFile, false, 0, null, firstHeader, () -> {
+                    processSingleFile(cpuExecutor, params, selectedFile, false, 0, selectedFile, firstHeader, () -> {
                         BatchOperations.submit(() -> workButtons.getChildren().remove(interruptButton));
                     })
             ));
@@ -714,7 +714,9 @@ public class JSolEx extends Application implements JSolExInterface {
         if (batchMode) {
             return new BatchModeEventListener(this, sequenceNumber, (BatchProcessingContext) context, params);
         }
-        return new SingleModeProcessingEventListener(this, baseName, params);
+        var serFile = (File) context;
+        var outputDirectory = serFile.getParentFile().toPath();
+        return new SingleModeProcessingEventListener(this, baseName, serFile, cpuExecutor, ioExecutor, outputDirectory, params);
     }
 
     private ProcessParamsController createProcessParams(SerFileReader serFileReader, boolean batchMode) {

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ime/ImageMathTextArea.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ime/ImageMathTextArea.java
@@ -18,6 +18,7 @@ package me.champeau.a4j.jsolex.app.jfx.ime;
 import javafx.beans.value.ObservableValue;
 import javafx.concurrent.Task;
 import javafx.scene.layout.BorderPane;
+import me.champeau.a4j.jsolex.app.jfx.BatchOperations;
 import me.champeau.a4j.jsolex.expr.ExpressionParser;
 import me.champeau.a4j.jsolex.expr.Token;
 import me.champeau.a4j.jsolex.expr.TokenType;
@@ -69,9 +70,11 @@ public class ImageMathTextArea extends BorderPane {
     }
 
     public void setText(String text) {
-        codeArea.replaceText(text);
-        codeArea.moveTo(0);
-        codeArea.showParagraphAtTop(0);
+        BatchOperations.submit(() -> {
+            codeArea.replaceText(text);
+            codeArea.moveTo(0);
+            codeArea.showParagraphAtTop(0);
+        });
     }
 
     public String getText() {

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages.properties
@@ -37,3 +37,4 @@ script.errors.many=There were errors during the execution of the script.
 new.release.available=A new release of JSol'Ex is available!
 has.been.released= has been released !
 download=Download
+restarting.process.missing.shifts=Restarting process because image shifts {} are missing

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages_fr_FR.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages_fr_FR.properties
@@ -37,3 +37,4 @@ script.errors.many=Des erreurs sont arrivées pendant l'exécution du script.
 new.release.available=Une nouvelle version de JSol'Ex est disponible!
 has.been.released= est sorti !
 download=Télécharger
+restarting.process.missing.shifts=Il manque les images pour les décalages {} : relance du traitement


### PR DESCRIPTION
After processing an image, we enable the image math editor on the right. This editor allows working with image shifts which are already computed. However, sometimes you want to try with other parameters, and it would be useful to be able to recompute with new image shifts. This is what this commit does, by automatically reprocessing the video if image shifts are missing.