### PR TITLE
Fix io executor not blocking

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ForkJoinContext.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ForkJoinContext.java
@@ -55,12 +55,7 @@ public interface ForkJoinContext {
      * blocks until the result is available
      * @param r the runnable
      */
-    default void blocking(Runnable r) {
-        submit(() -> {
-            r.run();
-            return null;
-        }).get();
-    }
+    void blocking(Runnable r);
 
     /**
      * Submits a callable for asynchonous execution.


### PR DESCRIPTION
There was a bug in the parallel executor, which made it that the blocking call wasn't using the semaphore, resulting in too many tasks being executed concurrently. In practice, it meant we could, in batch mode, read several SER files in parallel when in practice we wanted to restrict this to a single file.