### PR TITLE
Add ellipse fitting to image math

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/BuiltinFunction.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/BuiltinFunction.java
@@ -31,6 +31,7 @@ public enum BuiltinFunction {
     CROP,
     CROP_RECT,
     DISK_FILL,
+    ELLIPSE_FIT,
     FIX_BANDING,
     IMG,
     INVERT,

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/ExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/ExpressionEvaluator.java
@@ -32,7 +32,7 @@ public abstract class ExpressionEvaluator {
         return doEvaluate(parser.parseExpression(expression));
     }
 
-    private Object doEvaluate(Expression expression) {
+    protected Object doEvaluate(Expression expression) {
         if (expression instanceof Literal literal) {
             return literal.value();
         }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
@@ -23,6 +23,7 @@ import me.champeau.a4j.jsolex.processing.expr.impl.Colorize;
 import me.champeau.a4j.jsolex.processing.expr.impl.Convolution;
 import me.champeau.a4j.jsolex.processing.expr.impl.Crop;
 import me.champeau.a4j.jsolex.processing.expr.impl.DiskFill;
+import me.champeau.a4j.jsolex.processing.expr.impl.EllipseFit;
 import me.champeau.a4j.jsolex.processing.expr.impl.FixBanding;
 import me.champeau.a4j.jsolex.processing.expr.impl.Loader;
 import me.champeau.a4j.jsolex.processing.expr.impl.RGBCombination;
@@ -132,6 +133,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
             case CROP -> new Crop(forkJoinContext, context).crop(arguments);
             case CROP_RECT -> new Crop(forkJoinContext, context).cropToRect(arguments);
             case DISK_FILL -> new DiskFill(forkJoinContext, context).fill(arguments);
+            case ELLIPSE_FIT -> new EllipseFit(forkJoinContext, context).fit(arguments);
             case FIX_BANDING -> new FixBanding(forkJoinContext, context).fixBanding(arguments);
             case IMG -> image(arguments);
             case INVERT -> ScriptSupport.inverse(arguments);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/AbstractFunctionImpl.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/AbstractFunctionImpl.java
@@ -17,6 +17,7 @@ package me.champeau.a4j.jsolex.processing.expr.impl;
 
 import me.champeau.a4j.jsolex.processing.util.ForkJoinContext;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -31,6 +32,20 @@ class AbstractFunctionImpl {
 
     protected <T> Optional<T> getFromContext(Class<T> type) {
         return (Optional<T>) Optional.ofNullable(context.get(type));
+    }
+
+    protected void assertExpectedArgCount(List<Object> arguments, String help, int min, int max) {
+        var size = arguments.size();
+        if (size < min || size > max) {
+            throw new IllegalArgumentException(help);
+        }
+    }
+
+    protected <T> Optional<T> getArgument(Class<T> clazz, List<Object> args, int position) {
+        if (position < args.size()) {
+            return Optional.of((T) args.get(position));
+        }
+        return Optional.empty();
     }
 
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/BackgroundRemoval.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/BackgroundRemoval.java
@@ -22,6 +22,7 @@ import me.champeau.a4j.math.regression.Ellipse;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static me.champeau.a4j.jsolex.processing.expr.impl.ScriptSupport.expandToImageList;
 
@@ -31,12 +32,10 @@ public class BackgroundRemoval extends AbstractFunctionImpl {
     }
 
     public Object removeBackground(List<Object> arguments) {
-        if (arguments.size() != 1 && arguments.size() != 2) {
-            throw new IllegalArgumentException("masked takes 1 or 2 arguments (image(s), [tolerance])");
-        }
-        var ellipse = getFromContext(Ellipse.class);
+        assertExpectedArgCount(arguments, "remove_bg takes 1, 2 or 3 arguments (image(s), [tolerance], [fitting])", 1, 2);
+        Optional<Ellipse> ellipse = getArgument(Ellipse.class, arguments, 2).or(() -> getFromContext(Ellipse.class));
         if (ellipse.isEmpty()) {
-            throw new IllegalArgumentException("Cannot perform masked merge because ellipse isn't found");
+            throw new IllegalArgumentException("Cannot perform background removal because ellipse isn't found");
         }
         var arg = arguments.get(0);
         if (arg instanceof List<?>) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/DiskFill.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/DiskFill.java
@@ -33,15 +33,13 @@ public class DiskFill extends AbstractFunctionImpl {
     }
 
     public Object fill(List<Object> arguments) {
-        if (arguments.size() > 2 || arguments.isEmpty()) {
-            throw new IllegalArgumentException("disk_fill takes 1 or 2 arguments (image(s), [fillColor])");
-        }
+        assertExpectedArgCount(arguments, "disk_fill takes 1, 2 or 3 arguments (image(s), [fillColor], [ellipse])", 1, 3);
         var arg = arguments.get(0);
         if (arg instanceof List<?>) {
             return expandToImageList(forkJoinContext, arguments, this::fill);
         }
         var img = arguments.get(0);
-        var ellipse = getFromContext(Ellipse.class);
+        var ellipse = getArgument(Ellipse.class, arguments, 2).or(() -> getFromContext(Ellipse.class));
         if (ellipse.isPresent()) {
             var blackpoint = getFromContext(ImageStats.class).map(ImageStats::blackpoint).orElse(0f);
             var fill = arguments.size() == 2 ? ((Number) arguments.get(1)).floatValue() : blackpoint;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/EllipseFit.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/EllipseFit.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.expr.impl;
+
+import me.champeau.a4j.jsolex.processing.params.ProcessParams;
+import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
+import me.champeau.a4j.jsolex.processing.sun.tasks.EllipseFittingTask;
+import me.champeau.a4j.jsolex.processing.sun.workflow.ImageEmitter;
+import me.champeau.a4j.jsolex.processing.util.ForkJoinContext;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
+import me.champeau.a4j.jsolex.processing.util.ProcessingException;
+
+import java.util.List;
+import java.util.Map;
+
+import static me.champeau.a4j.jsolex.processing.expr.impl.ScriptSupport.expandToImageList;
+
+public class EllipseFit extends AbstractFunctionImpl {
+    public EllipseFit(ForkJoinContext forkJoinContext, Map<Class<?>, Object> context) {
+        super(forkJoinContext, context);
+    }
+
+    public Object fit(List<Object> arguments) {
+        if (arguments.size() != 1) {
+            throw new IllegalArgumentException("ellipse_fit takes 1 arguments (image(s))");
+        }
+        var arg = arguments.get(0);
+        if (arg instanceof List<?>) {
+            return expandToImageList(forkJoinContext, arguments, this::fit);
+        }
+        if (arg instanceof ImageWrapper32 image) {
+            var task = new EllipseFittingTask(
+                    getFromContext(Broadcaster.class).orElse(Broadcaster.NO_OP),
+                    image,
+                    getFromContext(ProcessParams.class).orElse(null),
+                    getFromContext(ImageEmitter.class).orElse(null)
+            );
+            task.withPrefilter();
+            EllipseFittingTask.Result result;
+            try {
+                result = task.call();
+            } catch (Exception e) {
+                throw ProcessingException.wrap(e);
+            }
+            return result.ellipse();
+        }
+        throw new IllegalStateException("Ellipse fitting only works on mono images");
+    }
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/FixBanding.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/FixBanding.java
@@ -28,10 +28,8 @@ public class FixBanding extends AbstractFunctionImpl {
     }
 
     public Object fixBanding(List<Object> arguments) {
-        if (arguments.size() < 3) {
-            throw new IllegalArgumentException("fix_banding takes 3 arguments (image, band size, passes)");
-        }
-        var ellipse = getFromContext(Ellipse.class);
+        assertExpectedArgCount(arguments, "fix_banding takes 3 or 4 arguments (image, band size, passes, [ellipse])", 3, 4);
+        var ellipse = getArgument(Ellipse.class, arguments, 3).or(() -> getFromContext(Ellipse.class));
         int bandSize = ((Number) arguments.get(1)).intValue();
         int passes = ((Number) arguments.get(2)).intValue();
         return ScriptSupport.monoToMonoImageTransformer("fix_banding", 3, arguments, (width, height, data) -> {

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SingleModeProcessingEventListener.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SingleModeProcessingEventListener.java
@@ -324,7 +324,7 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
         BatchOperations.submit(() -> owner.updateProgress(1.0, finishedString));
     }
 
-    private static Map<Class, Object> prepareExecutionContext(ProcessingDoneEvent.Outcome payload) {
+    private Map<Class, Object> prepareExecutionContext(ProcessingDoneEvent.Outcome payload) {
         Map<Class, Object> context = new HashMap<>();
         if (payload.ellipse() != null) {
             context.put(Ellipse.class, payload.ellipse());
@@ -332,6 +332,8 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
         if (payload.imageStats() != null) {
             context.put(ImageStats.class, payload.imageStats());
         }
+        context.put(ProcessParams.class, params);
+        context.put(ImageEmitter.class, payload.customImageEmitter());
         return context;
     }
 


### PR DESCRIPTION
This makes it possible to apply some functions _after_ cropping. Previously, some functions like disk_fill or fix_banding only worked if applied before cropping. Now, there's a new function which allows performing ellipse fitting on an image, and that can be used as a parameter to these functions.