### PR TITLE
Fix saving of mono JPEG files

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -559,7 +559,7 @@ public class SolexVideoProcessor implements Broadcaster {
                             if (name.toLowerCase(Locale.US).contains("doppler")) {
                                 return name;
                             }
-                            var suffix = "_" + shift;
+                            var suffix = "_" + String.format(Locale.US, "%.2f",shift).replace('.', '_');
                             return name + suffix;
                         }),
                         imageNamingStrategy,


### PR DESCRIPTION
JPEG doesn't support 16-bit greyscale files, so when we're saving such a mono file, we need to convert it to an RGB image.