### PR TITLE
Add a technical detail image

### DIFF
--- a/docs/src/docs/asciidoc/en/jsolex.adoc
+++ b/docs/src/docs/asciidoc/en/jsolex.adoc
@@ -265,6 +265,10 @@ TIP: A special variable named `angleP` contains the computed solar P angle, from
 - `rotate_deg` performs an arbitrary rotation, in degrees. It accepts between 2 and 4 parameters: the image and the rotation angle are mandatory. For example: `rotate_deg(img(0), 45)`. You can then specify the fill value for the pixels which didn't belong to the original image:  `rotate_deg(img(0), 45, 800)` and last, if you add `1` as the last argument, the image will be rescaled so that all pixels from the original image are found in the rotated version.
 - `rotate_rad` performs an arbitrary rotation, in degrees. It accepts between 2 and 4 parameters: the image and the rotation angle are mandatory. For example: `rotate_rad(img(0), 0.25)`. You can then specify the fill value for the pixels which didn't belong to the original image:  `rotate_rad(img(0), 0.25, 800)` and last, if you add `1` as the last argument, the image will be rescaled so that all pixels from the original image are found in the rotated version.
 
+Decorative functions
+
+- `draw_globe` draws a globe which orientation and diameter matches the detected solar parameters. It takes between 1 and 4 arguments. The 1st one is the image on which to draw the globe. e.g: `draw_globe(img(0))`. The next, optional parameters are the P angle (in radians), the B0 angle (in radians) and the ellipse. e.g: `draw_globe(img(0), p, b0, ellipse)`.
+
 === ImageMath scripts
 
 In the previous section, we have seen the building blocks of ImageMath, which permit computation of new images.

--- a/docs/src/docs/asciidoc/en/jsolex.adoc
+++ b/docs/src/docs/asciidoc/en/jsolex.adoc
@@ -268,6 +268,8 @@ TIP: A special variable named `angleP` contains the computed solar P angle, from
 Decorative functions
 
 - `draw_globe` draws a globe which orientation and diameter matches the detected solar parameters. It takes between 1 and 4 arguments. The 1st one is the image on which to draw the globe. e.g: `draw_globe(img(0))`. The next, optional parameters are the P angle (in radians), the B0 angle (in radians) and the ellipse. e.g: `draw_globe(img(0), p, b0, ellipse)`.
+- `draw_obs_details` prints on the image the observation details. For example: `draw_obs_details(img(0))`. By default, placed in the top left corner. It's possible to set the (x,y) position explicitly: `draw_obs_details(img(0), 100, 100)`.
+- `draw_solar_params` prints on the image the detected solar parameters. For example: `draw_solar_params(img(0))`. By default, placed in the top right corner. It's possible to set the (x,y) position explicitly, for example: `draw_solar_params(img(0), 500, 100)`.
 
 === ImageMath scripts
 

--- a/docs/src/docs/asciidoc/fr/jsolex.adoc
+++ b/docs/src/docs/asciidoc/fr/jsolex.adoc
@@ -263,6 +263,10 @@ TIP: Une variable spéciale nommée `angleP` contient la valeur calculée pour l
 - `rotate_deg` effectue une rotation d'un angle arbitraire en degrés. Elle accepte entre 2 et 4 paramètres: l'image, l'angle de rotation sont obligatoires. Par exemple `rotate_deg(img(0), 45)`. Vous pouvez ensuite spécifier la valeur du fond à utiliser pour remplir les portions manquantes:  `rotate_deg(img(0), 45, 800)` et enfin si vous ajoutez `1` en dernier paramètre l'image sera redimensionnée au maximum pour que tous les pixels de l'image d'origine apparaissent dans l'image tournée.
 - `rotate_rad` effectue une rotation d'un angle arbitraire en radians. Elle accepte entre 2 et 4 paramètres: l'image, l'angle de rotation sont obligatoires. Par exemple `rotate_rad(img(0), .2)`. Vous pouvez ensuite spécifier la valeur du fond à utiliser pour remplir les portions manquantes:  `rotate_rad(img(0), .2, 800)` et enfin si vous ajoutez `1` en dernier paramètre l'image sera redimensionnée au maximum pour que tous les pixels de l'image d'origine apparaissent dans l'image tournée.
 
+Fonctions décoratives
+
+- `draw_globe` dessine un globe dont l'orientation et le diamètre correspond aux paramètres solaires détectés. Elle prend entre 1 et 4 paramètres. Le premier est l'image sur laquelle dessiner le globe. Par exemple: `draw_globe(img(0))`. Les paramètres optionnels suivants sont l'angle P (en radians), l'angle B0 (en radians) et l'ellipse du disque solaire. Par exemple: `draw_globe(img(0), p, b0, ellipse)`.
+
 === Scripts ImageMath
 
 Dans la section précédente, nous avons vu les "briques élémentaires" d'ImageMath, qui permettent de calculer des images.

--- a/docs/src/docs/asciidoc/fr/jsolex.adoc
+++ b/docs/src/docs/asciidoc/fr/jsolex.adoc
@@ -266,6 +266,8 @@ TIP: Une variable spéciale nommée `angleP` contient la valeur calculée pour l
 Fonctions décoratives
 
 - `draw_globe` dessine un globe dont l'orientation et le diamètre correspond aux paramètres solaires détectés. Elle prend entre 1 et 4 paramètres. Le premier est l'image sur laquelle dessiner le globe. Par exemple: `draw_globe(img(0))`. Les paramètres optionnels suivants sont l'angle P (en radians), l'angle B0 (en radians) et l'ellipse du disque solaire. Par exemple: `draw_globe(img(0), p, b0, ellipse)`.
+- `draw_obs_details` affiche sur l'image les données d'observation. Par exemple: `draw_obs_details(img(0))`. Par défaut, positionné en haut à gauche. Il est possible de spéficier les coordonnées (x,y) où écrire : `draw_obs_details(img(0), 100, 100)`.
+- `draw_solar_params` affiche sur l'image les paramètres solaires. Par exemple: `draw_solar_params(img(0))`. Par défaut, positionné en haut à droite. Il est possible de spéficier les coordonnées (x,y) où écrire : `draw_solar_params(img(0), 500, 100)`.
 
 === Scripts ImageMath
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/BuiltinFunction.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/BuiltinFunction.java
@@ -33,6 +33,7 @@ public enum BuiltinFunction {
     DISK_FILL,
     DRAW_GLOBE,
     DRAW_OBS_DETAILS,
+    DRAW_SOLAR_PARAMS,
     ELLIPSE_FIT,
     FIX_BANDING,
     IMG,

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/BuiltinFunction.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/BuiltinFunction.java
@@ -32,6 +32,7 @@ public enum BuiltinFunction {
     CROP_RECT,
     DISK_FILL,
     DRAW_GLOBE,
+    DRAW_OBS_DETAILS,
     ELLIPSE_FIT,
     FIX_BANDING,
     IMG,

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/BuiltinFunction.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/BuiltinFunction.java
@@ -31,6 +31,7 @@ public enum BuiltinFunction {
     CROP,
     CROP_RECT,
     DISK_FILL,
+    DRAW_GLOBE,
     ELLIPSE_FIT,
     FIX_BANDING,
     IMG,

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
@@ -169,6 +169,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
             case DISK_FILL -> diskFill.fill(arguments);
             case DRAW_GLOBE -> imageDraw.drawGlobe(arguments);
             case DRAW_OBS_DETAILS -> imageDraw.drawObservationDetails(arguments);
+            case DRAW_SOLAR_PARAMS -> imageDraw.drawSolarParameters(arguments);
             case ELLIPSE_FIT -> ellipseFit.fit(arguments);
             case FIX_BANDING -> fixBanding.fixBanding(arguments);
             case IMG -> image(arguments);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
@@ -167,6 +167,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
             case CROP_RECT -> crop.cropToRect(arguments);
             case DISK_FILL -> diskFill.fill(arguments);
             case DRAW_GLOBE -> imageDraw.drawGlobe(arguments);
+            case DRAW_OBS_DETAILS -> imageDraw.drawObservationDetails(arguments);
             case ELLIPSE_FIT -> ellipseFit.fit(arguments);
             case FIX_BANDING -> fixBanding.fixBanding(arguments);
             case IMG -> image(arguments);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
@@ -27,6 +27,7 @@ import me.champeau.a4j.jsolex.processing.expr.impl.Crop;
 import me.champeau.a4j.jsolex.processing.expr.impl.DiskFill;
 import me.champeau.a4j.jsolex.processing.expr.impl.EllipseFit;
 import me.champeau.a4j.jsolex.processing.expr.impl.FixBanding;
+import me.champeau.a4j.jsolex.processing.expr.impl.ImageDraw;
 import me.champeau.a4j.jsolex.processing.expr.impl.Loader;
 import me.champeau.a4j.jsolex.processing.expr.impl.RGBCombination;
 import me.champeau.a4j.jsolex.processing.expr.impl.Rotate;
@@ -70,6 +71,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
     private final DiskFill diskFill;
     private final EllipseFit ellipseFit;
     private final FixBanding fixBanding;
+    private final ImageDraw imageDraw;
     private final Loader loader;
     private final Rotate rotate;
     private final Saturation saturation;
@@ -88,6 +90,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
         this.diskFill = new DiskFill(forkJoinContext, context);
         this.ellipseFit = new EllipseFit(forkJoinContext, context);
         this.fixBanding = new FixBanding(forkJoinContext, context);
+        this.imageDraw = new ImageDraw(forkJoinContext, context);
         this.loader = new Loader(forkJoinContext, context);
         this.rotate = new Rotate(forkJoinContext, context);
         this.saturation = new Saturation(forkJoinContext, context);
@@ -163,6 +166,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
             case CROP -> crop.crop(arguments);
             case CROP_RECT -> crop.cropToRect(arguments);
             case DISK_FILL -> diskFill.fill(arguments);
+            case DRAW_GLOBE -> imageDraw.drawGlobe(arguments);
             case ELLIPSE_FIT -> ellipseFit.fit(arguments);
             case FIX_BANDING -> fixBanding.fixBanding(arguments);
             case IMG -> image(arguments);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -258,7 +259,10 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
                 result[i] = v;
             }
             normalize(length, result, min);
-            return new ImageWrapper32(width, height, result);
+            Map<Class<?>, Object> metadata = new LinkedHashMap<>();
+            metadata.putAll(leftImage.metadata());
+            metadata.putAll(rightImage.metadata());
+            return new ImageWrapper32(width, height, result, metadata);
         }
         if (leftImage != null && rightScalar != null) {
             var scalar = rightScalar.doubleValue();
@@ -276,7 +280,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
                 result[i] = v;
             }
             normalize(length, result, min);
-            return new ImageWrapper32(width, height, result);
+            return new ImageWrapper32(width, height, result, leftImage.metadata());
         }
         if (rightImage != null && leftScalar != null) {
             var scalar = leftScalar.doubleValue();
@@ -294,7 +298,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
                 result[i] = v;
             }
             normalize(length, result, min);
-            return new ImageWrapper32(width, height, result);
+            return new ImageWrapper32(width, height, result, rightImage.metadata());
         }
         if (leftScalar != null && rightScalar != null) {
             return operator.applyAsDouble(leftScalar.doubleValue(), rightScalar.doubleValue());

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/DefaultImageScriptExecutor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/DefaultImageScriptExecutor.java
@@ -43,6 +43,9 @@ import java.util.function.Function;
 public class DefaultImageScriptExecutor implements ImageMathScriptExecutor {
     public static final String BLACK_POINT_VAR = "blackPoint";
     public static final String ANGLE_P_VAR = "angleP";
+    public static final String B0_VAR = "b0";
+    public static final String L0_VAR = "l0";
+    public static final String CARROT_VAR = "carrot";
     public static final String OUTPUTS_SECTION_NAME = "outputs";
     public static final String BATCH_SECTION_NAME = "batch";
 
@@ -97,6 +100,9 @@ public class DefaultImageScriptExecutor implements ImageMathScriptExecutor {
         var solarParams = (SolarParameters) context.get(SolarParameters.class);
         if (solarParams != null) {
             evaluator.putVariable(ANGLE_P_VAR,  String.format(Locale.US, "%.4f", solarParams.p()));
+            evaluator.putVariable(B0_VAR,  String.format(Locale.US, "%.4f", solarParams.b0()));
+            evaluator.putVariable(L0_VAR,  String.format(Locale.US, "%.4f", solarParams.l0()));
+            evaluator.putVariable(CARROT_VAR, String.valueOf(solarParams.carringtonRotation()));
         }
         var invalidExpressions = new ArrayList<InvalidExpression>();
         var variableShifts = new TreeSet<>(evaluator.getShifts());

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/ShiftCollectingImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/ShiftCollectingImageExpressionEvaluator.java
@@ -35,7 +35,7 @@ public class ShiftCollectingImageExpressionEvaluator extends ImageExpressionEval
 
     public static Function<Double, ImageWrapper> zeroImages() {
         var map = new HashMap<Double, ImageWrapper>();
-        return (Double idx) -> map.computeIfAbsent(idx, unused -> new ImageWrapper32(0, 0, new float[0]));
+        return (Double idx) -> map.computeIfAbsent(idx, unused -> new ImageWrapper32(0, 0, new float[0], Map.of()));
     }
 
     public ShiftCollectingImageExpressionEvaluator(ForkJoinContext forkJoinContext) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/AbstractFunctionImpl.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/AbstractFunctionImpl.java
@@ -16,6 +16,8 @@
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
 import me.champeau.a4j.jsolex.processing.util.ForkJoinContext;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
+import me.champeau.a4j.math.regression.Ellipse;
 
 import java.util.List;
 import java.util.Map;
@@ -28,6 +30,27 @@ class AbstractFunctionImpl {
     protected AbstractFunctionImpl(ForkJoinContext forkJoinContext, Map<Class<?>, Object> context) {
         this.forkJoinContext = forkJoinContext;
         this.context = context;
+    }
+
+    protected Optional<Ellipse> getEllipse(List<Object> arguments, int index) {
+        if (index >= 0) {
+            return getArgument(Ellipse.class, arguments, index)
+                    .or(() -> findEllipseInArguments(arguments))
+                    .or(() -> getFromContext(Ellipse.class));
+        }
+        return findEllipseInArguments(arguments)
+                .or(() -> getFromContext(Ellipse.class));
+    }
+
+    private static Optional<Ellipse> findEllipseInArguments(List<Object> arguments) {
+        if (arguments.isEmpty()) {
+            return Optional.empty();
+        }
+        var first = arguments.get(0);
+        if (first instanceof ImageWrapper img) {
+            return img.findMetadata(Ellipse.class);
+        }
+        return Optional.empty();
     }
 
     protected <T> Optional<T> getFromContext(Class<T> type) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/BackgroundRemoval.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/BackgroundRemoval.java
@@ -34,13 +34,13 @@ public class BackgroundRemoval extends AbstractFunctionImpl {
 
     public Object removeBackground(List<Object> arguments) {
         assertExpectedArgCount(arguments, "remove_bg takes 1, 2 or 3 arguments (image(s), [tolerance], [fitting])", 1, 2);
-        Optional<Ellipse> ellipse = getArgument(Ellipse.class, arguments, 2).or(() -> getFromContext(Ellipse.class));
-        if (ellipse.isEmpty()) {
-            throw new IllegalArgumentException("Cannot perform background removal because ellipse isn't found");
-        }
         var arg = arguments.get(0);
         if (arg instanceof List<?>) {
             return expandToImageList(forkJoinContext, arguments, this::removeBackground);
+        }
+        Optional<Ellipse> ellipse = getEllipse(arguments, 2);
+        if (ellipse.isEmpty()) {
+            throw new IllegalArgumentException("Cannot perform background removal because ellipse isn't found");
         }
         double tolerance;
         if (arguments.size() == 2) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Colorize.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Colorize.java
@@ -55,7 +55,7 @@ public class Colorize extends AbstractFunctionImpl {
                 return new ColorizedImageWrapper(mono, data -> {
                     var curve = new ColorCurve("adhoc", rIn, rOut, gIn, gOut, bIn, bOut);
                     return doColorize(data, curve);
-                });
+                }, mono.metadata());
             }
         } else {
             if (arg instanceof FileBackedImage fileBackedImage) {
@@ -67,7 +67,7 @@ public class Colorize extends AbstractFunctionImpl {
                 if (ray.label().equalsIgnoreCase(profile) && (arg instanceof ImageWrapper32 mono)) {
                     var curve = ray.colorCurve();
                     if (curve != null) {
-                        return new ColorizedImageWrapper(mono, data -> doColorize(data, curve));
+                        return new ColorizedImageWrapper(mono, data -> doColorize(data, curve), mono.metadata());
                     }
                 }
             }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Convolution.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Convolution.java
@@ -64,14 +64,14 @@ public class Convolution extends AbstractFunctionImpl {
             image = fileBackedImage.unwrapToMemory();
         }
         if (image instanceof ImageWrapper32 mono) {
-            return new ImageWrapper32(mono.width(), mono.height(), imageMath.convolve(mono.asImage(), kernel).data());
+            return new ImageWrapper32(mono.width(), mono.height(), imageMath.convolve(mono.asImage(), kernel).data(), mono.metadata());
         } else if (image instanceof ColorizedImageWrapper colorized) {
-            return new ColorizedImageWrapper((ImageWrapper32) convolve(colorized.mono(), kernel), colorized.converter());
+            return new ColorizedImageWrapper((ImageWrapper32) convolve(colorized.mono(), kernel), colorized.converter(), colorized.metadata());
         } else if (image instanceof RGBImage rgb) {
             var hsl = ImageUtils.fromRGBtoHSL(new float[][] { rgb.r(), rgb.g(), rgb.b() });
             hsl[2] = imageMath.convolve(new Image(rgb.width(), rgb.height(), hsl[2]), kernel).data();
             var transformed = ImageUtils.fromHSLtoRGB(hsl);
-            return new RGBImage(rgb.width(), rgb.height(), transformed[0], transformed[1], transformed[2]);
+            return new RGBImage(rgb.width(), rgb.height(), transformed[0], transformed[1], transformed[2], rgb.metadata());
         }
         throw new IllegalArgumentException("Unsupported image type " + image);
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/DiskFill.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/DiskFill.java
@@ -40,7 +40,7 @@ public class DiskFill extends AbstractFunctionImpl {
             return expandToImageList(forkJoinContext, arguments, this::fill);
         }
         var img = arguments.get(0);
-        var ellipse = getArgument(Ellipse.class, arguments, 2).or(() -> getFromContext(Ellipse.class));
+        var ellipse = getEllipse(arguments, 2);
         if (ellipse.isPresent()) {
             var blackpoint = getFromContext(ImageStats.class).map(ImageStats::blackpoint).orElse(0f);
             var fill = arguments.size() == 2 ? floatArg(arguments, 1) : blackpoint;
@@ -54,7 +54,7 @@ public class DiskFill extends AbstractFunctionImpl {
             } else if (img instanceof ColorizedImageWrapper colorized) {
                 var copy = colorized.mono().copy();
                 doFill(ellipse.get(), copy.data(), copy.width(), fill);
-                return new ColorizedImageWrapper(copy, colorized.converter());
+                return new ColorizedImageWrapper(copy, colorized.converter(), colorized.metadata());
             } else if (img instanceof RGBImage rgb) {
                 var r = new float[rgb.r().length];
                 System.arraycopy(rgb.r(), 0, r, 0, r.length);
@@ -65,7 +65,7 @@ public class DiskFill extends AbstractFunctionImpl {
                 var b = new float[rgb.b().length];
                 System.arraycopy(rgb.b(), 0, b, 0, b.length);
                 doFill(ellipse.get(), b, rgb.width(), fill);
-                return new RGBImage(rgb.width(), rgb.height(), r, g, b);
+                return new RGBImage(rgb.width(), rgb.height(), r, g, b, rgb.metadata());
             }
         }
         throw new IllegalArgumentException("Ellipse fitting not found, cannot perform fill");

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/FixBanding.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/FixBanding.java
@@ -17,7 +17,6 @@ package me.champeau.a4j.jsolex.processing.expr.impl;
 
 import me.champeau.a4j.jsolex.processing.sun.BandingReduction;
 import me.champeau.a4j.jsolex.processing.util.ForkJoinContext;
-import me.champeau.a4j.math.regression.Ellipse;
 
 import java.util.List;
 import java.util.Map;
@@ -29,7 +28,7 @@ public class FixBanding extends AbstractFunctionImpl {
 
     public Object fixBanding(List<Object> arguments) {
         assertExpectedArgCount(arguments, "fix_banding takes 3 or 4 arguments (image, band size, passes, [ellipse])", 3, 4);
-        var ellipse = getArgument(Ellipse.class, arguments, 3).or(() -> getFromContext(Ellipse.class));
+        var ellipse = getEllipse(arguments, 3);
         int bandSize = intArg(arguments, 1);
         int passes = intArg(arguments, 2);
         return ScriptSupport.monoToMonoImageTransformer(forkJoinContext, "fix_banding", 3, arguments, (width, height, data) -> {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ImageDraw.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ImageDraw.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.expr.impl;
+
+import me.champeau.a4j.jsolex.processing.util.ColorizedImageWrapper;
+import me.champeau.a4j.jsolex.processing.util.Constants;
+import me.champeau.a4j.jsolex.processing.util.FileBackedImage;
+import me.champeau.a4j.jsolex.processing.util.ForkJoinContext;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
+import me.champeau.a4j.jsolex.processing.util.RGBImage;
+import me.champeau.a4j.jsolex.processing.util.SolarParameters;
+import me.champeau.a4j.math.regression.Ellipse;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferUShort;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import static java.lang.Math.cos;
+import static java.lang.Math.round;
+import static java.lang.Math.sin;
+import static java.lang.Math.toRadians;
+import static me.champeau.a4j.jsolex.processing.expr.impl.ScriptSupport.expandToImageList;
+
+public class ImageDraw extends AbstractFunctionImpl {
+
+    private static final int DIVISIONS = 18;
+
+    public ImageDraw(ForkJoinContext forkJoinContext, Map<Class<?>, Object> context) {
+        super(forkJoinContext, context);
+    }
+
+    public Object drawGlobe(List<Object> arguments) {
+        assertExpectedArgCount(arguments, "draw_globe takes 1, 2, 3 or 4 arguments (image(s), [angleP], [b0], [ellipse])", 1, 4);
+        var arg = arguments.get(0);
+        if (arg instanceof List<?>) {
+            return expandToImageList(forkJoinContext, arguments, this::drawGlobe);
+        }
+        var img = arguments.get(0);
+        if (img instanceof ImageWrapper image) {
+            var angleP = getArgument(Number.class, arguments, 1).map(Number::doubleValue).or(() -> getFromContext(SolarParameters.class).map(SolarParameters::p)).orElse(0d);
+            var b0 = getArgument(Number.class, arguments, 2).map(Number::doubleValue).or(() -> getFromContext(SolarParameters.class).map(SolarParameters::b0)).orElse(0d);
+            var ellipse = getArgument(Ellipse.class, arguments, 3).or(() -> getFromContext(Ellipse.class)).orElseThrow(() -> new IllegalArgumentException("Ellipse not defined"));
+            return doDrawGlobe(image, ellipse, angleP, b0);
+        }
+        throw new IllegalArgumentException("Unexpected image type: " + img);
+    }
+
+    private static int maxValue(ImageWrapper wrapper) {
+        float max = Integer.MIN_VALUE;
+        if (wrapper instanceof ImageWrapper32 mono) {
+            for (float d : mono.data()) {
+                max = Math.max(max, d);
+            }
+        } else if (wrapper instanceof ColorizedImageWrapper colorized) {
+            for (float d : colorized.mono().data()) {
+                max = Math.max(max, d);
+            }
+        } else if (wrapper instanceof RGBImage rgb) {
+            for (float d : rgb.r()) {
+                max = Math.max(max, d);
+            }
+            for (float d : rgb.g()) {
+                max = Math.max(max, d);
+            }
+            for (float d : rgb.b()) {
+                max = Math.max(max, d);
+            }
+        } else {
+            max = Constants.MAX_PIXEL_VALUE;
+        }
+        return (int) max >> 8;
+    }
+
+    private ImageWrapper doDrawGlobe(ImageWrapper wrapper, Ellipse ellipse, double angleP, double b0) {
+        return drawOnImage(wrapper, (bufferedImage, image) -> {
+            var g = bufferedImage.createGraphics();
+            var font = g.getFont();
+            g.setFont(font.deriveFont(AffineTransform.getRotateInstance(-angleP)));
+            int greyValue = 80 * maxValue(image) / 100;
+            g.setColor(new Color(greyValue, greyValue, greyValue));
+            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            double centerX = ellipse.center().a();
+            double centerY = ellipse.center().b();
+            double radius = (ellipse.semiAxis().a() + ellipse.semiAxis().b()) / 2d;
+            double resolution = 0.04d;
+            var diameter = (int) Math.round(2 * radius);
+            g.setFont(g.getFont().deriveFont((float) (radius / 48)));
+            g.drawOval((int) (centerX - radius), (int) (centerY - radius), diameter, diameter);
+            g.drawOval((int) (centerX - radius), (int) (centerY - radius), diameter - 1, diameter - 1);
+            int geodesisInc = 180 / DIVISIONS;
+            for (int i = -180; i <= 180; i += geodesisInc) {
+                var angle = toRadians(i);
+                for (double theta = 0; theta < 360; theta += resolution) {
+                    var lines = List.of(
+                            ofSpherical(angle, theta, radius).rotateX(-b0).rotateZ(-angleP),
+                            ofSpherical(theta, angle, radius).rotateX(-b0).rotateZ(-angleP)
+                    );
+                    for (int j = 0; j < lines.size(); j++) {
+                        Coordinates c = lines.get(j);
+                        if (c.z > 0) {
+                            var equator = i == 90 && j == 1;
+                            g.fillRoundRect((int) round(centerX + c.x), (int) round(centerY + c.y), equator ? 4 : 1, equator ? 4 : 1, 1, 1);
+                        }
+                    }
+                }
+            }
+            drawAngleLabels(angleP, geodesisInc, radius, g, centerX, centerY);
+            drawRotationAxis(angleP, radius, g, centerX, centerY);
+            g.setFont(font);
+        });
+    }
+
+    private static void drawRotationAxis(double angleP, double radius, Graphics2D g, double centerX, double centerY) {
+        // draw rotation axis
+        var x0 = 0;
+        var y0 = -(radius * 1.1);
+        var p0 = rotate(x0, y0, -angleP);
+        var x1 = 0;
+        var y1 = (radius * 1.1);
+        var p1 = rotate(x1, y1, -angleP);
+        g.drawLine((int) (centerX + p0[0]), (int) (centerY + p0[1]), (int) (centerX + p1[0]), (int) (centerY + p1[1]));
+    }
+
+    private static void drawAngleLabels(double angleP, int geodesisInc, double radius, Graphics2D g, double centerX, double centerY) {
+        for (int i = 0; i < 90; i += geodesisInc) {
+            var angle = toRadians(i);
+            if ((i % 90) != 0) {
+                var latitude = 90 - i;
+                var p = rotate(0, radius * 1.05, angle - angleP);
+                g.drawString("" + latitude, (int) (centerX - p[0]), (int) (centerY - p[1]));
+                g.drawString("-" + latitude, (int) (centerX + p[0]), (int) (centerY + p[1]));
+                p = rotate(0, radius * 1.05, -angle - angleP);
+                g.drawString("" + latitude, (int) (centerX - p[0]), (int) (centerY - p[1]));
+                g.drawString("-" + latitude, (int) (centerX + p[0]), (int) (centerY + p[1]));
+            } else {
+                var p = rotate(0, radius * 1.05, -angleP);
+                var font = g.getFont();
+                g.setFont(font.deriveFont(Font.BOLD));
+                g.drawString("N", (int) (centerX - p[0]), (int) (centerY - p[1]));
+                g.drawString("S", (int) (centerX + p[0]), (int) (centerY + p[1]));
+                p = rotate(0, radius * 1.05, Math.PI/2 - angleP);
+                g.drawString("W", (int) (centerX - p[0]), (int) (centerY - p[1]));
+                g.drawString("E", (int) (centerX + p[0]), (int) (centerY + p[1]));
+                g.setFont(font);
+            }
+        }
+    }
+
+    public ImageWrapper drawOnImage(ImageWrapper wrapper, BiConsumer<? super BufferedImage, ? super ImageWrapper> consumer) {
+        BufferedImage image = null;
+        if (wrapper instanceof FileBackedImage fileBacked) {
+            wrapper = fileBacked.unwrapToMemory();
+        }
+        if (wrapper instanceof ImageWrapper32 mono) {
+            var data = mono.data();
+            image = new BufferedImage(mono.width(), mono.height(), BufferedImage.TYPE_USHORT_GRAY);
+            short[] converted = ((DataBufferUShort) image.getRaster().getDataBuffer()).getData();
+            for (int i = 0; i < converted.length; i++) {
+                converted[i] = (short) round(data[i]);
+            }
+        } else if (wrapper instanceof ColorizedImageWrapper colorized) {
+            var data = colorized.mono().data();
+            var rgb = colorized.converter().apply(data);
+            var r = rgb[0];
+            var g = rgb[1];
+            var b = rgb[2];
+            var width = colorized.width();
+            var height = colorized.height();
+            image = toBufferedImage(width, height, r, g, b);
+        } else if (wrapper instanceof RGBImage rgb) {
+            image = toBufferedImage(rgb.width(), rgb.height(), rgb.r(), rgb.g(), rgb.b());
+        }
+        if (image != null) {
+            consumer.accept(image, wrapper);
+            return Loader.toImageWrapper(image);
+        }
+        return null;
+    }
+
+    private static BufferedImage toBufferedImage(int width, int height, float[] r, float[] g, float[] b) {
+        BufferedImage image;
+        image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                int rv = round(r[y * width + x]);
+                int gv = round(g[y * width + x]);
+                int bv = round(b[y * width + x]);
+                rv = (rv >> 8) & 0xFF;
+                gv = (gv >> 8) & 0xFF;
+                bv = (bv >> 8) & 0xFF;
+                image.setRGB(x, y, rv << 16 | gv << 8 | bv);
+            }
+        }
+        return image;
+    }
+
+    private static Coordinates ofSpherical(double ascension, double declination, double radius) {
+        return new Coordinates(
+                sin(ascension) * sin(declination) * radius,
+                cos(declination) * radius,
+                cos(ascension) * sin(declination) * radius
+        );
+    }
+
+    private static double[] rotate(double a, double b, double angle) {
+        return new double[]{
+                cos(angle) * a - sin(angle) * b,
+                sin(angle) * a + cos(angle) * b
+        };
+    }
+
+    private record Coordinates(double x, double y, double z) {
+
+        public Coordinates rotateX(double angle) {
+            var rot = rotate(y, z, angle);
+            return new Coordinates(x, rot[0], rot[1]);
+        }
+
+        public Coordinates rotateY(double angle) {
+            var rot = rotate(x, z, angle);
+            return new Coordinates(rot[0], y, rot[1]);
+        }
+
+        public Coordinates rotateZ(double angle) {
+            var rot = rotate(x, y, angle);
+            return new Coordinates(rot[0], rot[1], z);
+        }
+    }
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ImageDraw.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ImageDraw.java
@@ -122,7 +122,7 @@ public class ImageDraw extends AbstractFunctionImpl {
         if (img instanceof ImageWrapper image) {
             var angleP = getArgument(Number.class, arguments, 1).map(Number::doubleValue).or(() -> getFromContext(SolarParameters.class).map(SolarParameters::p)).orElse(0d);
             var b0 = getArgument(Number.class, arguments, 2).map(Number::doubleValue).or(() -> getFromContext(SolarParameters.class).map(SolarParameters::b0)).orElse(0d);
-            var ellipse = getArgument(Ellipse.class, arguments, 3).or(() -> getFromContext(Ellipse.class)).orElseThrow(() -> new IllegalArgumentException("Ellipse not defined"));
+            var ellipse = getEllipse(arguments, 3).orElseThrow(() -> new IllegalArgumentException("Ellipse not defined"));
             return doDrawGlobe(image, ellipse, angleP, b0);
         }
         throw new IllegalArgumentException("Unexpected image type: " + img);
@@ -263,7 +263,7 @@ public class ImageDraw extends AbstractFunctionImpl {
             g.setColor(new Color(greyValue, greyValue, greyValue));
             g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
             consumer.accept(g, wrapper);
-            return Loader.toImageWrapper(image);
+            return Loader.toImageWrapper(image, wrapper.metadata());
         }
         return null;
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Loader.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Loader.java
@@ -76,10 +76,10 @@ public class Loader extends AbstractFunctionImpl {
         } catch (IOException e) {
             throw new ProcessingException(e);
         }
-        return toImageWrapper(image);
+        return toImageWrapper(image, Map.of());
     }
 
-    static ImageWrapper toImageWrapper(BufferedImage image) {
+    static ImageWrapper toImageWrapper(BufferedImage image, Map<Class<?>, Object> metadata) {
         var width = image.getWidth();
         var height = image.getHeight();
         var colorModel = image.getColorModel();
@@ -95,7 +95,7 @@ public class Loader extends AbstractFunctionImpl {
                 g[i] = (pixel >> 8) & 0xFF;
                 b[i] = pixel & 0xFF;
             }
-            return new RGBImage(width, height, r, g, b);
+            return new RGBImage(width, height, r, g, b, metadata);
         } else {
             var data = new float[size];
             var dataBuffer = image.getRaster().getDataBuffer();
@@ -110,7 +110,7 @@ public class Loader extends AbstractFunctionImpl {
                     data[i] = rgb[i] & 0xFF;
                 }
             }
-            return new ImageWrapper32(width, height, data);
+            return new ImageWrapper32(width, height, data, metadata);
         }
     }
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Loader.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Loader.java
@@ -76,6 +76,10 @@ public class Loader extends AbstractFunctionImpl {
         } catch (IOException e) {
             throw new ProcessingException(e);
         }
+        return toImageWrapper(image);
+    }
+
+    static ImageWrapper toImageWrapper(BufferedImage image) {
         var width = image.getWidth();
         var height = image.getHeight();
         var colorModel = image.getColorModel();

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/RGBCombination.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/RGBCombination.java
@@ -45,7 +45,7 @@ public class RGBCombination {
         if (ra instanceof ImageWrapper32 r && ga instanceof ImageWrapper32 g && ba instanceof ImageWrapper32 b) {
             if ((r.width() == g.width()) && (r.width() == b.width())
                 && (r.height() == g.height()) && (r.height() == b.height())) {
-                return new RGBImage(r.width(), r.height(), r.data(), g.data(), b.data());
+                return new RGBImage(r.width(), r.height(), r.data(), g.data(), b.data(), r.metadata());
             } else {
                 throw new IllegalArgumentException("Images must have the same dimensions");
             }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Rotate.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Rotate.java
@@ -89,14 +89,14 @@ public class Rotate extends AbstractFunctionImpl {
         } else if (arg instanceof ColorizedImageWrapper colorized) {
             var mono = colorized.mono();
             var trn = rotateFunction.apply(mono.asImage());
-            return new ColorizedImageWrapper(ImageWrapper32.fromImage(trn), colorized.converter());
+            return new ColorizedImageWrapper(ImageWrapper32.fromImage(trn), colorized.converter(), mono.metadata());
         } else if (arg instanceof RGBImage rgb) {
             var height = rgb.height();
             var width = rgb.width();
             var r = rotateFunction.apply(new Image(width, height, rgb.r()));
             var g = rotateFunction.apply(new Image(width, height, rgb.g()));
             var b = rotateFunction.apply(new Image(width, height, rgb.b()));
-            return new RGBImage(r.width(), r.height(), r.data(), g.data(), b.data());
+            return new RGBImage(r.width(), r.height(), r.data(), g.data(), b.data(), rgb.metadata());
         }
         throw new IllegalArgumentException("Unsupported image type");
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Saturation.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Saturation.java
@@ -51,7 +51,7 @@ public class Saturation extends AbstractFunctionImpl {
                 }
                 ImageUtils.fromHSLtoRGB(hsl, rgb);
                 return rgb;
-            });
+            }, colorized.metadata());
         } else if (arg instanceof RGBImage rgb) {
             var hsl = ImageUtils.fromRGBtoHSL(new float[][]{rgb.r(), rgb.g(), rgb.b()});
             var s = hsl[1];
@@ -61,7 +61,7 @@ public class Saturation extends AbstractFunctionImpl {
             }
             var output = new float[3][rgb.r().length];
             ImageUtils.fromHSLtoRGB(hsl, output);
-            return new RGBImage(rgb.width(), rgb.height(), output[0], output[1], output[2]);
+            return new RGBImage(rgb.width(), rgb.height(), output[0], output[1], output[2], rgb.metadata());
         }
         return arg;
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Scaling.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Scaling.java
@@ -72,7 +72,7 @@ public class Scaling extends AbstractFunctionImpl {
         int width = intArg(arguments, 1);
         int height = intArg(arguments, 2);
         if (width < 0 || height < 0) {
-            throw new IllegalArgumentException("Width and height must be > 0");
+            throw new IllegalArgumentException("Width and height must be >= 0");
         }
         if (arg instanceof ImageWrapper img) {
             var result = doRescale(img, width, height);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Scaling.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Scaling.java
@@ -141,7 +141,7 @@ public class Scaling extends AbstractFunctionImpl {
                             imageMath.rescale(mono.asImage(),
                                     width,
                                     height
-                            )), colorized.converter()
+                            )), colorized.converter(), Map.of()
             );
         } else if (img instanceof RGBImage rgb) {
             var r = new Image(rgb.width(), rgb.height(), rgb.r());
@@ -152,7 +152,8 @@ public class Scaling extends AbstractFunctionImpl {
                     height,
                     imageMath.rescale(r, width, height).data(),
                     imageMath.rescale(g, width, height).data(),
-                    imageMath.rescale(b, width, height).data()
+                    imageMath.rescale(b, width, height).data(),
+                    Map.of()
             );
         }
         return null;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ScriptSupport.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ScriptSupport.java
@@ -117,7 +117,7 @@ public class ScriptSupport {
                 var idx = i;
                 result[i] = (float) operator.apply(images.stream().mapToDouble(img -> img.data()[idx])).orElse(0);
             }
-            return new ImageWrapper32(width, height, result);
+            return new ImageWrapper32(width, height, result, first.metadata());
         }
         throw new IllegalArgumentException("Unexpected argument type '" + type + "'");
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/RequestedImages.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/RequestedImages.java
@@ -41,7 +41,8 @@ public record RequestedImages(
             GeneratedImageKind.NEGATIVE,
             GeneratedImageKind.DOPPLER,
             GeneratedImageKind.GEOMETRY_CORRECTED_STRETCHED,
-            GeneratedImageKind.CONTINUUM
+            GeneratedImageKind.CONTINUUM,
+            GeneratedImageKind.TECHNICAL_CARD
     );
     public static final Set<GeneratedImageKind> FULL_MODE_WITH_DEBUG = EnumSet.of(
             GeneratedImageKind.DEBUG,
@@ -53,7 +54,8 @@ public record RequestedImages(
             GeneratedImageKind.NEGATIVE,
             GeneratedImageKind.DOPPLER,
             GeneratedImageKind.GEOMETRY_CORRECTED_STRETCHED,
-            GeneratedImageKind.CONTINUUM
+            GeneratedImageKind.CONTINUUM,
+            GeneratedImageKind.TECHNICAL_CARD
     );
     public static final Set<GeneratedImageKind> QUICK_MODE = EnumSet.of(
             GeneratedImageKind.RECONSTRUCTION,

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -403,9 +403,10 @@ public class SolexVideoProcessor implements Broadcaster {
                 .stream()
                 .map(i -> WorkflowState.prepare(width, newHeight, i))
                 .toList();
-        if (list.stream().noneMatch(s -> s.pixelShift() <= -Constants.CONTINUUM_SHIFT)) {
+        var detectionShift = processParams.spectrumParams().pixelShift() - 6;
+        if (list.stream().noneMatch(s -> s.pixelShift() == detectionShift)) {
             // add an internal state used for edge detection only
-            var internalState = WorkflowState.prepare(width, newHeight, -Constants.CONTINUUM_SHIFT);
+            var internalState = WorkflowState.prepare(width, newHeight, detectionShift);
             internalState.setInternal(true);
             list = new ArrayList<>(list);
             list.add(internalState);
@@ -566,7 +567,7 @@ public class SolexVideoProcessor implements Broadcaster {
                             if (name.toLowerCase(Locale.US).contains("doppler")) {
                                 return name;
                             }
-                            var suffix = "_" + String.format(Locale.US, "%.2f",shift).replace('.', '_');
+                            var suffix = "_" + String.format(Locale.US, "%.2f", shift).replace('.', '_');
                             return name + suffix;
                         }),
                         imageNamingStrategy,

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -284,7 +284,8 @@ public class SolexVideoProcessor implements Broadcaster {
                 ellipse = geo.correctedCircle();
                 imageStats = new ImageStats(geo.blackpoint());
             } else {
-                images.put(workflowState.pixelShift(), FileBackedImage.wrap(new ImageWrapper32(workflowState.width(), workflowState.height(), workflowState.reconstructed())));
+                Map<Class<?>, Object> metadata = ellipse != null ? Map.of(Ellipse.class, ellipse) : Map.of();
+                images.put(workflowState.pixelShift(), FileBackedImage.wrap(new ImageWrapper32(workflowState.width(), workflowState.height(), workflowState.reconstructed(), metadata)));
             }
         }
         broadcast(ProcessingDoneEvent.of(System.nanoTime(), images, createCustomImageEmitter(imageNamingStrategy, baseName), ellipse, imageStats));
@@ -306,7 +307,8 @@ public class SolexVideoProcessor implements Broadcaster {
                         imageStats = new ImageStats(geo.blackpoint());
                     }
                 } else {
-                    images.put(workflowState.pixelShift(), new ImageWrapper32(workflowState.width(), workflowState.height(), workflowState.reconstructed()));
+                    Map<Class<?>, Object> metadata = ellipse != null ? Map.of(Ellipse.class, ellipse) : Map.of();
+                    images.put(workflowState.pixelShift(), new ImageWrapper32(workflowState.width(), workflowState.height(), workflowState.reconstructed(), metadata));
                 }
             }
             var emitter = createCustomImageEmitter(imageNamingStrategy, baseName);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -317,11 +317,7 @@ public class SolexVideoProcessor implements Broadcaster {
                 ImageStats finalImageStats = imageStats;
                 blockingContext.async(() -> {
                     broadcast(ProgressEvent.of(0, "Running script " + scriptFile.getName()));
-                    Map<Class, Object> context = new HashMap<>();
-                    context.put(ProcessParams.class, processParams);
-                    context.put(SolarParameters.class, SolarParametersUtils.computeSolarParams(
-                            processParams.observationDetails().date().toLocalDateTime()
-                    ));
+                    var context = createBaseExecutionContext(processParams);
                     if (circle != null) {
                         context.put(Ellipse.class, circle);
                     }
@@ -350,6 +346,15 @@ public class SolexVideoProcessor implements Broadcaster {
                 });
             }
         }
+    }
+
+    public static Map<Class<?>, Object> createBaseExecutionContext(ProcessParams processParams) {
+        Map<Class<?>, Object> context = new HashMap<>();
+        context.put(ProcessParams.class, processParams);
+        context.put(SolarParameters.class, SolarParametersUtils.computeSolarParams(
+                processParams.observationDetails().date().toLocalDateTime()
+        ));
+        return context;
     }
 
     private ImageEmitter createCustomImageEmitter(FileNamingStrategy imageNamingStrategy, String baseName) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -316,6 +316,7 @@ public class SolexVideoProcessor implements Broadcaster {
                 blockingContext.async(() -> {
                     broadcast(ProgressEvent.of(0, "Running script " + scriptFile.getName()));
                     Map<Class, Object> context = new HashMap<>();
+                    context.put(ProcessParams.class, processParams);
                     context.put(SolarParameters.class, SolarParametersUtils.computeSolarParams(
                             processParams.observationDetails().date().toLocalDateTime()
                     ));

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/align/Aligner.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/align/Aligner.java
@@ -86,7 +86,7 @@ public class Aligner {
         EllipseFittingTask.Result fitting;
         try {
             fitting = task.call();
-            prepared = Cropper.cropToSquare(image, fitting.ellipse(), 0, null, null);
+            prepared = Cropper.cropToSquare(image, fitting.ellipse(), 0, null, null).cropped();
         } catch (Exception e) {
             throw ProcessingException.wrap(e);
         }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/crop/Cropper.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/crop/Cropper.java
@@ -17,6 +17,7 @@ package me.champeau.a4j.jsolex.processing.sun.crop;
 
 import me.champeau.a4j.math.image.Image;
 import me.champeau.a4j.math.regression.Ellipse;
+import me.champeau.a4j.math.tuples.DoublePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +33,7 @@ public class Cropper {
 
     }
 
-    public static Image cropToSquare(Image image, Ellipse sunDisk, float blackPoint, Double diameterFactor, Integer rounding) {
+    public static CropResult cropToSquare(Image image, Ellipse sunDisk, float blackPoint, Double diameterFactor, Integer rounding) {
         var source = image.data();
         // at this stage, the new fitting should give us a good estimate of the center and radius
         // because if geometry correction worked, the disk should be circle, so we can crop to a square
@@ -65,10 +66,13 @@ public class Cropper {
                 }
             }
         }
-        return new Image(square, square, cropped);
+        return new CropResult(
+                new Image(square, square, cropped),
+                new DoublePair(cx - half, cy - half)
+        );
     }
 
-    public static Image cropToRectangle(Image image, Ellipse sunDisk, float blackPoint, int width, int height) {
+    public static CropResult cropToRectangle(Image image, Ellipse sunDisk, float blackPoint, int width, int height) {
         var source = image.data();
         var sourceWidth = image.width();
         var sourceHeight = image.height();
@@ -89,6 +93,15 @@ public class Cropper {
             }
         }
 
-        return new Image(width, height, cropped);
+        return new CropResult(
+                new Image(width, height, cropped),
+                new DoublePair(cx - offsetX, cy - offsetY)
+        );
+    }
+
+    public record CropResult(
+            Image cropped,
+            DoublePair centerShift
+    ) {
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/GeometryCorrector.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/GeometryCorrector.java
@@ -29,6 +29,7 @@ import me.champeau.a4j.math.regression.EllipseRegression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
@@ -125,7 +126,7 @@ public class GeometryCorrector extends AbstractTask<GeometryCorrector.Result> {
         double finalSy = sy;
         var circle = computeCorrectedCircle(shear, shift, sx, finalSy);
         broadcaster.broadcast(ProgressEvent.of(1, "Correcting geometry"));
-        return new Result(ImageWrapper32.fromImage(rescaled), ellipse, circle, blackPoint);
+        return new Result(ImageWrapper32.fromImage(rescaled, Map.of(Ellipse.class, circle)), ellipse, circle, blackPoint);
     }
 
     /**

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/WriteColorizedImageTask.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/WriteColorizedImageTask.java
@@ -22,6 +22,7 @@ import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 
 import java.io.File;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -43,6 +44,6 @@ public class WriteColorizedImageTask extends AbstractImageWriterTask {
 
     @Override
     public ImageWrapper createImageWrapper() {
-        return new ColorizedImageWrapper(mono.get(), converter);
+        return new ColorizedImageWrapper(mono.get(), converter, Map.of());
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/WriteMonoImageTask.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/WriteMonoImageTask.java
@@ -21,6 +21,7 @@ import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 
 import java.io.File;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class WriteMonoImageTask extends AbstractImageWriterTask {
@@ -30,6 +31,6 @@ public class WriteMonoImageTask extends AbstractImageWriterTask {
 
     @Override
     public ImageWrapper createImageWrapper() {
-        return new ImageWrapper32(width, height, getBuffer());
+        return new ImageWrapper32(width, height, getBuffer(), Map.of());
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/WriteRGBImageTask.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/WriteRGBImageTask.java
@@ -22,6 +22,7 @@ import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
 
 import java.io.File;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class WriteRGBImageTask extends AbstractImageWriterTask {
@@ -41,6 +42,6 @@ public class WriteRGBImageTask extends AbstractImageWriterTask {
     @Override
     public ImageWrapper createImageWrapper() {
         var rgb = supplier.get();
-        return new RGBImage(width, height, rgb[0], rgb[1], rgb[2]);
+        return new RGBImage(width, height, rgb[0], rgb[1], rgb[2], Map.of());
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DefaultImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DefaultImageEmitter.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -104,7 +105,7 @@ public class DefaultImageEmitter implements ImageEmitter {
     public Supplier<Void> newColorImage(GeneratedImageKind kind, String title, String name, int width, int height, Supplier<float[][]> rgbSupplier) {
         prepareOutput(name);
         return executor.submit(new WriteRGBImageTask(broadcaster,
-                () -> new ImageWrapper32(width, height, new float[0]),
+                () -> new ImageWrapper32(width, height, new float[0], Map.of()),
                 outputDir,
                 title,
                 name,

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/GeneratedImageKind.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/GeneratedImageKind.java
@@ -32,5 +32,6 @@ public enum GeneratedImageKind {
     RAW_STRETCHED,
     RECONSTRUCTION,
     VIRTUAL_ECLIPSE,
+    TECHNICAL_CARD,
     IMAGE_MATH
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import static me.champeau.a4j.jsolex.processing.sun.ImageUtils.bilinearSmoothing;
@@ -264,7 +265,7 @@ public class ProcessingWorkflow {
                             for (int i = 0; i < 2; i++) {
                                 bilinearSmoothing(diskEllipse, width, height, data);
                             }
-                            var mixedImage = new ImageWrapper32(width, height, mix);
+                            var mixedImage = new ImageWrapper32(width, height, mix, Map.of(Ellipse.class, diskEllipse));
                             var colorCurve = processParams.spectrumParams().ray().getColorCurve();
                             if (colorCurve.isPresent()) {
                                 var curve = colorCurve.get();

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ColorizedImageWrapper.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ColorizedImageWrapper.java
@@ -15,6 +15,8 @@
  */
 package me.champeau.a4j.jsolex.processing.util;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -24,7 +26,8 @@ import java.util.function.Function;
  */
 public record ColorizedImageWrapper(
         ImageWrapper32 mono,
-        Function<float[], float[][]> converter
+        Function<float[], float[][]> converter,
+        Map<Class<?>, Object> metadata
 ) implements ImageWrapper {
     @Override
     public int width() {
@@ -37,6 +40,6 @@ public record ColorizedImageWrapper(
     }
 
     public ColorizedImageWrapper copy() {
-        return new ColorizedImageWrapper(mono.copy(), converter);
+        return new ColorizedImageWrapper(mono.copy(), converter, new LinkedHashMap<>(metadata));
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImage.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImage.java
@@ -84,6 +84,7 @@ public final class FileBackedImage implements ImageWrapper {
                     floatBuffer.put(r);
                     floatBuffer.put(g);
                     floatBuffer.put(b);
+                    return new FileBackedImage(width, height, backingFile, null);
                 }
                 throw new ProcessingException("Unexpected image type " + wrapper);
             }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImage.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImage.java
@@ -21,6 +21,7 @@ import java.lang.ref.Cleaner;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -36,12 +37,14 @@ public final class FileBackedImage implements ImageWrapper {
     private final int width;
     private final int height;
     private final Path backingFile;
+    private final Map<Class<?>, Object> metadata;
     private final Object keptInMemory;
 
-    private FileBackedImage(int width, int height, Path backingFile, Object keptInMemory) {
+    private FileBackedImage(int width, int height, Path backingFile, Map<Class<?>, Object> metadata, Object keptInMemory) {
         this.width = width;
         this.height = height;
         this.backingFile = backingFile;
+        this.metadata = metadata;
         this.keptInMemory = keptInMemory;
         CLEANER.register(this, () -> clean(backingFile));
     }
@@ -63,7 +66,7 @@ public final class FileBackedImage implements ImageWrapper {
                     byteBuffer.put(MONO);
                     byteBuffer.putInt(data.length);
                     byteBuffer.asFloatBuffer().put(data);
-                    return new FileBackedImage(width, height, backingFile, null);
+                    return new FileBackedImage(width, height, backingFile, mono.metadata(), null);
                 }
                 if (wrapper instanceof ColorizedImageWrapper colorized) {
                     var data = colorized.mono().data();
@@ -71,7 +74,7 @@ public final class FileBackedImage implements ImageWrapper {
                     byteBuffer.put(COLORIZED);
                     byteBuffer.putInt(data.length);
                     byteBuffer.asFloatBuffer().put(data);
-                    return new FileBackedImage(width, height, backingFile, colorized.converter());
+                    return new FileBackedImage(width, height, backingFile, colorized.metadata(), colorized.converter());
                 }
                 if (wrapper instanceof RGBImage rgb) {
                     var r = rgb.r();
@@ -84,7 +87,7 @@ public final class FileBackedImage implements ImageWrapper {
                     floatBuffer.put(r);
                     floatBuffer.put(g);
                     floatBuffer.put(b);
-                    return new FileBackedImage(width, height, backingFile, null);
+                    return new FileBackedImage(width, height, backingFile, rgb.metadata(), null);
                 }
                 throw new ProcessingException("Unexpected image type " + wrapper);
             }
@@ -104,13 +107,13 @@ public final class FileBackedImage implements ImageWrapper {
                     // Mono image
                     float[] data = new float[size];
                     byteBuffer.asFloatBuffer().get(data);
-                    yield new ImageWrapper32(width, height, data);
+                    yield new ImageWrapper32(width, height, data, metadata);
                 }
                 case COLORIZED -> {
                     // Colorized image
                     float[] data = new float[size];
                     byteBuffer.asFloatBuffer().get(data);
-                    yield new ColorizedImageWrapper(new ImageWrapper32(width, height, data), (Function<float[], float[][]>) keptInMemory);
+                    yield new ColorizedImageWrapper(new ImageWrapper32(width, height, data, metadata), (Function<float[], float[][]>) keptInMemory, metadata);
                 }
                 case RGB -> {
                     // RGB image
@@ -121,7 +124,7 @@ public final class FileBackedImage implements ImageWrapper {
                     floatBuffer.get(r);
                     floatBuffer.get(g);
                     floatBuffer.get(b);
-                    yield new RGBImage(width, height, r, g, b);
+                    yield new RGBImage(width, height, r, g, b, metadata);
                 }
                 default -> throw new IllegalStateException("Undefined image kind " + kind);
             };
@@ -138,6 +141,11 @@ public final class FileBackedImage implements ImageWrapper {
     @Override
     public int height() {
         return height;
+    }
+
+    @Override
+    public Map<Class<?>, Object> metadata() {
+        return metadata;
     }
 
     @Override

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ImageSaver.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ImageSaver.java
@@ -44,7 +44,7 @@ public class ImageSaver {
             float[] stretched = stretch(mono.width(), mono.height(), mono.data());
             ImageUtils.writeMonoImage(image.width(), image.height(), stretched, target, imageFormats);
             if (imageFormats.contains(ImageFormat.FITS)) {
-                FitsUtils.writeFitsFile(new ImageWrapper32(image.width(), image.height(), stretched), toFits(target), processParams);
+                FitsUtils.writeFitsFile(new ImageWrapper32(image.width(), image.height(), stretched, mono.metadata()), toFits(target), processParams);
             }
         } else if (image instanceof ColorizedImageWrapper colorImage) {
             float[] stretched = stretch(colorImage.width(), colorImage.height(), colorImage.mono().data());
@@ -54,7 +54,7 @@ public class ImageSaver {
             var b = colorized[2];
             ImageUtils.writeRgbImage(colorImage.width(), colorImage.height(), r, g, b, target, imageFormats);
             if (imageFormats.contains(ImageFormat.FITS)) {
-                FitsUtils.writeFitsFile(new RGBImage(image.width(), image.height(), r, g, b), toFits(target), processParams);
+                FitsUtils.writeFitsFile(new RGBImage(image.width(), image.height(), r, g, b, colorImage.metadata()), toFits(target), processParams);
             }
         } else if (image instanceof RGBImage rgb) {
             var stretched = stretch(rgb.width(), rgb.height(), rgb.r(), rgb.g(), rgb.b());
@@ -63,7 +63,7 @@ public class ImageSaver {
             var b = stretched[2];
             ImageUtils.writeRgbImage(rgb.width(), rgb.height(), r, g, b, target, imageFormats);
             if (imageFormats.contains(ImageFormat.FITS)) {
-                FitsUtils.writeFitsFile(new RGBImage(image.width(), image.height(), r, g, b), toFits(target), processParams);
+                FitsUtils.writeFitsFile(new RGBImage(image.width(), image.height(), r, g, b, rgb.metadata()), toFits(target), processParams);
             }
         }
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ImageWrapper.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ImageWrapper.java
@@ -15,9 +15,21 @@
  */
 package me.champeau.a4j.jsolex.processing.util;
 
+import java.util.Map;
+import java.util.Optional;
+
 public sealed interface ImageWrapper permits ImageWrapper32, ColorizedImageWrapper, RGBImage, FileBackedImage {
     int width();
     int height();
+    Map<Class<?>, Object> metadata();
+    default <T> Optional<T> findMetadata(Class<T> clazz) {
+        var metadata = metadata();
+        if (metadata.containsKey(clazz)) {
+            //noinspection unchecked
+            return (Optional<T>) Optional.of(metadata.get(clazz));
+        }
+        return Optional.empty();
+    }
 
     ImageWrapper copy();
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ImageWrapper32.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ImageWrapper32.java
@@ -17,6 +17,9 @@ package me.champeau.a4j.jsolex.processing.util;
 
 import me.champeau.a4j.math.image.Image;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
  * A wrapper for images which are using 32-bit floats.
  * @param width the width of the image
@@ -26,19 +29,24 @@ import me.champeau.a4j.math.image.Image;
 public record ImageWrapper32(
         int width,
         int height,
-        float[] data
+        float[] data,
+        Map<Class<?>, Object> metadata
 ) implements ImageWrapper {
     public Image asImage() {
         return new Image(width, height, data);
     }
 
     public static ImageWrapper32 fromImage(Image image) {
-        return new ImageWrapper32(image.width(), image.height(), image.data());
+        return new ImageWrapper32(image.width(), image.height(), image.data(), Map.of());
+    }
+
+    public static ImageWrapper32 fromImage(Image image, Map<Class<?>, Object> metadata) {
+        return new ImageWrapper32(image.width(), image.height(), image.data(), metadata);
     }
 
     public ImageWrapper32 copy() {
         float[] copy = new float[data.length];
         System.arraycopy(data, 0, copy, 0, data.length);
-        return new ImageWrapper32(width, height, copy);
+        return new ImageWrapper32(width, height, copy, new LinkedHashMap<>(metadata));
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/RGBImage.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/RGBImage.java
@@ -15,10 +15,20 @@
  */
 package me.champeau.a4j.jsolex.processing.util;
 
-public record RGBImage(int width, int height, float[] r, float[] g, float[] b) implements ImageWrapper {
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public record RGBImage(
+        int width,
+        int height,
+        float[] r,
+        float[] g,
+        float[] b,
+        Map<Class<?>, Object> metadata
+) implements ImageWrapper {
     @Override
     public RGBImage copy() {
-        return new RGBImage(width, height, copyOf(r), copyOf(g), copyOf(b));
+        return new RGBImage(width, height, copyOf(r), copyOf(g), copyOf(b), new LinkedHashMap<>(metadata));
     }
 
     private static float[] copyOf(float[] array) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/SpectralLineFrameImageCreator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/SpectralLineFrameImageCreator.java
@@ -21,6 +21,7 @@ import me.champeau.a4j.math.Point2D;
 import me.champeau.a4j.math.tuples.DoubleTriplet;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static me.champeau.a4j.jsolex.processing.util.Constants.MAX_PIXEL_VALUE;
@@ -115,6 +116,6 @@ public class SpectralLineFrameImageCreator {
             gg[(int) (offset + x + y * width)] = MAX_PIXEL_VALUE;
             bb[(int) (offset + x + y * width)] = 0;
         }
-        return new RGBImage(width, 2 * height + 10, rr, gg, bb);
+        return new RGBImage(width, 2 * height + 10, rr, gg, bb, Map.of());
     }
 }

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
@@ -49,3 +49,4 @@ imageKind.RECONSTRUCTION=Reconstructed
 imageKind.VIRTUAL_ECLIPSE=Virtual eclipse
 processing.cancelled=Processing cancelled
 solar.parameters=Solar parameters {}
+technical.card=Technical card

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr_FR.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr_FR.properties
@@ -49,3 +49,4 @@ imageKind.RECONSTRUCTION=Reconstruite
 imageKind.VIRTUAL_ECLIPSE=Eclipse virtuelle
 processing.cancelled=Traitement annulé
 solar.parameters=Paramètres solaires {}
+technical.card=Fiche technique

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/ImageExpressionEvaluatorTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/ImageExpressionEvaluatorTest.groovy
@@ -30,7 +30,7 @@ class ImageExpressionEvaluatorTest extends Specification {
 
     ForkJoinContext forkJoinContext = ForkJoinParallelExecutor.newExecutor()
 
-    private Map<Integer, ImageWrapper32> images = [:].withDefault { new ImageWrapper32(0, 0, new float[0]) }
+    private Map<Integer, ImageWrapper32> images = [:].withDefault { new ImageWrapper32(0, 0, new float[0], [:]) }
 
 
     def cleanup() {

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageSelector.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageSelector.java
@@ -348,7 +348,7 @@ public class ImageSelector {
         var images = new HashMap<Double, ImageWrapper32>();
         return new DefaultImageScriptExecutor(
                 forkJoinContext,
-                i -> images.computeIfAbsent(i, unused -> new ImageWrapper32(0, 0, new float[0])),
+                i -> images.computeIfAbsent(i, unused -> new ImageWrapper32(0, 0, new float[0], Map.of())),
                 Map.of()
         );
     }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageSelector.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageSelector.java
@@ -77,6 +77,8 @@ public class ImageSelector {
     @FXML
     private CheckBox reconstruction;
     @FXML
+    private CheckBox technicalCard;
+    @FXML
     private TextField pixelShifts;
     @FXML
     private Button openImageMathButton;
@@ -143,6 +145,7 @@ public class ImageSelector {
                 case DOPPLER -> doppler.setSelected(true);
                 case CONTINUUM -> continuum.setSelected(true);
                 case RECONSTRUCTION -> reconstruction.setSelected(true);
+                case TECHNICAL_CARD -> technicalCard.setSelected(true);
             }
         }
         this.debug.setSelected(debug);
@@ -212,51 +215,39 @@ public class ImageSelector {
         Set<GeneratedImageKind> images = EnumSet.noneOf(GeneratedImageKind.class);
         if (raw.isSelected()) {
             images.add(GeneratedImageKind.RAW);
-            if (internalPixelShifts != null) {
-                internalPixelShifts.remove(0d);
-            }
+            makeDefaultShiftNonInternal();
         }
         if (stretched.isSelected()) {
             images.add(GeneratedImageKind.RAW_STRETCHED);
-            if (internalPixelShifts != null) {
-                internalPixelShifts.remove(0d);
-            }
+            makeDefaultShiftNonInternal();
+        }
+        if (technicalCard.isSelected()) {
+            images.add(GeneratedImageKind.TECHNICAL_CARD);
+            makeDefaultShiftNonInternal();
         }
         if (geometryCorrected.isSelected()) {
             images.add(GeneratedImageKind.GEOMETRY_CORRECTED);
-            if (internalPixelShifts != null) {
-                internalPixelShifts.remove(0d);
-            }
+            makeDefaultShiftNonInternal();
         }
         if (geometryCorrectedStretched.isSelected()) {
             images.add(GeneratedImageKind.GEOMETRY_CORRECTED_STRETCHED);
-            if (internalPixelShifts != null) {
-                internalPixelShifts.remove(0d);
-            }
+            makeDefaultShiftNonInternal();
         }
         if (colorized.isSelected()) {
             images.add(GeneratedImageKind.COLORIZED);
-            if (internalPixelShifts != null) {
-                internalPixelShifts.remove(0d);
-            }
+            makeDefaultShiftNonInternal();
         }
         if (virtualEclipse.isSelected()) {
             images.add(GeneratedImageKind.VIRTUAL_ECLIPSE);
-            if (internalPixelShifts != null) {
-                internalPixelShifts.remove(0d);
-            }
+            makeDefaultShiftNonInternal();
         }
         if (negative.isSelected()) {
             images.add(GeneratedImageKind.NEGATIVE);
-            if (internalPixelShifts != null) {
-                internalPixelShifts.remove(0d);
-            }
+            makeDefaultShiftNonInternal();
         }
         if (mixed.isSelected()) {
             images.add(GeneratedImageKind.MIXED);
-            if (internalPixelShifts != null) {
-                internalPixelShifts.remove(0d);
-            }
+            makeDefaultShiftNonInternal();
         }
         if (doppler.isSelected()) {
             images.add(GeneratedImageKind.DOPPLER);
@@ -287,6 +278,12 @@ public class ImageSelector {
         requestClose();
     }
 
+    private void makeDefaultShiftNonInternal() {
+        if (internalPixelShifts != null) {
+            internalPixelShifts.remove(0d);
+        }
+    }
+
     @FXML
     private void selectAll() {
         selectAll(true);
@@ -309,6 +306,7 @@ public class ImageSelector {
         doppler.setSelected(selected);
         continuum.setSelected(selected);
         reconstruction.setSelected(selected);
+        technicalCard.setSelected(selected);
         debug.setSelected(selected);
     }
 

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
@@ -172,6 +172,7 @@ public class ImageViewer {
             BatchOperations.submit(() -> {
                 imageView.setImage(new Image(imageFile.toURI().toString()));
                 saveButton.setDisable(true);
+                imageView.fileSaved();
             });
         });
     }
@@ -234,7 +235,9 @@ public class ImageViewer {
     }
 
     private boolean shouldDisableCorrectionOfAngleP() {
-        return kind == GeneratedImageKind.IMAGE_MATH || kind == GeneratedImageKind.DEBUG;
+        return kind == GeneratedImageKind.IMAGE_MATH
+               || kind == GeneratedImageKind.DEBUG
+               || kind == GeneratedImageKind.TECHNICAL_CARD;
     }
 
     private static float linValueOf(double sliderValue) {

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
@@ -212,7 +212,7 @@ public class ImageViewer {
         correctAngleP = new CheckBox(message("correct.p.angle"));
         correctAngleP.setSelected(processParams.geometryParams().isAutocorrectAngleP());
         correctAngleP.selectedProperty().addListener((obj, oldValue, newValue) -> strechAndDisplay());
-        correctAngleP.setDisable(kind == GeneratedImageKind.IMAGE_MATH);
+        correctAngleP.setDisable(shouldDisableCorrectionOfAngleP());
         var prevButton = new Button(message("prev.image"));
         prevButton.disableProperty().bind(currentImage.isEqualTo(0));
         prevButton.visibleProperty().bind(imageHistory.sizeProperty().greaterThan(1));
@@ -231,6 +231,10 @@ public class ImageViewer {
         line2.getChildren().addAll(correctAngleP, zoomLabel, zoomSlider, dimensions, coordinatesLabel);
         stretchingParams.getChildren().addAll(line1, line2);
         strechAndDisplay(true);
+    }
+
+    private boolean shouldDisableCorrectionOfAngleP() {
+        return kind == GeneratedImageKind.IMAGE_MATH || kind == GeneratedImageKind.DEBUG;
     }
 
     private static float linValueOf(double sliderValue) {
@@ -351,7 +355,7 @@ public class ImageViewer {
     }
 
     private ImageWrapper maybeRotate(ImageWrapper image) {
-        if (kind != GeneratedImageKind.IMAGE_MATH && correctAngleP.isSelected()) {
+        if (!shouldDisableCorrectionOfAngleP() && correctAngleP.isSelected()) {
             image = image.copy();
             var p = SolarParametersUtils.computeSolarParams(processParams.observationDetails().date().toLocalDateTime()).p();
             return RotationCorrector.rotate(image, p);

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/RotationCorrector.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/RotationCorrector.java
@@ -35,18 +35,18 @@ public class RotationCorrector {
         }
         if (img instanceof ImageWrapper32 mono) {
             var trn = imageMath.rotate(mono.asImage(), angle, 0, false);
-            return ImageWrapper32.fromImage(trn);
+            return ImageWrapper32.fromImage(trn, mono.metadata());
         } else if (img instanceof ColorizedImageWrapper colorized) {
             var mono = colorized.mono();
             var trn = imageMath.rotate(mono.asImage(), angle, 0, false);
-            return new ColorizedImageWrapper(ImageWrapper32.fromImage(trn), colorized.converter());
+            return new ColorizedImageWrapper(ImageWrapper32.fromImage(trn), colorized.converter(), colorized.metadata());
         } else if (img instanceof RGBImage rgb) {
             var height = rgb.height();
             var width = rgb.width();
             var r = imageMath.rotate(new Image(width, height, rgb.r()), angle, 0, false);
             var g = imageMath.rotate(new Image(width, height, rgb.g()), angle, 0, false);
             var b = imageMath.rotate(new Image(width, height, rgb.b()), angle, 0, false);
-            return new RGBImage(r.width(), r.height(), r.data(), g.data(), b.data());
+            return new RGBImage(r.width(), r.height(), r.data(), g.data(), b.data(), rgb.metadata());
         }
         throw new IllegalArgumentException("Unsupported image type");
     }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/SpectralRayEditor.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/SpectralRayEditor.java
@@ -47,6 +47,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.EnumSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -200,7 +201,7 @@ public class SpectralRayEditor {
             sunPreview.setImage(new Image(SunDiskColorPreview.getMonoImageStream()));
             return;
         }
-        var colorImage = new ColorizedImageWrapper(MONO_SUN_IMAGE, mono -> ImageUtils.convertToRGB(curve, mono));
+        var colorImage = new ColorizedImageWrapper(MONO_SUN_IMAGE, mono -> ImageUtils.convertToRGB(curve, mono), Map.of());
         var colorized = colorImage.converter().apply(MONO_SUN_IMAGE.data());
         var r = colorized[0];
         var g = colorized[1];
@@ -277,7 +278,7 @@ public class SpectralRayEditor {
                 data[i] = rgb[i] & 0xFF;
             }
             LinearStrechingStrategy.DEFAULT.stretch(width, height, data);
-            return new ImageWrapper32(width, height, data);
+            return new ImageWrapper32(width, height, data, Map.of());
         }
 
         private static InputStream getMonoImageStream() {

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ZoomableImageView.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ZoomableImageView.java
@@ -60,7 +60,11 @@ public class ZoomableImageView extends HBox {
         });
         imageView.setOnMouseClicked(evt -> {
             if (evt.getButton().equals(MouseButton.PRIMARY) && evt.getClickCount() == 2) {
-                zoom = 1.0;
+                if (zoom == 1.0) {
+                    zoom = getWidth() / imageView.getImage().getWidth();
+                } else {
+                    zoom = 1.0;
+                }
                 triggerOnZoomChanged();
             }
         });

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ZoomableImageView.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ZoomableImageView.java
@@ -16,6 +16,7 @@
 package me.champeau.a4j.jsolex.app.jfx;
 
 import javafx.beans.binding.Bindings;
+import javafx.beans.binding.BooleanBinding;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.ScrollPane;
@@ -37,6 +38,7 @@ public class ZoomableImageView extends HBox {
     private final ScrollPane scrollPane;
     private final ImageView imageView;
     private final ContextMenu ctxMenu;
+    private final BooleanBinding allowFileOpen;
     private BiConsumer<? super Double, ? super Double> onCoordinatesListener;
     private Consumer<? super Double> onZoomChanged;
 
@@ -71,7 +73,8 @@ public class ZoomableImageView extends HBox {
 
         ctxMenu = new ContextMenu();
         var showFile = new MenuItem(message("show.in.files"));
-        showFile.disableProperty().bind(Bindings.createBooleanBinding(() -> imagePath == null || !Files.exists(imagePath)));
+        allowFileOpen = Bindings.createBooleanBinding(() -> imagePath == null || !Files.exists(imagePath));
+        showFile.disableProperty().bind(allowFileOpen);
         showFile.setOnAction(e -> ExplorerSupport.openInExplorer(imagePath));
         ctxMenu.getItems().add(showFile);
 
@@ -132,6 +135,10 @@ public class ZoomableImageView extends HBox {
     public void setImage(Image image) {
         imageView.setImage(image);
         imageView.setPreserveRatio(true);
+    }
+
+    public void fileSaved() {
+        allowFileOpen.invalidate();
     }
 
     public ContextMenu getCtxMenu() {

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ime/ImageMathTextArea.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ime/ImageMathTextArea.java
@@ -122,6 +122,9 @@ public class ImageMathTextArea extends BorderPane {
                 .collect(Collectors.toSet());
         knownVariables.add(DefaultImageScriptExecutor.BLACK_POINT_VAR);
         knownVariables.add(DefaultImageScriptExecutor.ANGLE_P_VAR);
+        knownVariables.add(DefaultImageScriptExecutor.B0_VAR);
+        knownVariables.add(DefaultImageScriptExecutor.L0_VAR);
+        knownVariables.add(DefaultImageScriptExecutor.CARROT_VAR);
         var spansBuilder = new StyleSpansBuilder<Collection<String>>();
         for (var token : tokens) {
             int tokenLength = token.length();

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/image-selection.fxml
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/image-selection.fxml
@@ -61,6 +61,7 @@
                         <CheckBox fx:id="mixed" mnemonicParsing="false" text="%mixed.image" />
                         <CheckBox fx:id="doppler" mnemonicParsing="false" text="%doppler.image" />
                         <CheckBox fx:id="continuum" mnemonicParsing="false" text="%continuum" />
+                        <CheckBox fx:id="technicalCard" mnemonicParsing="false" text="%technical.card" />
                         <CheckBox fx:id="debug" mnemonicParsing="false" text="%debug.images" />
                     </children>
                     <padding>

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/image-selection.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/image-selection.properties
@@ -21,3 +21,4 @@ mode=Mode
 open.imagemath=Open ImageMath
 mode.simple=Simple
 mode.imagemath=ImageMath
+technical.card=Technical card

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/image-selection_fr_FR.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/image-selection_fr_FR.properties
@@ -21,3 +21,4 @@ open.imagemath=Ouvrir ImageMath
 mode=Mode
 mode.simple=Simple
 mode.imagemath=ImageMath
+technical.card=Fiche technique

--- a/math/src/main/java/me/champeau/a4j/math/regression/Ellipse.java
+++ b/math/src/main/java/me/champeau/a4j/math/regression/Ellipse.java
@@ -137,27 +137,11 @@ public class Ellipse {
         );
     }
 
-    public Ellipse translatedBy(double dx, double dy) {
-        var a = cart.a();
-        var b = cart.b();
-        var c = cart.c();
-        var d = cart.d();
-        var e = cart.e();
-        var f = cart.f();
-
-        var newD = d - 2 * a * dx - b * dy;
-        var newE = e - 2 * c * dy - b * dx;
-        var newF = f + a * dx * dx + b * dx * dy + c * dy * dy - d * dx - e * dy;
-
-        return Ellipse.ofCartesian(new DoubleSextuplet(a, b, c, newD, newE, newF));
-    }
-
-
     public Ellipse centeredAt(int cx, int cy) {
         var center = center();
         var dx = cx - center.a();
         var dy = cy - center.b();
-        return translatedBy(dx, dy);
+        return translate(dx, dy);
     }
 
 

--- a/math/src/main/java/me/champeau/a4j/math/regression/Ellipse.java
+++ b/math/src/main/java/me/champeau/a4j/math/regression/Ellipse.java
@@ -210,6 +210,29 @@ public class Ellipse {
         return a >= 0 && value <= 0 || a <= 0 && value >= 0;
     }
 
+    /**
+     * Computes the parameters of this ellipse translated by vector (u,v)
+     * @param u the translation on the X axis
+     * @param v the translation on the Y axis
+     * @return the new ellipse
+     */
+    public Ellipse translate(double u, double v) {
+        var a = cart.a();
+        var b = cart.b();
+        var c = cart.c();
+        var d = cart.d();
+        var e = cart.e();
+        var f = cart.f();
+        return new Ellipse(new DoubleSextuplet(
+                a,
+                b,
+                c,
+                d - 2 * a * u - b * v,
+                e - 2 * c * v - b * u,
+                a * u * u + b * u * v + c * v * v - d * u - e * v + f
+        ));
+    }
+
     @Override
     public String toString() {
         var sb = new StringBuilder();

--- a/math/src/main/java/me/champeau/a4j/math/regression/Ellipse.java
+++ b/math/src/main/java/me/champeau/a4j/math/regression/Ellipse.java
@@ -19,6 +19,8 @@ import me.champeau.a4j.math.Point2D;
 import me.champeau.a4j.math.tuples.DoublePair;
 import me.champeau.a4j.math.tuples.DoubleSextuplet;
 
+import java.util.Optional;
+
 /**
  * Represents an ellipse, as the result of ellipse regression.
  */
@@ -178,6 +180,19 @@ public class Ellipse {
                 new Point2D(cx - s2 * cosOrtho, cy - s2 * sinOrtho),
                 new Point2D(cx + s2 * cosOrtho, cy + s2 * sinOrtho)
         };
+    }
+
+    public Optional<DoublePair> findY(double x) {
+        var a = cart.c();
+        var b = cart.b() * x + cart.e();
+        var c = cart.a() * x * x + cart.d() * x + cart.f();
+        var disc = b * b - 4 * a * c;
+        if (disc >= 0 && 2 * a != 0) {
+            var y1 = (-b + Math.sqrt(disc)) / 2 * a;
+            var y2 = (-b - Math.sqrt(disc)) / 2 * a;
+            return Optional.of(new DoublePair(y1, y2));
+        }
+        return Optional.empty();
     }
 
     public boolean isWithin(Point2D point) {


### PR DESCRIPTION
This image adds a globe overlay on the image, showing the detected orientation of the solar disk, as well as the observation details.

Here's an example:

![13_06_30_best_0000_card_0_00](https://github.com/melix/astro4j/assets/316357/d60c3e03-28ee-47c1-ab56-2cf2dbce731d)
