### PR TITLE
Compute average params (ellipse, process params) on aggregate functions

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -234,7 +234,7 @@ public class SolexVideoProcessor implements Broadcaster {
                             ImageWrapper32 rotated;
                             var recon = new Image(width, newHeight, state.reconstructed());
                             var rotateLeft = ImageMath.newInstance().rotateLeft(recon);
-                            rotated = ImageWrapper32.fromImage(rotateLeft);
+                            rotated = ImageWrapper32.fromImage(rotateLeft, createMetadata(processParams));
                             maybePerformFlips(rotated);
                             state.setImage(rotated);
                         });
@@ -318,7 +318,7 @@ public class SolexVideoProcessor implements Broadcaster {
                 ImageStats finalImageStats = imageStats;
                 blockingContext.async(() -> {
                     broadcast(ProgressEvent.of(0, "Running script " + scriptFile.getName()));
-                    var context = createBaseExecutionContext(processParams);
+                    var context = createMetadata(processParams);
                     if (circle != null) {
                         context.put(Ellipse.class, circle);
                     }
@@ -349,7 +349,7 @@ public class SolexVideoProcessor implements Broadcaster {
         }
     }
 
-    public static Map<Class<?>, Object> createBaseExecutionContext(ProcessParams processParams) {
+    public static Map<Class<?>, Object> createMetadata(ProcessParams processParams) {
         Map<Class<?>, Object> context = new HashMap<>();
         context.put(ProcessParams.class, processParams);
         context.put(SolarParameters.class, SolarParametersUtils.computeSolarParams(

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/GeometryCorrector.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/GeometryCorrector.java
@@ -32,6 +32,7 @@ import me.champeau.a4j.ser.Header;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -136,7 +137,9 @@ public class GeometryCorrector extends AbstractTask<GeometryCorrector.Result> {
         var rescaled = imageMath.rotateAndScale(new Image(extendedWidth, height, newBuffer), 0, blackPoint, sx, sy);
         double finalSy = sy;
         var circle = computeCorrectedCircle(shear, shift, sx, finalSy);
-        var corrected = ImageWrapper32.fromImage(rescaled, Map.of(Ellipse.class, circle));
+        var metadata = new HashMap<>(getMetadata());
+        metadata.put(Ellipse.class, circle);
+        var corrected = ImageWrapper32.fromImage(rescaled, metadata);
         var autocropMode = processParams.geometryParams().autocropMode();
         if (autocropMode != null) {
             var cropping = new Crop(forkJoinContext, Map.of(Ellipse.class, ellipse));

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
@@ -239,7 +239,7 @@ public class ProcessingWorkflow {
 
     private void produceTechnicalCard(ImageWrapper32 clahe) {
         var details = clahe.copy();
-        var context = SolexVideoProcessor.createBaseExecutionContext(processParams);
+        var context = SolexVideoProcessor.createMetadata(processParams);
         var rotate = new Rotate(executor, context);
         var crop = new Crop(executor, context);
         var draw = new ImageDraw(executor, context);


### PR DESCRIPTION
This commit adds support for computing an "average" ellipse or process parameters when using aggregate functions like avg, median, ... so that for example we can produce virtual eclipses or technical cards in a batch script.