### PR TITLE
Make sure ImageMath operators result in 16-bit values

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ScriptSupport.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ScriptSupport.java
@@ -16,6 +16,7 @@
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
 import me.champeau.a4j.jsolex.processing.params.ProcessParams;
+import me.champeau.a4j.jsolex.processing.stretching.CutoffStretchingStrategy;
 import me.champeau.a4j.jsolex.processing.stretching.NegativeImageStrategy;
 import me.champeau.a4j.jsolex.processing.util.FileBackedImage;
 import me.champeau.a4j.jsolex.processing.util.ForkJoinContext;
@@ -132,6 +133,7 @@ public class ScriptSupport {
                 var idx = i;
                 result[i] = (float) operator.apply(images.stream().mapToDouble(img -> img.data()[idx])).orElse(0);
             }
+            CutoffStretchingStrategy.DEFAULT.stretch(width, height, result);
             Map<Class<?>, Object> metadata = new HashMap<>();
             List<Point2D> ellipseSamplePoints = new ArrayList<>();
             long avgDate = 0;


### PR DESCRIPTION
It was possible for operations, e.g img(0)+img(1) to result in images which would exceed the 0-65535 range.