### PR TITLE
Store metadata in FITS file

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 slf4j-api = "2.0.7"
 logback = "1.4.6"
 commons-math = "3.6.1"
-fits = "1.17.1"
+fits = "1.18.0"
 gson = "2.10.1"
 micronaut = "4.0.0-M2"
 richtextfx = "0.11.0"

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/DiskFill.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/DiskFill.java
@@ -61,7 +61,7 @@ public class DiskFill extends AbstractFunctionImpl {
                 doFill(ellipse.get(), r, rgb.width(), fill);
                 var g = new float[rgb.g().length];
                 System.arraycopy(rgb.g(), 0, g, 0, g.length);
-                doFill(ellipse.get(), r, rgb.width(), fill);
+                doFill(ellipse.get(), g, rgb.width(), fill);
                 var b = new float[rgb.b().length];
                 System.arraycopy(rgb.b(), 0, b, 0, b.length);
                 doFill(ellipse.get(), b, rgb.width(), fill);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Loader.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Loader.java
@@ -15,6 +15,7 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+import me.champeau.a4j.jsolex.processing.util.FitsUtils;
 import me.champeau.a4j.jsolex.processing.util.ForkJoinContext;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
@@ -45,7 +46,9 @@ public class Loader extends AbstractFunctionImpl {
             "jpg",
             "jpeg",
             "tif",
-            "tiff"
+            "tiff",
+            "fits",
+            "fit"
     );
 
     public Loader(ForkJoinContext forkJoinContext, Map<Class<?>, Object> context) {
@@ -70,6 +73,9 @@ public class Loader extends AbstractFunctionImpl {
     }
 
     private static ImageWrapper doLoadImage(File file) {
+        if (file.getName().toLowerCase(Locale.US).endsWith(".fits")) {
+            return FitsUtils.readFitsFile(file);
+        }
         BufferedImage image;
         try {
             image = ImageIO.read(file);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ProcessParamsIO.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ProcessParamsIO.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -35,13 +36,12 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
-abstract class ProcessParamsIO {
+public abstract class ProcessParamsIO {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProcessParamsIO.class);
 
     private ProcessParamsIO() {
 
     }
-
 
     private static Path resolveDefaultsFile() {
         var jsolexDir = Paths.get(System.getProperty("user.home"), ".jsolex");
@@ -92,82 +92,8 @@ abstract class ProcessParamsIO {
     public static ProcessParams readFrom(Path configFile) {
         if (Files.exists(configFile)) {
             try (var reader = FilesUtils.newTextReader(configFile)) {
-                Gson gson = newGson();
-                var params = gson.fromJson(reader, ProcessParams.class);
+                var params = readFrom(reader);
                 if (params != null) {
-                    if (params.videoParams() == null) {
-                        // happens if loading an old config file
-                        params = new ProcessParams(
-                                params.spectrumParams(),
-                                params.observationDetails(),
-                                params.extraParams(),
-                                new VideoParams(ColorMode.MONO),
-                                params.geometryParams(),
-                                params.bandingCorrectionParams(),
-                                params.requestedImages()
-                        );
-                    }
-                    if (params.geometryParams() == null) {
-                        params = new ProcessParams(
-                                params.spectrumParams(),
-                                params.observationDetails(),
-                                params.extraParams(),
-                                params.videoParams(),
-                                new GeometryParams(
-                                        null,
-                                        null,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        true,
-                                        RotationKind.NONE,
-                                        AutocropMode.OFF),
-                                params.bandingCorrectionParams(),
-                                params.requestedImages()
-                        );
-                    }
-                    if (params.bandingCorrectionParams() == null) {
-                        params = new ProcessParams(
-                                params.spectrumParams(),
-                                params.observationDetails(),
-                                params.extraParams(),
-                                params.videoParams(),
-                                params.geometryParams(),
-                                new BandingCorrectionParams(
-                                        24,
-                                        3
-                                ),
-                                params.requestedImages()
-                        );
-                    }
-                    if (params.requestedImages() == null) {
-                        params = new ProcessParams(
-                                params.spectrumParams(),
-                                params.observationDetails(),
-                                params.extraParams(),
-                                params.videoParams(),
-                                params.geometryParams(),
-                                params.bandingCorrectionParams(),
-                                new RequestedImages(RequestedImages.FULL_MODE, List.of(0d), Set.of(), ImageMathParams.NONE)
-                        );
-                    }
-                    if (params.extraParams() == null) {
-                        params = params.withExtraParams(new ExtraParams(
-                                false,
-                                true,
-                                EnumSet.of(ImageFormat.PNG),
-                                FileNamingStrategy.DEFAULT_TEMPLATE,
-                                FileNamingStrategy.DEFAULT_DATETIME_FORMAT,
-                                FileNamingStrategy.DEFAULT_DATE_FORMAT
-                        ));
-                    }
-                    if (params.extraParams().datetimeFormat() == null) {
-                        params = params.withExtraParams(params.extraParams().withDateTimeFormat(FileNamingStrategy.DEFAULT_DATETIME_FORMAT));
-                    }
-                    if (params.extraParams().dateFormat() == null) {
-                        params = params.withExtraParams(params.extraParams().withDateFormat(FileNamingStrategy.DEFAULT_DATE_FORMAT));
-                    }
                     return params;
                 }
             } catch (IOException e) {
@@ -175,6 +101,93 @@ abstract class ProcessParamsIO {
             }
         }
         return null;
+    }
+
+    public static ProcessParams readFrom(Reader reader) {
+        Gson gson = newGson();
+        var params = gson.fromJson(reader, ProcessParams.class);
+        if (params != null) {
+            if (params.videoParams() == null) {
+                // happens if loading an old config file
+                params = new ProcessParams(
+                        params.spectrumParams(),
+                        params.observationDetails(),
+                        params.extraParams(),
+                        new VideoParams(ColorMode.MONO),
+                        params.geometryParams(),
+                        params.bandingCorrectionParams(),
+                        params.requestedImages()
+                );
+            }
+            if (params.geometryParams() == null) {
+                params = new ProcessParams(
+                        params.spectrumParams(),
+                        params.observationDetails(),
+                        params.extraParams(),
+                        params.videoParams(),
+                        new GeometryParams(
+                                null,
+                                null,
+                                false,
+                                false,
+                                false,
+                                false,
+                                true,
+                                RotationKind.NONE,
+                                AutocropMode.OFF),
+                        params.bandingCorrectionParams(),
+                        params.requestedImages()
+                );
+            }
+            if (params.bandingCorrectionParams() == null) {
+                params = new ProcessParams(
+                        params.spectrumParams(),
+                        params.observationDetails(),
+                        params.extraParams(),
+                        params.videoParams(),
+                        params.geometryParams(),
+                        new BandingCorrectionParams(
+                                24,
+                                3
+                        ),
+                        params.requestedImages()
+                );
+            }
+            if (params.requestedImages() == null) {
+                params = new ProcessParams(
+                        params.spectrumParams(),
+                        params.observationDetails(),
+                        params.extraParams(),
+                        params.videoParams(),
+                        params.geometryParams(),
+                        params.bandingCorrectionParams(),
+                        new RequestedImages(RequestedImages.FULL_MODE, List.of(0d), Set.of(), ImageMathParams.NONE)
+                );
+            }
+            if (params.extraParams() == null) {
+                params = params.withExtraParams(new ExtraParams(
+                        false,
+                        true,
+                        EnumSet.of(ImageFormat.PNG),
+                        FileNamingStrategy.DEFAULT_TEMPLATE,
+                        FileNamingStrategy.DEFAULT_DATETIME_FORMAT,
+                        FileNamingStrategy.DEFAULT_DATE_FORMAT
+                ));
+            }
+            if (params.extraParams().datetimeFormat() == null) {
+                params = params.withExtraParams(params.extraParams().withDateTimeFormat(FileNamingStrategy.DEFAULT_DATETIME_FORMAT));
+            }
+            if (params.extraParams().dateFormat() == null) {
+                params = params.withExtraParams(params.extraParams().withDateFormat(FileNamingStrategy.DEFAULT_DATE_FORMAT));
+            }
+            return params;
+        }
+        return null;
+    }
+
+    public static String serializeToJson(ProcessParams params) {
+        var gson = newGson();
+        return gson.toJson(params);
     }
 
     public static void saveTo(ProcessParams params, File destination) {


### PR DESCRIPTION
This pull request adds support for storing and reading metadata in FITS files. In particular, we are storing:

- the ellipse fit
- the process parameters (as JSON)
- the solar parameters

This makes it possible to perform the same actions as with regular images in a session, in another session. For example, one can load a previous file in a script via `load("some_fits_file.fits")` and still get the associated ellipse fit (e.g to perform a virtual eclipse).
