### PR TITLE
Use ellipse metadata for radius rescale

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Scaling.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Scaling.java
@@ -90,9 +90,9 @@ public class Scaling extends AbstractFunctionImpl {
             var fittings = new LinkedHashMap<ImageWrapper, Double>();
             for (Object obj : list) {
                 if (obj instanceof ImageWrapper img) {
-                    var fit = ellipseFit.fit(List.of(img));
-                    if (fit instanceof Ellipse e) {
-                        fittings.put(img, radiusOf(e));
+                    var fit = img.findMetadata(Ellipse.class).orElseGet(() -> (Ellipse) ellipseFit.fit(List.of(img)));
+                    if (fit != null) {
+                        fittings.put(img, radiusOf(fit));
                     }
                 }
             }


### PR DESCRIPTION
Now that we keep ellipse metadata on images, it is no longer necessary to perform a new ellipse fit on each image when performing a radius rescale. Ellipse fit is kept in case the metadata is not available (e.g when loading jpg files).