### PR TITLE
Fix contrast adjustment strategy

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/ContrastAdjustmentStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/ContrastAdjustmentStrategy.java
@@ -18,18 +18,28 @@ package me.champeau.a4j.jsolex.processing.stretching;
 import me.champeau.a4j.jsolex.processing.util.Constants;
 
 public final class ContrastAdjustmentStrategy implements StretchingStrategy {
-    public static final ContrastAdjustmentStrategy DEFAULT = new ContrastAdjustmentStrategy(0, Constants.MAX_PIXEL_VALUE);
+    public static final ContrastAdjustmentStrategy DEFAULT = new ContrastAdjustmentStrategy(0, .95f*Constants.MAX_PIXEL_VALUE);
 
+    private final boolean normalize;
     private final float min;
     private final float max;
 
     public ContrastAdjustmentStrategy(float min, float max) {
+        this(min, max, false);
+    }
+
+    private ContrastAdjustmentStrategy(float min, float max, boolean normalize) {
         this.min = min;
         this.max = max;
+        this.normalize = normalize;
     }
 
     public ContrastAdjustmentStrategy withRange(float min, float max) {
-        return new ContrastAdjustmentStrategy(min, max);
+        return new ContrastAdjustmentStrategy(min, max, normalize);
+    }
+
+    public ContrastAdjustmentStrategy withNormalize(boolean normalize) {
+        return new ContrastAdjustmentStrategy(min, max, normalize);
     }
 
     public float getMin() {
@@ -48,6 +58,9 @@ public final class ContrastAdjustmentStrategy implements StretchingStrategy {
             } else if (data[i] > max) {
                 data[i] = max;
             }
+        }
+        if (normalize) {
+            LinearStrechingStrategy.DEFAULT.stretch(width, height, data);
         }
     }
 

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
@@ -71,7 +71,7 @@ import static me.champeau.a4j.jsolex.app.JSolEx.message;
 public class ImageViewer {
     private Node root;
     private Stage stage;
-    private ContrastAdjustmentStrategy stretchingStrategy = ContrastAdjustmentStrategy.DEFAULT;
+    private ContrastAdjustmentStrategy stretchingStrategy = ContrastAdjustmentStrategy.DEFAULT.withNormalize(true);
     private ImageWrapper image;
     private ImageWrapper displayImage;
     private ImageWrapper stretchedImage;
@@ -188,6 +188,9 @@ public class ImageViewer {
 
     private void configureStretching() {
         this.stretchingStrategy = ContrastAdjustmentStrategy.DEFAULT;
+        if (kind != GeneratedImageKind.IMAGE_MATH) {
+            this.stretchingStrategy = this.stretchingStrategy.withNormalize(true);
+        }
         var line1 = new HBox(4);
         line1.setAlignment(Pos.CENTER_LEFT);
         var line2 = new HBox(4);


### PR DESCRIPTION
The previous implementation was truncating, but not expanding the range afterwards, which led to greyish images instead of saturated ones.