### PR TITLE
Add an option to process a pixel shift from the profile

### DIFF
--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages.properties
@@ -80,3 +80,5 @@ wavelength=Wavelength (\u212B)
 save.to.file=Save to file
 chart.saved.title=Chart saved
 chart.saved=Chart saved to file {}
+click.to.reprocess=Click to process
+reprocess=Process

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages_fr_FR.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages_fr_FR.properties
@@ -79,3 +79,5 @@ wavelength=Longueur d'onde
 save.to.file=Enregistrer dans un fichier
 chart.saved.title=Graphique sauvegardé
 chart.saved=Graphique sauvegardé dans le fichier {}
+click.to.reprocess=Cliquer pour traiter
+reprocess=Traiter


### PR DESCRIPTION
One can now go on the "profile" tab of an image, which shows the wavelength intensity per pixel shift. By clicking on a node, it is possible to start a process at that pixel shift.