### PR TITLE
Fix infinite loop when processing some files

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -226,8 +226,15 @@ public class SolexVideoProcessor implements Broadcaster {
             if (maybePolynomial.isPresent()) {
                 var polynomial = maybePolynomial.get();
                 var avgImage = new Image(width, height, averageImage);
+                var leftBorder = Math.max(0, start);
+                var rightBorder = Math.min(end, width);
+                if (leftBorder >= rightBorder) {
+                    // unreliable detection which happens on some SER files
+                    leftBorder = 0;
+                    rightBorder = width;
+                }
                 broadcast(new AverageImageComputedEvent(
-                    new AverageImageComputedEvent.AverageImage(avgImage, polynomial, Math.max(0,start), Math.min(end, width), processParams.spectrumParams().ray(), processParams.observationDetails())
+                    new AverageImageComputedEvent.AverageImage(avgImage, polynomial, leftBorder, rightBorder, processParams.spectrumParams().ray(), processParams.observationDetails())
                 ));
                 ioForkJoinContext.blocking(() -> {
                     try (var reader = SerFileReader.of(serFile)) {

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SingleModeProcessingEventListener.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SingleModeProcessingEventListener.java
@@ -780,6 +780,14 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
             min = Math.min(v, min);
             max = Math.max(v, max);
         }
+        if (min == Double.MAX_VALUE) {
+            min = 0;
+        }
+        if (max == Double.MIN_VALUE) {
+            max = height;
+        }
+        min = Math.max(0, min);
+        max = Math.min(height, max);
         double mid = (max + min) / 2.0;
         double range = (max - min) / 2.0;
         for (int y = (int) range; y < height - range; y++) {


### PR DESCRIPTION
In some difficult cases, it was possible that the computed left and right borders were inconsistent, resulting in a nearly infinite loop.