### PR TITLE
Fix animation sometimes not loaded

### DIFF
--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
@@ -475,7 +475,7 @@ public class JSolEx extends Application implements JSolExInterface {
             var text = imageMathScript.getText();
             cpuExecutor.async(() -> {
                 if (clearImagesCheckbox.isSelected()) {
-                    BatchOperations.submit(this::prepareTabs);
+                    BatchOperations.submit(this::newSession);
                 }
                 executor.execute(text, ImageMathScriptExecutor.SectionKind.SINGLE);
             });
@@ -650,6 +650,7 @@ public class JSolEx extends Application implements JSolExInterface {
             },
             e -> {
                 stage.close();
+                BatchOperations.submit(this::newSession);
                 e.getConfiguration().ifPresent(scripts -> ioExecutor.async(() -> executeStandaloneScripts(
                     params.withRequestedImages(
                         params.requestedImages().withMathImages(scripts)
@@ -760,6 +761,7 @@ public class JSolEx extends Application implements JSolExInterface {
                                 var fileName = entry.getValue().toFile().getName();
                                 var ext = fileName.substring(fileName.lastIndexOf("."));
                                 var targetPath = new File(outputDirectory, name + ext).toPath();
+                                Files.createDirectories(targetPath.getParent());
                                 Files.move(entry.getValue(), targetPath, StandardCopyOption.REPLACE_EXISTING);
                                 listener.onFileGenerated(FileGeneratedEvent.of(entry.getKey(), targetPath));
                             } catch (IOException e) {
@@ -869,7 +871,7 @@ public class JSolEx extends Application implements JSolExInterface {
     }
 
     private void processFileWithParams(File selectedFile, Header firstHeader, ProcessParams params) {
-        prepareTabs();
+        newSession();
         console.clear();
         var interruptButton = addInterruptButton();
         var processingThread = new Thread(() -> cpuExecutor.blocking(() ->
@@ -885,7 +887,7 @@ public class JSolEx extends Application implements JSolExInterface {
         processingThread.start();
     }
 
-    private void prepareTabs() {
+    public void newSession() {
         mainPane.getTabs().clear();
         mainPane.getTabs().add(new Tab(message("images"), multipleImagesViewer));
         multipleImagesViewer.clear();
@@ -926,7 +928,7 @@ public class JSolEx extends Application implements JSolExInterface {
     }
 
     private void startBatchProcess(Header header, ProcessParams params, List<File> selectedFiles) {
-        prepareTabs();
+        newSession();
         LOGGER.info(message("batch.mode.info"));
         var tab = new Tab(message("batch.process"));
         var table = new TableView<BatchItem>();

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/MultipleImagesViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/MultipleImagesViewer.java
@@ -213,9 +213,13 @@ public class MultipleImagesViewer extends Pane {
         categoryPane.getProperties().put(DisplayCategory.class, category);
         List<CategoryPane> newCategories = new ArrayList<>(categories().toList());
         newCategories.add(categoryPane);
-        newCategories.sort(Comparator.comparingInt(t -> ((DisplayCategory) t.getProperties().get(DisplayCategory.class)).ordinal()));
+        newCategories.sort(Comparator.comparingInt(t -> categoryOf(t).ordinal()));
         categories.setAll(newCategories);
         return categoryPane;
+    }
+
+    private static DisplayCategory categoryOf(CategoryPane pane) {
+        return (DisplayCategory) pane.getProperties().get(DisplayCategory.class);
     }
 
 }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/stacking/StackingAndMosaicController.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/stacking/StackingAndMosaicController.java
@@ -32,7 +32,6 @@ import javafx.scene.layout.FlowPane;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import me.champeau.a4j.jsolex.app.JSolEx;
-import me.champeau.a4j.jsolex.app.jfx.BatchOperations;
 import me.champeau.a4j.jsolex.app.jfx.I18N;
 import me.champeau.a4j.jsolex.app.jfx.ImageMathEditor;
 import me.champeau.a4j.jsolex.app.jfx.ImageViewer;
@@ -50,7 +49,6 @@ import me.champeau.a4j.jsolex.processing.params.StackingParamsIO;
 import me.champeau.a4j.jsolex.processing.sun.workflow.StackingWorkflow;
 import me.champeau.a4j.jsolex.processing.util.ForkJoinContext;
 import me.champeau.a4j.jsolex.processing.util.ImageFormat;
-import me.champeau.a4j.jsolex.processing.util.ProcessingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -258,6 +256,7 @@ public class StackingAndMosaicController {
 
     @FXML
     private void proceed() {
+        owner.newSession();
         var processingDate = LocalDateTime.now();
         var processParams = createProcessParams();
         var panels = cardsPane.getChildren().stream()

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/JSolExInterface.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/JSolExInterface.java
@@ -42,4 +42,6 @@ public interface JSolExInterface {
     void prepareForScriptExecution(ImageMathScriptExecutor executor, ProcessParams params);
 
     HostServices getHostServices();
+
+    void newSession();
 }


### PR DESCRIPTION
It was possible, when using scripts, that the parent directory where to save animations didn't exist. This commit fixes this problem and also makes sure that the tabs are open when using the image math editor.