### PR TITLE
Improve virtual eclipse image

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/ArcsinhStretchingStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/ArcsinhStretchingStrategy.java
@@ -57,6 +57,11 @@ public final class ArcsinhStretchingStrategy implements StretchingStrategy {
             var pixel = Math.max(0, original - bp);
             double stretched = (pixel * asinh(original * stretch)) / (original * asinh);
             data[i] = (float) (stretched * max);
+            if (Float.valueOf(data[i]).isNaN()) {
+                data[i] = 0;
+            }
+            data[i] = Math.max(0, data[i]);
+            data[i] = Math.min(Constants.MAX_PIXEL_VALUE, data[i]);
         }
         LinearStrechingStrategy.DEFAULT.stretch(width, height, data);
     }
@@ -73,6 +78,11 @@ public final class ArcsinhStretchingStrategy implements StretchingStrategy {
                 var pixel = Math.max(0, original - bp);
                 double stretched = (pixel * asinh(original * stretch)) / (mean * asinh);
                 rgb[j][i] = (float) (stretched * max);
+                if (Float.valueOf(rgb[j][i]).isNaN()) {
+                    rgb[j][i] = 0;
+                }
+                rgb[j][i] = Math.max(0, rgb[j][i]);
+                rgb[j][i] = Math.min(Constants.MAX_PIXEL_VALUE, rgb[j][i]);
             }
         }
         LinearStrechingStrategy.DEFAULT.stretch(width, height, rgb);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/BackgroundRemoval.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/BackgroundRemoval.java
@@ -105,14 +105,6 @@ public class BackgroundRemoval {
                 data[idx] = (float) Math.max(0, value - estimated);
             }
         }
-        if (false) {
-            for (double[] sample : samples) {
-                var x = sample[0];
-                var y = sample[1];
-                var idx = (int) (y * width + x);
-                data[idx] = 65535;
-            }
-        }
         return copy;
     }
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/CoronagraphTask.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/CoronagraphTask.java
@@ -18,7 +18,6 @@ package me.champeau.a4j.jsolex.processing.sun.tasks;
 import me.champeau.a4j.jsolex.processing.stretching.ArcsinhStretchingStrategy;
 import me.champeau.a4j.jsolex.processing.sun.BackgroundRemoval;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
-import me.champeau.a4j.jsolex.processing.sun.workflow.AnalysisUtils;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.math.regression.Ellipse;
 
@@ -41,11 +40,13 @@ public class CoronagraphTask extends AbstractTask<ImageWrapper32> {
     protected ImageWrapper32 doCall() throws Exception {
         var buffer = getBuffer();
         fill(fitting, buffer, width, 0);
-        new ArcsinhStretchingStrategy(blackPoint * .25f, 5000, 20000).stretch(width, height, buffer);
-        var background = AnalysisUtils.estimateBackground(workImage, fitting);
-        BackgroundRemoval.removeBackground(width, height, buffer, .25, background, fitting);
+        for (int i=0;i<2;i++) {
+            workImage = BackgroundRemoval.neutralizeBackground(workImage);
+        }
+        buffer = workImage.data();
+        new ArcsinhStretchingStrategy(0, 50, 50).stretch(width, height, buffer);
+        workImage = new ImageWrapper32(width, height, buffer, workImage.metadata());
         return workImage;
-
     }
 
     private void fill(Ellipse ellipse, float[] image, int width, int color) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/AnalysisUtils.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/AnalysisUtils.java
@@ -82,7 +82,7 @@ public class AnalysisUtils {
                 break;
             }
         }
-        while (values[idx + 1] <= cur) {
+        while (idx + 1 < values.length && values[idx + 1] <= cur) {
             idx++;
             cur = values[idx];
         }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
@@ -351,6 +351,10 @@ public class ProcessingWorkflow {
                             }
                             var metadata = new HashMap<>(geometryFixed.metadata());
                             metadata.put(Ellipse.class, diskEllipse);
+                            for (int i = 0; i < mix.length; i++) {
+                                float d = mix[i];
+                                mix[i] = Math.max(0, Math.min(d, Constants.MAX_PIXEL_VALUE));
+                            }
                             var mixedImage = new ImageWrapper32(width, height, mix, metadata);
                             var colorCurve = processParams.spectrumParams().ray().getColorCurve();
                             if (colorCurve.isPresent()) {


### PR DESCRIPTION
This image will now use background modelization to further improve constrast while not saturating pixels.

Here's a sample image with JSol'Ex 2.1.0:

![protus_2 1 0](https://github.com/melix/astro4j/assets/316357/080b617a-7220-40f2-9515-db9c8ed5f619)

The same image with JSol'Ex 2.1.1 (this commit):

![protus_2 1 1](https://github.com/melix/astro4j/assets/316357/f21636be-006f-4983-ab09-3c887664d596)

And the same image processed with INTI 5.0.0 for comparison:

![protus_inti](https://github.com/melix/astro4j/assets/316357/92a444dc-f7d6-446f-9fdb-863644e843bf)
