### PR TITLE
Fix frames being decoded multiple times

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -403,14 +403,13 @@ public class SolexVideoProcessor implements Broadcaster {
             byte[] copy = new byte[currentFrame.length];
             System.arraycopy(currentFrame, 0, copy, 0, currentFrame.length);
             reader.nextFrame();
+            var original = converter.createBuffer(geometry);
+            // The converter makes sure we only have a single channel
+            converter.convert(i, ByteBuffer.wrap(copy), geometry, original);
             int offset = j;
-            int index = i;
-            Arrays.stream(images).parallel().forEach(state -> {
-                var original = converter.createBuffer(geometry);
-                // The converter makes sure we only have a single channel
-                converter.convert(index, ByteBuffer.wrap(copy), geometry, original);
-                processSingleFrame(state.isInternal(), width, height, state.reconstructed(), offset, original, polynomial, state.pixelShift(), totalLines);
-            });
+            Arrays.stream(images).parallel().forEach(state ->
+                processSingleFrame(state.isInternal(), width, height, state.reconstructed(), offset, original, polynomial, state.pixelShift(), totalLines)
+            );
         }
         LOGGER.info(message("processing.done.generate.images"));
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -90,6 +90,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.DoubleUnaryOperator;
@@ -398,18 +399,23 @@ public class SolexVideoProcessor implements Broadcaster {
         LOGGER.info(message("distortion.polynomial"), polynomial);
         reader.seekFrame(start);
         int totalLines = end - start;
-        for (int i = start, j = 0; i < end; i++, j += width) {
-            var currentFrame = reader.currentFrame().data().array();
-            byte[] copy = new byte[currentFrame.length];
-            System.arraycopy(currentFrame, 0, copy, 0, currentFrame.length);
-            reader.nextFrame();
-            var original = converter.createBuffer(geometry);
-            // The converter makes sure we only have a single channel
-            converter.convert(i, ByteBuffer.wrap(copy), geometry, original);
-            int offset = j;
-            Arrays.stream(images).parallel().forEach(state ->
-                processSingleFrame(state.isInternal(), width, height, state.reconstructed(), offset, original, polynomial, state.pixelShift(), totalLines)
-            );
+        try (var executor = Executors.newFixedThreadPool(Math.min(32, 8 * Runtime.getRuntime().availableProcessors()))) {
+            for (int i = start, j = 0; i < end; i++, j += width) {
+                var currentFrame = reader.currentFrame().data().array();
+                byte[] copy = new byte[currentFrame.length];
+                System.arraycopy(currentFrame, 0, copy, 0, currentFrame.length);
+                reader.nextFrame();
+                var original = converter.createBuffer(geometry);
+                int offset = j;
+                int frameId = i;
+                executor.submit(() -> {
+                    // The converter makes sure we only have a single channel
+                    converter.convert(frameId, ByteBuffer.wrap(copy), geometry, original);
+                    Arrays.stream(images).parallel().forEach(state ->
+                        processSingleFrame(state.isInternal(), width, height, state.reconstructed(), offset, original, polynomial, state.pixelShift(), totalLines)
+                    );
+                });
+            }
         }
         LOGGER.info(message("processing.done.generate.images"));
     }


### PR DESCRIPTION
This commit fixes a performance issue, where the same frame was decoded multiple times in parallel. In fact, only the reconstruction should be done concurrently.