### PR TITLE
Improve blending of protus images in autohistogram

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
@@ -272,7 +272,11 @@ public class ProcessingWorkflow {
         var stretched = geometryFixed.copy();
         switch (contrastEnhancement) {
             case AUTOSTRETCH -> {
-                new AutohistogramStrategy(autoStretchParams.gamma()).stretch(stretched);
+                var autohistogramStrategy = new AutohistogramStrategy(autoStretchParams.gamma());
+                if (System.getProperty("jsolex.debug.autohistogram.masking") != null) {
+                    autohistogramStrategy.setBroadcaster(broadcaster);
+                }
+                autohistogramStrategy.stretch(stretched);
                 TransformationHistory.recordTransform(stretched, "AutoStretch (gamma: " + autoStretchParams.gamma() + ")");
             }
             case CLAHE -> {


### PR DESCRIPTION
This commit improves how the protus image is blend into the main image when using the autohistogram function. This fixes an issue with solar limbs sometimes being too much lightened.