### PR TITLE
Fix parsing of binning

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/CaptureSoftwareMetadataHelper.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/CaptureSoftwareMetadataHelper.java
@@ -19,7 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Optional;
 
@@ -45,17 +44,27 @@ public class CaptureSoftwareMetadataHelper {
                 var binning = 1;
                 for (var line : lines) {
                     if (line.startsWith("Binning=")) {
-                        binning = Integer.parseInt(line.substring(line.indexOf('=') + 1).trim());
+                        binning = parseBinning(line);
                         break;
                     }
                 }
                 LOGGER.info(message("found.metadata"), "Sharpcap", camera, binning);
                 return Optional.of(new CaptureMetadata(camera, binning));
-            } catch (IOException e) {
+            } catch (Exception e) {
                 return Optional.empty();
             }
         }
         return Optional.empty();
+    }
+
+    private static int parseBinning(String line) {
+        int binning;
+        var value = line.substring(line.indexOf('=') + 1);
+        if (value.contains("x")) {
+            value = value.substring(0, value.indexOf("x"));
+        }
+        binning = Integer.parseInt(value.trim());
+        return binning;
     }
 
     public static Optional<CaptureMetadata> readFireCaptureMetadata(File serFile) {
@@ -70,7 +79,7 @@ public class CaptureSoftwareMetadataHelper {
                     for (var line : lines) {
                         if (line.startsWith("Binning=")) {
                             var tmp = line.substring(line.indexOf('=') + 1);
-                            binning = Integer.parseInt(tmp.substring(0, tmp.indexOf("x")).trim());
+                            binning = parseBinning(tmp);
                         } else if (line.startsWith("Camera=")) {
                             camera = line.substring(line.indexOf('=') + 1).trim();
                         }
@@ -80,7 +89,7 @@ public class CaptureSoftwareMetadataHelper {
                         }
                     }
                 }
-            } catch (IOException e) {
+            } catch (Exception e) {
                 return Optional.empty();
             }
         }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
@@ -879,20 +879,20 @@ public class JSolEx extends Application implements JSolExInterface {
     @Override
     public void prepareForRedshiftImages(RedshiftImagesProcessor processor) {
         var redshifts = processor.getRedshifts();
-        redshiftTab.setDisable(redshifts.isEmpty());
         var maxSize = redshifts.stream()
             .mapToDouble(RedshiftArea::size)
             .max()
             .orElse(0);
         var power = highestPowerOfTwoGreaterOrEqualTo(processor.getSunRadius().map(r -> r / 10d).orElse(maxSize));
         int boxSize = (int) Math.pow(2, power);
-        redshiftBoxSize.getItems().clear();
-        int bSize = boxSize;
-        for (int i = 0; i < 4; i++) {
-            redshiftBoxSize.getItems().add(bSize);
-            bSize += boxSize;
-        }
         BatchOperations.submit(() -> {
+            redshiftTab.setDisable(redshifts.isEmpty());
+            redshiftBoxSize.getItems().clear();
+            int bSize = boxSize;
+            for (int i = 0; i < 4; i++) {
+                redshiftBoxSize.getItems().add(bSize);
+                bSize += boxSize;
+            }
             generateRedshiftImages.setOnAction(e -> {
                 var kind = redshiftCreatorKind.getValue();
                 var size = redshiftBoxSize.getValue();


### PR DESCRIPTION
It appears that the Sharpcap format is not consistent over versions. This commit makes sure that we can parse the binning whether it consists of a single number (e.g 2) or a matrix (2x2).

In addition, we make sure that if reading of metadata fails, it doesn't block processing.