### PR TITLE
Fix pixel shift to Angstrom conversion in legend

### DIFF
--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/RedshiftImagesProcessor.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/RedshiftImagesProcessor.java
@@ -243,7 +243,7 @@ public class RedshiftImagesProcessor {
                     var col = i % cols;
                     var offset = row * finalSnapHeight * panelWidth + col * finalSnapWidth;
                     var pixelShift = snap.findMetadata(PixelShift.class).map(PixelShift::pixelShift).orElse(0d);
-                    var legend = String.format(Locale.US, "%.2fÅ (%.2f km/s)", pixelShift * dispersion, PhenomenaDetector.speedOf(pixelShift, dispersion, lambda0));
+                    var legend = String.format(Locale.US, "%.2fÅ (%.2f km/s)", 10 * pixelShift * dispersion, PhenomenaDetector.speedOf(pixelShift, dispersion, lambda0));
                     // draw legend on a dummy image
                     var legendImage = createLegendImage(finalSnapWidth, finalSnapHeight, legend);
                     var legendOverlay = legendImage.getData();


### PR DESCRIPTION
In the panels, there was a 10x factor between the real angstrom shift and the one that was displayed.