### PR TITLE
Fix polynomial detection

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -196,11 +196,6 @@ public class SolexVideoProcessor implements Broadcaster {
         if (header != null) {
             if (averageImage == null) {
                 averageImage = detector.getAverageImage();
-                detector.ifEdgesDetected((start, end) -> {
-                    LOGGER.info(message("sun.edges.detected"), start, end);
-                }, () -> {
-                    LOGGER.info(message("sun.edges.detected.full"));
-                });
             }
             generateImages(converter, header, fpsRef.get(), serFile, 0, frameCountRef.get() - 1);
         }
@@ -656,6 +651,9 @@ public class SolexVideoProcessor implements Broadcaster {
             for (int i = 0; i < images.length; i++) {
                 var state = images[i];
                 state.recordResult(WorkflowResults.RECONSTRUCTED, new ImageWrapper32(width, totalLines, reconstructedImages[i], MutableMap.of()));
+            }
+            if (hasRedshifts.get() && phenomenaDetector.isEmpty()) {
+                LOGGER.warn(message("no.redshifts.detected"));
             }
         }
         return new ReconstructionOutputs(hasRedshifts.get() ? phenomenaDetector.getMaxRedshiftAreas(5) : null);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SpectrumFrameAnalyzer.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SpectrumFrameAnalyzer.java
@@ -90,7 +90,8 @@ public class SpectrumFrameAnalyzer {
     private int findYAtMinimalValue(float[] data, int x) {
         int minY = 0;
         double min = Double.MAX_VALUE;
-        for (int y = 0; y < height; y++) {
+        var margin = Math.min(height, 4);
+        for (int y = margin; y < height - margin; y++) {
             double value = data[y * width + x];
             if (value < min) {
                 minY = y;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/detection/PhenomenaDetector.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/detection/PhenomenaDetector.java
@@ -267,4 +267,7 @@ public class PhenomenaDetector {
     }
 
 
+    public boolean isEmpty() {
+        return redshiftsPerFrame.isEmpty();
+    }
 }

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
@@ -100,3 +100,4 @@ redshift.creator.kind.ALL=Animation and panel
 reconstruction.batches=In order to save memory, reconstruction will be performed in {} batches of {} pixel shifts.
 processing.disk.requirements=Processing will require approximatively {}{} of disk space
 not.enough.disk.space=Not enough disk space in %s. You need at least %s%s
+no.redshifts.detected=No redshifts detected

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr_FR.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr_FR.properties
@@ -100,3 +100,4 @@ redshift.creator.kind.ALL=Animation et panneau
 reconstruction.batches=Afin de sauver de la mémoire, la reconstruction va se faire en {} lots de {} pixel shifts.
 processing.disk.requirements=Le traitement va nécessiter approximativement {}{} d'espace disque
 not.enough.disk.space=Espace disque disponible insuffisant sur %s. Vous devez avoir au moins %s%s de libre.
+no.redshifts.detected=Aucun décalage vers le rouge détecté

--- a/math/src/main/java/me/champeau/a4j/math/regression/LinearRegression.java
+++ b/math/src/main/java/me/champeau/a4j/math/regression/LinearRegression.java
@@ -167,8 +167,10 @@ public abstract class LinearRegression {
         var mmT = mm.transpose();
         double[][] result = mmT.mul(mm).inverse().mul(mmT).mul(DoubleMatrix.of(yy)).asArray();
         double[] res = new double[k + 1];
-        for (int i = 0; i <= k; i++) {
-            res[k - i] = result[i][0];
+        if (result.length == k + 1) {
+            for (int i = 0; i <= k; i++) {
+                res[k - i] = result[i][0];
+            }
         }
         return res;
     }


### PR DESCRIPTION
This commit fixes the polynomial detection for some edge cases. It appears that in some videos, the first and last lines are too dark and can be confused with the actual line that we want to detect. To avoid this, we're filtering the lines so that they are not too close to the edges.

The average image computation is also modified in order to keep only the brightest frames. This is done by sampling frames in the video file in the beginning, and this is more accurate than the initial detection algorithm.

In addition this fixes a bug where the polynomial regression algorithm could return an empty array, in which case it means that detection failed.

Fixes #263