### PR TITLE
Fix race condition when reconstructing images

### DIFF
--- a/build-logic/src/main/kotlin/me.champeau.astro4j.jfxapp.gradle.kts
+++ b/build-logic/src/main/kotlin/me.champeau.astro4j.jfxapp.gradle.kts
@@ -12,7 +12,7 @@ javafx {
 }
 
 val os = System.getProperty("os.name").lowercase(Locale.ENGLISH)
-val jvmMemorySettings = listOf("-XX:MaxRAMPercentage=80", "-XX:+UseParallelGC", "-XX:MaxGCPauseMillis=250", "-XX:GCTimeRatio=49")
+val jvmMemorySettings = listOf("-XX:MaxRAMPercentage=80", "-XX:+UseParallelGC")
 
 application {
     applicationDefaultJvmArgs = jvmMemorySettings + listOf("--enable-preview")

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImage.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImage.java
@@ -18,7 +18,7 @@ package me.champeau.a4j.jsolex.processing.util;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.lang.ref.Cleaner;
-import java.lang.ref.SoftReference;
+import java.lang.ref.WeakReference;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -46,7 +46,7 @@ public final class FileBackedImage implements ImageWrapper {
     private final Path backingFile;
     private final Map<Class<?>, Object> metadata;
     private final Object keptInMemory;
-    private final SoftReference<ImageWrapper> unwrapped;
+    private final WeakReference<ImageWrapper> unwrapped;
 
     private FileBackedImage(int width, int height, Path backingFile, Map<Class<?>, Object> metadata, Object keptInMemory, ImageWrapper source) {
         this.width = width;
@@ -54,7 +54,7 @@ public final class FileBackedImage implements ImageWrapper {
         this.backingFile = backingFile;
         this.metadata = metadata;
         this.keptInMemory = keptInMemory;
-        this.unwrapped = new SoftReference<>(source.unwrapToMemory());
+        this.unwrapped = new WeakReference<>(source.unwrapToMemory());
         LOCK.lock();
         try {
             REF_COUNT.compute(backingFile, (k, v) -> v == null ? 1 : v + 1);

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/LogbackConfigurer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/LogbackConfigurer.java
@@ -99,7 +99,7 @@ class LogbackConfigurer {
             contextBasedAppender.setEncoder(encoder);
             contextBasedAppender.start();
         } catch (Exception ex) {
-            System.out.println("ex = " + ex);
+            // ignore
         }
         return contextBasedAppender;
     }


### PR DESCRIPTION
This commit fixes a race condition which could lead to incorrectly reconstructed images. A typical symptom was that from one run to the other the image was slightly different. In some rare cases where the image was having a large tilt, this could even lead to completely broken geometry correction.