### PR TITLE
Defer stretching to when an image is selected

### DIFF
--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
@@ -100,6 +100,7 @@ public class ImageViewer {
     private Runnable onDisplayUpdate;
     private int rotation;
     private boolean vflip;
+    private boolean firstShow = true;
 
     private final ListProperty<ImageState> imageHistory = new SimpleListProperty<>(FXCollections.observableArrayList());
     private final IntegerProperty currentImage = new SimpleIntegerProperty(0);
@@ -158,6 +159,7 @@ public class ImageViewer {
                             stage.setOnCloseRequest(evt -> popupViews.remove(title));
                             stage.show();
                             popupViews.put(title, controller);
+                            controller.display();
                         } catch (IOException ex) {
                             throw new ProcessingException(ex);
                         }
@@ -335,7 +337,6 @@ public class ImageViewer {
             line1.getChildren().forEach(e -> HBox.setHgrow(e, Priority.ALWAYS));
             line2.getChildren().stream().filter(e -> !(e instanceof Slider)).forEach(e -> HBox.setHgrow(e, Priority.ALWAYS));
         });
-        stretchAndDisplay(true);
     }
 
     private static float linValueOf(double sliderValue) {
@@ -384,6 +385,13 @@ public class ImageViewer {
             return copy;
         } finally {
             broadcaster.onProgress(ProgressEvent.of(1, message("stretching") + " " + imageFile.getName()));
+        }
+    }
+
+    void display() {
+        if (image != null && firstShow) {
+            BackgroundOperations.async(() -> stretchAndDisplay(true));
+            firstShow = false;
         }
     }
 

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/MultipleImagesViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/MultipleImagesViewer.java
@@ -140,6 +140,7 @@ public class MultipleImagesViewer extends Pane {
             selected = link;
             selectedKind = kind;
             onShow.accept(viewer);
+            viewer.display();
         }, this::onClose);
         if (selected == null) {
             category.selectFirst();


### PR DESCRIPTION
This should improve reactivity, especially on slower systems. Before, all images were stretched in parallel, which could lead to a UI which would not display any image before seconds.