### PR TITLE
Add ability to generate full range panels

### DIFF
--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
@@ -229,6 +229,11 @@ public class JSolEx extends Application implements JSolExInterface {
     @FXML
     private TextField pixelShiftMargin;
 
+    @FXML
+    private CheckBox fullRangePanels;
+    @FXML
+    private Label fullRangePanelsLabel;
+
     private final Map<String, ImageViewer> popupViewers = new ConcurrentHashMap<>();
 
     private final MultipleImagesViewer multipleImagesViewer = new MultipleImagesViewer();
@@ -897,6 +902,8 @@ public class JSolEx extends Application implements JSolExInterface {
         int boxSize = (int) Math.pow(2, power);
         BatchOperations.submit(() -> {
             redshiftTab.setDisable(redshifts.isEmpty());
+            fullRangePanels.disableProperty().bind(redshiftCreatorKind.valueProperty().isEqualTo(RedshiftImagesProcessor.RedshiftCreatorKind.ANIMATION));
+            fullRangePanelsLabel.disableProperty().bind(redshiftCreatorKind.valueProperty().isEqualTo(RedshiftImagesProcessor.RedshiftCreatorKind.ANIMATION));
             redshiftBoxSize.getItems().clear();
             int bSize = boxSize;
             for (int i = 0; i < 4; i++) {
@@ -907,10 +914,11 @@ public class JSolEx extends Application implements JSolExInterface {
                 var kind = redshiftCreatorKind.getValue();
                 var size = redshiftBoxSize.getValue();
                 var margin = Integer.valueOf(pixelShiftMargin.getText());
+                var useFullRangePanels = fullRangePanels.isSelected();
                 if (kind != null && size != null) {
                     BackgroundOperations.async(() -> {
                         BatchOperations.submit(() -> rightTabs.getSelectionModel().select(logsTab));
-                        processor.produceImages(kind, size, margin);
+                        processor.produceImages(kind, size, margin, useFullRangePanels);
                     });
                 }
             });

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/CategoryPane.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/CategoryPane.java
@@ -132,8 +132,10 @@ public class CategoryPane extends VBox {
         links.add(link);
         var box = new HBox();
         box.setAlignment(Pos.CENTER_LEFT);
+        var spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
         var close = createCloseLink(box, link, onClose);
-        box.getChildren().addAll(link, close);
+        box.getChildren().addAll(link, spacer, close);
         getChildren().add(box);
         return link;
     }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/MultipleImagesViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/MultipleImagesViewer.java
@@ -224,7 +224,10 @@ public class MultipleImagesViewer extends Pane {
     }
 
     private CategoryPane addCategory(DisplayCategory category) {
-        var categoryPane = new CategoryPane(message("displayCategory." + category.name()), categories::remove);
+        var categoryPane = new CategoryPane(message("displayCategory." + category.name()), e ->{
+            categories.remove(e);
+            safeCategories.remove(e);
+        });
         categoryPane.setMinWidth(190);
         categoryPane.getProperties().put(DisplayCategory.class, category);
         safeCategories.add(categoryPane);

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/app.fxml
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/app.fxml
@@ -14,7 +14,9 @@
 <?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.control.TabPane?>
+<?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.TitledPane?>
+<?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.GridPane?>
@@ -24,7 +26,6 @@
 <?import me.champeau.a4j.jsolex.app.jfx.ime.ImageMathTextArea?>
 <?import org.fxmisc.flowless.VirtualizedScrollPane?>
 <?import org.fxmisc.richtext.StyleClassedTextArea?>
-<?import javafx.scene.control.TextField?>
 <BorderPane xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
     <top>
         <MenuBar>
@@ -116,7 +117,18 @@
                                         <Label text="%redshift.creator.kind" GridPane.columnIndex="0" GridPane.rowIndex="3" prefWidth="200"/>
                                         <ChoiceBox fx:id="redshiftCreatorKind" GridPane.columnIndex="1" GridPane.rowIndex="3" prefWidth="200"/>
 
-                                        <VBox alignment="CENTER" GridPane.rowIndex="4" GridPane.columnIndex="0" GridPane.columnSpan="2">
+                                        <Label fx:id="fullRangePanelsLabel" text="%full.range.panels" GridPane.columnIndex="0" GridPane.rowIndex="4" prefWidth="300">
+                                            <tooltip>
+                                                <Tooltip text="%full.range.panels.tooltip"/>
+                                            </tooltip>
+                                        </Label>
+                                        <CheckBox fx:id="fullRangePanels" GridPane.columnIndex="1" GridPane.rowIndex="4" prefWidth="100">
+                                            <tooltip>
+                                                <Tooltip text="%full.range.panels.tooltip"/>
+                                            </tooltip>
+                                        </CheckBox>
+
+                                        <VBox alignment="CENTER" GridPane.rowIndex="5" GridPane.columnIndex="0" GridPane.columnSpan="2">
                                             <Button fx:id="generateRedshiftImages" text="%generate"/>
                                         </VBox>
                                     </GridPane>

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/app.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/app.properties
@@ -34,3 +34,5 @@ box.size=Box size
 redshift.creator.kind=Type
 pixel.shift.margin=Pixel shift margin
 reference.image=GONG
+full.range.panels=Use full range in panels
+full.range.panels.tooltip=By default, the panels only cover the 0 to n Å range. By checking this box, the ranges will be completed by the opposite shifts (thus from -n to n Å).

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/app_fr_FR.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/app_fr_FR.properties
@@ -33,3 +33,5 @@ generate=Générer
 box.size=Taille
 redshift.creator.kind=Type
 pixel.shift.margin=Marge de décalage de pixels
+full.range.panels=Intervalle complet dans les panneaux
+full.range.panels.tooltip=Par défaut, les panneaux ne couvrent que les intervalles 0 à n Å. En cochant cette case, les intervalles seront complétés par les décalages opposés (donc de -n à n Å).


### PR DESCRIPTION
By default, panels are generated with "half" of the range of pixel shifts, in order to reduce their size. This commit introduces a new checkbox for people who want to see the full range.

Fixes #273