### PR TITLE
Fix rotation with P angle changing the cropped image dimensions

### DIFF
--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/Corrector.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/Corrector.java
@@ -32,7 +32,7 @@ public class Corrector {
 
     }
 
-    public static ImageWrapper rotate(ImageWrapper image, double angle) {
+    public static ImageWrapper rotate(ImageWrapper image, double angle, boolean resize) {
         return (ImageWrapper) MetadataSupport.applyMetadata(String.format(message("rotate.radians.format"), angle), () -> {
             var img = image;
             var imageMath = ImageMath.newInstance();
@@ -40,18 +40,18 @@ public class Corrector {
                 img = fileBackedImage.unwrapToMemory();
             }
             if (img instanceof ImageWrapper32 mono) {
-                var trn = imageMath.rotate(mono.asImage(), angle, -1, true);
+                var trn = imageMath.rotate(mono.asImage(), angle, -1, resize);
                 return ImageWrapper32.fromImage(trn, Rotate.fixMetadata(mono, angle, trn.width(), trn.height()));
             } else if (img instanceof ColorizedImageWrapper colorized) {
                 var mono = colorized.mono();
-                var trn = imageMath.rotate(mono.asImage(), angle, -1, true);
+                var trn = imageMath.rotate(mono.asImage(), angle, -1, resize);
                 return new ColorizedImageWrapper(ImageWrapper32.fromImage(trn), colorized.converter(), Rotate.fixMetadata(colorized, angle, trn.width(), trn.height()));
             } else if (img instanceof RGBImage rgb) {
                 var height = rgb.height();
                 var width = rgb.width();
-                var r = imageMath.rotate(new Image(width, height, rgb.r()), angle, -1, true);
-                var g = imageMath.rotate(new Image(width, height, rgb.g()), angle, -1, true);
-                var b = imageMath.rotate(new Image(width, height, rgb.b()), angle, -1, true);
+                var r = imageMath.rotate(new Image(width, height, rgb.r()), angle, -1, resize);
+                var g = imageMath.rotate(new Image(width, height, rgb.g()), angle, -1, resize);
+                var b = imageMath.rotate(new Image(width, height, rgb.b()), angle, -1, resize);
                 return new RGBImage(r.width(), r.height(), r.data(), g.data(), b.data(), Rotate.fixMetadata(rgb, angle, r.width(), r.height()));
             }
             throw new IllegalArgumentException("Unsupported image type");

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
@@ -43,6 +43,7 @@ import me.champeau.a4j.jsolex.app.JSolEx;
 import me.champeau.a4j.jsolex.processing.event.GenericMessage;
 import me.champeau.a4j.jsolex.processing.event.ProcessingEventListener;
 import me.champeau.a4j.jsolex.processing.event.ProgressEvent;
+import me.champeau.a4j.jsolex.processing.params.AutocropMode;
 import me.champeau.a4j.jsolex.processing.params.ProcessParams;
 import me.champeau.a4j.jsolex.processing.params.RotationKind;
 import me.champeau.a4j.jsolex.processing.stretching.ContrastAdjustmentStrategy;
@@ -468,7 +469,7 @@ public class ImageViewer {
         }
         if (correction != 0) {
             image = image.copy();
-            image = Corrector.rotate(image, correction);
+            image = Corrector.rotate(image, correction, processParams.geometryParams().autocropMode() == AutocropMode.OFF);
         }
         return image;
     }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/BatchModeEventListener.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/BatchModeEventListener.java
@@ -36,6 +36,7 @@ import me.champeau.a4j.jsolex.processing.expr.DefaultImageScriptExecutor;
 import me.champeau.a4j.jsolex.processing.expr.ImageMathScriptExecutor;
 import me.champeau.a4j.jsolex.processing.expr.ImageMathScriptResult;
 import me.champeau.a4j.jsolex.processing.file.FileNamingStrategy;
+import me.champeau.a4j.jsolex.processing.params.AutocropMode;
 import me.champeau.a4j.jsolex.processing.params.ProcessParams;
 import me.champeau.a4j.jsolex.processing.params.RotationKind;
 import me.champeau.a4j.jsolex.processing.stretching.RangeExpansionStrategy;
@@ -112,7 +113,7 @@ public class BatchModeEventListener implements ProcessingEventListener, ImageMat
             }
         }
         if (correction != 0) {
-            img = Corrector.rotate(img, correction);
+            img = Corrector.rotate(img, correction, processParams.geometryParams().autocropMode() == AutocropMode.OFF);
         }
         new ImageSaver(RangeExpansionStrategy.DEFAULT, processParams).save(img, target);
         item.generatedFiles().add(target);


### PR DESCRIPTION
When an image is autocropped, it is not necessary to resize the image so that the solar disk is not truncated, because we know that it is already centered.