### PR TITLE
Improve speed detection

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Crop.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Crop.java
@@ -226,6 +226,7 @@ public class Crop extends AbstractFunctionImpl {
             metadata.put(Redshifts.class, new Redshifts(
                 redshifts.redshifts().stream()
                     .map(rs -> new RedshiftArea(
+                        rs.id(),
                         rs.pixelShift(),
                         rs.relPixelShift(),
                         rs.kmPerSec(),

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Rotate.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Rotate.java
@@ -163,7 +163,7 @@ public class Rotate extends AbstractFunctionImpl {
                     var y2p = (int) (sy + Math.round((x2 - cx) * sinAlpha + (y2 - cy) * cosAlpha));
                     var maxXP = (int) (sx + Math.round((maxX - cx) * cosAlpha - (maxY - cy) * sinAlpha));
                     var maxYP = (int) (sy + Math.round((maxX - cx) * sinAlpha + (maxY - cy) * cosAlpha));
-                    return new RedshiftArea(rs.pixelShift(), rs.relPixelShift(), rs.kmPerSec(), x1p, y1p, x2p, y2p, maxXP, maxYP);
+                    return new RedshiftArea(rs.id(), rs.pixelShift(), rs.relPixelShift(), rs.kmPerSec(), x1p, y1p, x2p, y2p, maxXP, maxYP);
                 })
                 .toList();
             metadata.put(Redshifts.class, new Redshifts(rotated));

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Scaling.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Scaling.java
@@ -188,7 +188,7 @@ public class Scaling extends AbstractFunctionImpl {
             double sx = image.width() / width;
             double sy = image.height() / height;
             metadata.put(Redshifts.class, new Redshifts(redshifts.redshifts().stream()
-                .map(rs -> new RedshiftArea(rs.pixelShift(), rs.relPixelShift(), rs.kmPerSec(), (int) (rs.x1() / sx), (int) (rs.y1() / sy), (int) (rs.x2() / sx), (int) (rs.y2() / sy), (int) (rs.maxX() / sx), (int) (rs.maxY() / sy)))
+                .map(rs -> new RedshiftArea(rs.id(), rs.pixelShift(), rs.relPixelShift(), rs.kmPerSec(), (int) (rs.x1() / sx), (int) (rs.y1() / sy), (int) (rs.x2() / sx), (int) (rs.y2() / sy), (int) (rs.maxX() / sx), (int) (rs.maxY() / sy)))
                 .toList()));
         });
         return metadata;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/spectrum/SpectrumAnalyzer.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/spectrum/SpectrumAnalyzer.java
@@ -62,15 +62,15 @@ public class SpectrumAnalyzer {
      * Returns the spectral dispersion, in nanometers/pixel
      *
      * @param instrument the SHG for which to compute the dispersion
-     * @param lambda0 the wavelength in nanometers
-     * @param pixelSize the pixel size, in micrometers
+     * @param lambda0NanoMeters the wavelength in nanometers
+     * @param pixelSizeMicrons the pixel size, in micrometers
      * @return the spectral dispersion, in nanometers/pixel
      */
-    public static double computeSpectralDispersion(SpectroHeliograph instrument,
-                                                   double lambda0,
-                                                   double pixelSize) {
-        var beta = computeAngleBeta(instrument.order(), instrument.density(), lambda0, instrument.totalAngleRadians());
-        return 1000 * pixelSize * Math.cos(beta) / instrument.density() / instrument.focalLength();
+    public static double computeSpectralDispersionNanosPerPixel(SpectroHeliograph instrument,
+                                                                double lambda0NanoMeters,
+                                                                double pixelSizeMicrons) {
+        var beta = computeAngleBeta(instrument.order(), instrument.density(), lambda0NanoMeters, instrument.totalAngleRadians());
+        return 1000 * pixelSizeMicrons * Math.cos(beta) / instrument.density() / instrument.focalLength();
     }
 
     /**
@@ -117,7 +117,7 @@ public class SpectrumAnalyzer {
         var pixelSize = details.pixelSize();
         var binning = details.binning();
         var instrument = details.instrument();
-        double dispersion = computeSpectralDispersion(instrument, lambda0, pixelSize * binning);
+        double dispersion = computeSpectralDispersionNanosPerPixel(instrument, lambda0, pixelSize * binning);
         var dataPoints = new ArrayList<DataPoint>();
         double min = Double.MAX_VALUE;
         double max = -Double.MAX_VALUE;
@@ -229,7 +229,7 @@ public class SpectrumAnalyzer {
                                            double lambda0Angstroms,
                                            double targetWaveLengthAngstroms,
                                            SpectroHeliograph instrument) {
-        var dispersionAngstromsPerPixel = 10 * SpectrumAnalyzer.computeSpectralDispersion(
+        var dispersionAngstromsPerPixel = 10 * SpectrumAnalyzer.computeSpectralDispersionNanosPerPixel(
             instrument,
             lambda0Angstroms / 10,
             pixelSize * binning

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/AutohistogramStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/AutohistogramStrategy.java
@@ -99,7 +99,7 @@ public final class AutohistogramStrategy implements StretchingStrategy {
             stdev = Math.sqrt(stdev / area);
             var limit = 1.2 * (avg + 6 * stdev);
             if (limit < MAX_PIXEL_VALUE) {
-                new ContrastAdjustmentStrategy(0, (float) limit).withNormalize(true).stretch(disk);
+                new ContrastAdjustmentStrategy(0, (float) limit).stretch(disk);
             }
 
             var mask = createMask(height, width, e);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/ContrastAdjustmentStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/ContrastAdjustmentStrategy.java
@@ -22,26 +22,16 @@ import me.champeau.a4j.jsolex.processing.util.RGBImage;
 public final class ContrastAdjustmentStrategy implements StretchingStrategy {
     public static final ContrastAdjustmentStrategy DEFAULT = new ContrastAdjustmentStrategy(0, .95f*Constants.MAX_PIXEL_VALUE);
 
-    private final boolean normalize;
     private final float min;
     private final float max;
 
     public ContrastAdjustmentStrategy(float min, float max) {
-        this(min, max, false);
-    }
-
-    private ContrastAdjustmentStrategy(float min, float max, boolean normalize) {
         this.min = min;
         this.max = max;
-        this.normalize = normalize;
     }
 
     public ContrastAdjustmentStrategy withRange(float min, float max) {
-        return new ContrastAdjustmentStrategy(min, max, normalize);
-    }
-
-    public ContrastAdjustmentStrategy withNormalize(boolean normalize) {
-        return new ContrastAdjustmentStrategy(min, max, normalize);
+        return new ContrastAdjustmentStrategy(min, max);
     }
 
     public float getMin() {
@@ -56,9 +46,6 @@ public final class ContrastAdjustmentStrategy implements StretchingStrategy {
     public void stretch(ImageWrapper32 image) {
         var data = image.data();
         truncate(data);
-        if (normalize) {
-            LinearStrechingStrategy.DEFAULT.stretch(image);
-        }
     }
 
     private void truncate(float[] data) {
@@ -76,8 +63,5 @@ public final class ContrastAdjustmentStrategy implements StretchingStrategy {
        truncate(image.r());
        truncate(image.g());
        truncate(image.b());
-        if (normalize) {
-            LinearStrechingStrategy.DEFAULT.stretch(image);
-        }
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/MagnitudeBasedSunEdgeDetector.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/MagnitudeBasedSunEdgeDetector.java
@@ -113,6 +113,14 @@ public class MagnitudeBasedSunEdgeDetector implements SunEdgeDetector {
         }
     }
 
+    public Integer getLeftEdge() {
+        return startEdge;
+    }
+
+    public Integer getRightEdge() {
+        return endEdge;
+    }
+
     @Override
     public Optional<ChannelStats[]> getFrameStats() {
         return Optional.empty();

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/detection/Redshift.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/detection/Redshift.java
@@ -27,6 +27,6 @@ record Redshift(int pixelShift, int relMaxShift, double kmPerSec, IntPair positi
     }
 
     public RedshiftArea toArea() {
-        return new RedshiftArea(pixelShift, relMaxShift, kmPerSec, position.a(), position.b(), position.a(), position.b(), position.a(), position.b());
+        return new RedshiftArea(null, pixelShift, relMaxShift, kmPerSec, position.a(), position.b(), position.a(), position.b(), position.a(), position.b());
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/detection/RedshiftArea.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/detection/RedshiftArea.java
@@ -16,6 +16,7 @@
 package me.champeau.a4j.jsolex.processing.sun.detection;
 
 public record RedshiftArea(
+    String id,
     int pixelShift,
     int relPixelShift,
     double kmPerSec,
@@ -49,5 +50,9 @@ public record RedshiftArea(
 
     public double size() {
         return Math.max(width(), height());
+    }
+
+    public int area() {
+        return width() * height();
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/GeometryCorrector.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/GeometryCorrector.java
@@ -153,7 +153,7 @@ public class GeometryCorrector extends AbstractTask<GeometryCorrector.Result> {
                     var y2 = r.y2();
                     var maxX = r.maxX() + shift - r.maxY() * shear;
                     var maxY = r.maxY();
-                    return new RedshiftArea(r.pixelShift(), r.relPixelShift(), r.kmPerSec(), (int) (x1 * sx), (int) (y1 * finalSy), (int) (x2 *sx), (int) (y2 * finalSy), (int) (maxX * sx), (int) (maxY * finalSy));
+                    return new RedshiftArea(r.id(), r.pixelShift(), r.relPixelShift(), r.kmPerSec(), (int) (x1 * sx), (int) (y1 * finalSy), (int) (x2 *sx), (int) (y2 * finalSy), (int) (maxX * sx), (int) (maxY * finalSy));
                 })
                 .toList());
             metadata.put(Redshifts.class, redshifts);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DefaultImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DefaultImageEmitter.java
@@ -16,13 +16,17 @@
 package me.champeau.a4j.jsolex.processing.sun.workflow;
 
 import me.champeau.a4j.jsolex.processing.event.FileGeneratedEvent;
+import me.champeau.a4j.jsolex.processing.expr.impl.ImageDraw;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.tasks.WriteColorizedImageTask;
 import me.champeau.a4j.jsolex.processing.sun.tasks.WriteMonoImageTask;
 import me.champeau.a4j.jsolex.processing.sun.tasks.WriteRGBImageTask;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.ProcessingException;
+import me.champeau.a4j.jsolex.processing.util.RGBImage;
 
+import java.awt.Graphics2D;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -30,6 +34,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -102,6 +107,27 @@ public class DefaultImageEmitter implements ImageEmitter {
             name,
             kind,
             rgbSupplier).get();
+    }
+
+    @Override
+    public void newColorImage(GeneratedImageKind kind, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
+        newColorImage(kind, title, name, image, img -> {
+            var rgb = rgbSupplier.apply(img);
+            var r = rgb[0];
+            var g = rgb[1];
+            var b = rgb[2];
+            var copy = new RGBImage(
+                img.width(),
+                img.height(),
+                r,
+                g,
+                b,
+                new HashMap<>(image.metadata())
+            );
+            var draw = new ImageDraw(Map.of(), broadcaster);
+            RGBImage color = (RGBImage) draw.drawOnImage(copy, painter);
+            return new float[][]{color.r(), color.g(), color.b()};
+        });
     }
 
     @Override

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DiscardNonRequiredImages.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DiscardNonRequiredImages.java
@@ -15,11 +15,14 @@
  */
 package me.champeau.a4j.jsolex.processing.sun.workflow;
 
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 
+import java.awt.Graphics2D;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -70,6 +73,14 @@ public class DiscardNonRequiredImages implements ImageEmitter {
             return;
         }
         delegate.newColorImage(kind, title, name, width, height, metadata, rgbSupplier);
+    }
+
+    @Override
+    public void newColorImage(GeneratedImageKind kind, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
+        if (discard(kind)) {
+            return;
+        }
+        delegate.newColorImage(kind, title, name, image, rgbSupplier, painter);
     }
 
     @Override

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ImageEmitter.java
@@ -15,10 +15,13 @@
  */
 package me.champeau.a4j.jsolex.processing.sun.workflow;
 
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 
+import java.awt.Graphics2D;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -29,6 +32,8 @@ public interface ImageEmitter {
     void newMonoImage(GeneratedImageKind kind, String title, String name, ImageWrapper32 image);
 
     void newColorImage(GeneratedImageKind kind, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier);
+
+    void newColorImage(GeneratedImageKind kind, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter);
 
     void newColorImage(GeneratedImageKind kind, String title, String name, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][]> rgbSupplier);
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/NamingStrategyAwareImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/NamingStrategyAwareImageEmitter.java
@@ -16,10 +16,13 @@
 package me.champeau.a4j.jsolex.processing.sun.workflow;
 
 import me.champeau.a4j.jsolex.processing.file.FileNamingStrategy;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 
+import java.awt.Graphics2D;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -65,6 +68,11 @@ public class NamingStrategyAwareImageEmitter implements ImageEmitter {
     @Override
     public void newColorImage(GeneratedImageKind kind, String title, String name, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][]> rgbSupplier) {
         delegate.newColorImage(kind, title, rename(name), width, height, metadata, rgbSupplier);
+    }
+
+    @Override
+    public void newColorImage(GeneratedImageKind kind, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
+        delegate.newColorImage(kind, title, rename(name), image, rgbSupplier, painter);
     }
 
     @Override

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/NoOpImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/NoOpImageEmitter.java
@@ -15,10 +15,13 @@
  */
 package me.champeau.a4j.jsolex.processing.sun.workflow;
 
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 
+import java.awt.Graphics2D;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -38,6 +41,11 @@ public class NoOpImageEmitter implements ImageEmitter {
 
     @Override
     public void newColorImage(GeneratedImageKind kind, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier) {
+    }
+
+    @Override
+    public void newColorImage(GeneratedImageKind kind, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
+
     }
 
     @Override

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/RenamingImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/RenamingImageEmitter.java
@@ -15,10 +15,13 @@
  */
 package me.champeau.a4j.jsolex.processing.sun.workflow;
 
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 
+import java.awt.Graphics2D;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -51,6 +54,11 @@ public class RenamingImageEmitter implements ImageEmitter {
     @Override
     public void newColorImage(GeneratedImageKind kind, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier) {
         delegate.newColorImage(kind, titleRenamer.apply(title), fileRenamer.apply(name), image, rgbSupplier);
+    }
+
+    @Override
+    public void newColorImage(GeneratedImageKind kind, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
+        delegate.newColorImage(kind, titleRenamer.apply(title), fileRenamer.apply(name), image, rgbSupplier, painter);
     }
 
     @Override

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FitsUtils.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FitsUtils.java
@@ -234,6 +234,7 @@ public class FitsUtils {
                     var values = new ArrayList<RedshiftArea>();
                     for (int i = 0; i < cpt; i++) {
                         var redshift = new RedshiftArea(
+                            binaryTable.getSize() == 10 ? binaryTable.getString(i, 9) : null,
                             binaryTable.getNumber(i, 0).intValue(),
                             binaryTable.getNumber(i, 1).intValue(),
                             binaryTable.getNumber(i, 2).doubleValue(),
@@ -319,7 +320,8 @@ public class FitsUtils {
                 redshift.x2(),
                 redshift.y2(),
                 redshift.maxX(),
-                redshift.maxY()
+                redshift.maxY(),
+                redshift.id()
             }));
             var binaryTableHDU = BinaryTableHDU.wrap(table);
             binaryTableHDU.getHeader().addValue(JSOLEX_HEADER_KEY, REDSHIFTS_VALUE, "Measured redshifts");
@@ -451,7 +453,7 @@ public class FitsUtils {
             var pixelSize = obsParams.pixelSize();
             var binning = obsParams.binning();
             if (pixelShift.isPresent() && pixelSize != null && pixelSize>0 && binning != null && binning > 0) {
-                var dispersion = SpectrumAnalyzer.computeSpectralDispersion(obsParams.instrument(), wavelength, pixelSize * binning);
+                var dispersion = SpectrumAnalyzer.computeSpectralDispersionNanosPerPixel(obsParams.instrument(), wavelength, pixelSize * binning);
                 wavelength += pixelShift.get() * dispersion;
             }
             header.addValue("WAVELNTH", wavelength, "Wavelength (nm)");

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
@@ -708,7 +708,7 @@ public class JSolEx extends Application implements JSolExInterface {
             var stage = newStage();
             Scene scene = new Scene((Parent) configWindow);
             controller.open(file, null, scene, stage);
-            stage.setTitle(I18N.string(getClass(), "frame-debugger", "frame.debugger"));
+            stage.setTitle(I18N.string(getClass(), "frame-debugger", "frame.debugger") + " (" + file.getName() + ")");
             stage.setScene(scene);
             stage.showAndWait();
         });

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
@@ -79,7 +79,7 @@ public class ImageViewer {
     private final Lock displayLock = new ReentrantLock();
     private Node root;
     private Stage stage;
-    private ContrastAdjustmentStrategy stretchingStrategy = ContrastAdjustmentStrategy.DEFAULT.withNormalize(true);
+    private ContrastAdjustmentStrategy stretchingStrategy = ContrastAdjustmentStrategy.DEFAULT;
     private ImageWrapper image;
     private ImageWrapper displayImage;
     private ImageWrapper stretchedImage;
@@ -212,9 +212,6 @@ public class ImageViewer {
 
     private void configureStretching() {
         this.stretchingStrategy = ContrastAdjustmentStrategy.DEFAULT;
-        if (kind != GeneratedImageKind.IMAGE_MATH) {
-            this.stretchingStrategy = this.stretchingStrategy.withNormalize(true);
-        }
         var line1 = new HBox(8);
         line1.setAlignment(Pos.CENTER_LEFT);
         var line2 = new HBox(8);

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SingleModeProcessingEventListener.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SingleModeProcessingEventListener.java
@@ -418,8 +418,6 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
             serFile,
             outputDirectory,
             owner,
-            width,
-            height,
             this,
             imageEmitter,
             redshifts,
@@ -595,7 +593,7 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
             var canDrawReference = binning != null && pixelSize != null && lambda0 > 0 && pixelSize > 0 && binning > 0;
             registerSaveChartAction("profile", lineChart);
             series.setName(formatLegend(params.observationDetails().instrument(), lambda0, binning, pixelSize));
-            double dispersion = canDrawReference ? SpectrumAnalyzer.computeSpectralDispersion(params.observationDetails().instrument(), lambda0, pixelSize * binning) : 0;
+            double dispersion = canDrawReference ? SpectrumAnalyzer.computeSpectralDispersionNanosPerPixel(params.observationDetails().instrument(), lambda0, pixelSize * binning) : 0;
             double min = Double.MAX_VALUE;
             double max = -Double.MAX_VALUE;
             for (int x = start; x < end; x++) {
@@ -760,7 +758,7 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
             double lambda = lambda0;
             double pixSize = pixelSize;
             if (lambda > 0 && pixSize > 0) {
-                double disp = 10 * SpectrumAnalyzer.computeSpectralDispersion(instrument, lambda, pixelSize * binning);
+                double disp = 10 * SpectrumAnalyzer.computeSpectralDispersionNanosPerPixel(instrument, lambda, pixelSize * binning);
                 return String.format(message("intensity.legend"), pixelSize, binning, disp);
             }
         }

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/frame-debugger.fxml
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/frame-debugger.fxml
@@ -36,7 +36,7 @@
                     <Button mnemonicParsing="false" onAction="#fastRewind" text="&lt;&lt;"/>
                     <Button mnemonicParsing="false" onAction="#rewind" text="&lt;"/>
                     <Slider fx:id="frameSlider" prefHeight="16.0" prefWidth="258.0"/>
-                    <Label fx:id="frameId"/>
+                    <Label text="Frame "/> <TextField fx:id="frameId" maxWidth="64"/>
                     <Button mnemonicParsing="false" onAction="#forward" text="&gt;"/>
                     <Button mnemonicParsing="false" onAction="#fastForward" text="&gt;&gt;"/>
                 </HBox>


### PR DESCRIPTION
This commit reworks speed detection to be more accurate. It should result in less false positives, while more accurately representing the areas where speeds are detected.

The speed images are assigned a unique id, so that it is easier to locate them and match images together.

In addition, the spectrum debugger will now show detected shifts, and the generated debug images will tell where shifts are detected.