### PR TITLE
Use an AlertFactory so that we have all alerts configured the same

### DIFF
--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/BatchModeEventListener.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/BatchModeEventListener.java
@@ -80,6 +80,9 @@ public class BatchModeEventListener implements ProcessingEventListener, ImageMat
     private final double totalItems;
     private final File outputDirectory;
     private final LocalDateTime processingDate;
+
+    private final Header referenceHeader;
+
     private final int sequenceNumber;
     private DefaultImageScriptExecutor batchScriptExecutor;
 
@@ -101,6 +104,7 @@ public class BatchModeEventListener implements ProcessingEventListener, ImageMat
         this.outputDirectory = context.outputDirectory();
         this.processingDate = context.processingDate();
         this.imagesByLabel = context.imagesByLabel();
+        this.referenceHeader = context.referenceHeader();
         this.item = context.items().stream().filter(batchItem -> batchItem.id() == sequenceNumber).findFirst().get();
         this.totalItems = context.items().size();
         this.sequenceNumber = sequenceNumber;
@@ -154,7 +158,10 @@ public class BatchModeEventListener implements ProcessingEventListener, ImageMat
 
     @Override
     public void onVideoMetadataAvailable(VideoMetadataEvent event) {
-        this.header = event.getPayload();
+        var payload = event.getPayload();
+        if (payload != null) {
+            this.header = payload;
+        }
     }
 
     @Override
@@ -324,7 +331,7 @@ public class BatchModeEventListener implements ProcessingEventListener, ImageMat
             processParams.extraParams().datetimeFormat(),
             processParams.extraParams().dateFormat(),
             processingDate,
-            header
+            header != null ? header : referenceHeader
         );
     }
 

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/BatchProcessingContext.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/BatchProcessingContext.java
@@ -17,6 +17,7 @@ package me.champeau.a4j.jsolex.app.listeners;
 
 import me.champeau.a4j.jsolex.app.jfx.BatchItem;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
+import me.champeau.a4j.ser.Header;
 
 import java.io.File;
 import java.time.LocalDateTime;
@@ -26,12 +27,13 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public record BatchProcessingContext(
-        List<BatchItem> items,
-        Set<Integer> progress,
-        Set<Integer> errors,
-        AtomicBoolean batchFinished,
-        File outputDirectory,
-        LocalDateTime processingDate,
-        Map<String, List<ImageWrapper>> imagesByLabel
+    List<BatchItem> items,
+    Set<Integer> progress,
+    Set<Integer> errors,
+    AtomicBoolean batchFinished,
+    File outputDirectory,
+    LocalDateTime processingDate,
+    Map<String, List<ImageWrapper>> imagesByLabel,
+    Header referenceHeader
 ) {
 }

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -9,6 +9,7 @@ Here are the new features in this version:
 
 ## Changes since 2.4.0
 
+- Fixed excessive memory consumption during image reconstruction
 - Fixed links to open generated files in batch mode
 - Fixed an error when a script tries to overwrite an animation under Windows
 - Added ability to continue processing a batch script even if some files are in error

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -9,6 +9,7 @@ Voici les nouvelles fonctionnalités de cette version :
 
 ## Changements depuis la 2.4.0
 
+- Correction d'une consommation excessive de mémoire pendant la reconstruction
 - Correction des liens d'ouverture des fichiers générés en mode batch
 - Correction d'une erreur lorsqu'un script essaie d'enregistrer une animation par dessus une autre sous Windows
 - Ajout de la possibilité de continuer le traitement d'un script en mode batch même si certains fichiers sont en erreur


### PR DESCRIPTION
Under Windows 11, the text may not appear correctly so it's important that the alerts are resizable Fix memory consumption issue when reconstructing images.