### PR TITLE
Ignore gamma correction if original image is too dark

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/ImageAnalysis.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/ImageAnalysis.java
@@ -16,6 +16,7 @@
 package me.champeau.a4j.jsolex.processing.sun.tasks;
 
 import me.champeau.a4j.jsolex.processing.util.Histogram;
+import me.champeau.a4j.math.regression.Ellipse;
 
 import java.util.HashSet;
 
@@ -44,6 +45,36 @@ public record ImageAnalysis(float avg, float stddev, float min, float max, int d
             max = Math.max(max, v);
             distinctValues.add(v);
             builder.record(v);
+        }
+        float average = sum / n;
+        float stddev = 0;
+        for (float v : array) {
+            stddev += (v - average) * (v - average);
+        }
+        stddev = (float) Math.sqrt(stddev / (n - 1));
+        return new ImageAnalysis(average, stddev, min, max, distinctValues.size(), builder.build());
+    }
+
+    public static ImageAnalysis masked(float[] array, int width, int height, Ellipse e) {
+        float min = Float.MAX_VALUE;
+        float max = Float.MIN_VALUE;
+        float sum = 0.0f;
+        var builder = Histogram.builder(65536);
+        var distinctValues = new HashSet<Float>();
+
+        int n = 0;
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                if (e.isWithin(x, y)) {
+                    n++;
+                    var v = array[y * width + x];
+                    sum += v;
+                    min = Math.min(min, v);
+                    max = Math.max(max, v);
+                    distinctValues.add(v);
+                    builder.record(v);
+                }
+            }
         }
         float average = sum / n;
         float stddev = 0;

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
@@ -107,3 +107,4 @@ apply.next.time=Apply these rotation settings in the next processing session
 cannot.perform.bg.neutralization=Cannot perform background neutralization
 script.completed.in=Script completed in {}.{}s
 doppler.eclipse=Doppler eclipse
+skip.gamma.stretch=Image is too dark, skipping gamma stretch

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr_FR.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr_FR.properties
@@ -106,3 +106,4 @@ horizontal.flip=Retournement horizontal
 cannot.perform.bg.neutralization=Neutralisation du fond impossible
 script.completed.in=Script executé en {}.{}s
 doppler.eclipse=Eclipse Doppler
+skip.gamma.stretch=L'image est trop sombre, la correction gamma ne sera pas appliquée

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -9,7 +9,9 @@ Here are the new features in this version:
 
 ## Changes since 2.4.0
 
+- Autostretch will now ignore gamma correction if image is too dark
 - Added "Doppler Eclipse" image
+- Fixed mono Helium image being overwritten by its colorized version
 - Improved resolution of reference spectral lines (1/100th of Angstrom)
 - Added ability to save GONG image by right-clicking on the image
 - Improved edge detection for improved images

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -9,7 +9,9 @@ Voici les nouvelles fonctionnalités de cette version :
 
 ## Changements depuis la 2.4.0
 
+- L'autostretch ignorera désormais la correction gamma si l'image est trop sombre
 - Ajout d'une image "Eclipse en mode Doppler"
+- Correction de l'image Hélium mono écrasée par sa version couleur
 - Amélioration de la résolution des lignes spectrales de référence (1/100e d'Angström)
 - Ajout de la possibilité de sauvegarder l'image GONG en faisant un clic droit sur l'image
 - Amélioration de la reconnaissance de contours


### PR DESCRIPTION
This will improve processing of dark images, in particular calcium lines.