### PR TITLE
Promote redshift debug images to dedicated category

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -318,7 +318,7 @@ public class SolexVideoProcessor implements Broadcaster {
                 for (var batch : batches) {
                     try (var reader = SerFileReader.of(serFile)) {
                         var outputs = performImageReconstruction(converter, reader, start, end, geometry, width, height, polynomial, batch.toArray(new WorkflowState[0]));
-                        maybeProduceRedshiftDetectionDebugImages(outputs.redshifts, width, height, reader, converter, geometry, polynomial, imageNamingStrategy, baseName);
+                        maybeProduceRedshiftDetectionImages(outputs.redshifts, width, height, reader, converter, geometry, polynomial, imageNamingStrategy, baseName);
                         if (redshifts == null && outputs.redshifts != null) {
                             redshifts = new Redshifts(outputs.redshifts);
                         }
@@ -518,16 +518,16 @@ public class SolexVideoProcessor implements Broadcaster {
             .toList();
     }
 
-    private void maybeProduceRedshiftDetectionDebugImages(List<RedshiftArea> redshifts,
-                                                          int width,
-                                                          int height,
-                                                          SerFileReader reader,
-                                                          ImageConverter<float[]> converter,
-                                                          ImageGeometry geometry,
-                                                          DoubleUnaryOperator polynomial,
-                                                          FileNamingStrategy fileNamingStrategy,
-                                                          String baseName) {
-        if (redshifts != null && !redshifts.isEmpty() && processParams.requestedImages().isEnabled(GeneratedImageKind.DEBUG)) {
+    private void maybeProduceRedshiftDetectionImages(List<RedshiftArea> redshifts,
+                                                     int width,
+                                                     int height,
+                                                     SerFileReader reader,
+                                                     ImageConverter<float[]> converter,
+                                                     ImageGeometry geometry,
+                                                     DoubleUnaryOperator polynomial,
+                                                     FileNamingStrategy fileNamingStrategy,
+                                                     String baseName) {
+        if (redshifts != null && !redshifts.isEmpty() && processParams.requestedImages().isEnabled(GeneratedImageKind.REDSHIFT)) {
             var analyzer = new SpectrumFrameAnalyzer(
                 width,
                 height,
@@ -573,10 +573,10 @@ public class SolexVideoProcessor implements Broadcaster {
                         System.arraycopy(color.g(), 0, rgb.g(), 0, color.g().length);
                         System.arraycopy(color.b(), 0, rgb.b(), 0, color.b().length);
                     });
-                    var targetFile = outputDirectory.resolve(fileNamingStrategy.render(sequenceNumber, Constants.TYPE_DEBUG, "redshift", baseName + "_" + redshift.id()));
+                    var targetFile = outputDirectory.resolve(fileNamingStrategy.render(sequenceNumber, Constants.TYPE_PROCESSED, "redshift", baseName + "_" + redshift.id()));
                     broadcast(new ImageGeneratedEvent(
                         new GeneratedImage(
-                            GeneratedImageKind.DEBUG,
+                            GeneratedImageKind.REDSHIFT,
                             "Redshift %s (%.2f km/s)".formatted(redshift.id(), speed),
                             targetFile,
                             image

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DisplayCategory.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DisplayCategory.java
@@ -25,5 +25,6 @@ public enum DisplayCategory {
     PROCESSED,
     COLORIZED,
     IMAGE_MATH,
-    MISC;
+    MISC,
+    REDSHIFT;
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/GeneratedImageKind.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/GeneratedImageKind.java
@@ -36,7 +36,7 @@ public enum GeneratedImageKind {
     IMAGE_MATH(DisplayCategory.IMAGE_MATH),
     COMPOSITION(DisplayCategory.PROCESSED),
     CROPPED(DisplayCategory.MISC),
-    REDSHIFT(DisplayCategory.MISC);
+    REDSHIFT(DisplayCategory.REDSHIFT);
 
     private final DisplayCategory displayCategory;
 

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
@@ -68,6 +68,7 @@ displayCategory.DEBUG=Debug images
 displayCategory.PROCESSED=Processed
 displayCategory.COLORIZED=Colorized
 displayCategory.IMAGE_MATH=ImageMath Scripts
+displayCategory.REDSHIFT=Redshifts
 displayCategory.MISC=Miscellaneous
 rotate.left=Rotate left
 rotate.right=Rotate right

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr_FR.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr_FR.properties
@@ -69,6 +69,7 @@ displayCategory.PROCESSED=Traitées
 displayCategory.COLORIZED=Colorisées
 displayCategory.IMAGE_MATH=Scripts ImageMath
 displayCategory.MISC=Divers
+displayCategory.REDSHIFT=Décalages vers le rouge
 rotate.left=Rotation gauche
 rotate.right=Rotation droite
 flip=Inversion

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -7,6 +7,7 @@ Here are the new features in this version:
 
 ## Changes in 2.5.1
 
+- Use separate display category for redshifts and promote redshift debug images to this category
 - Display of FPS in the optimal exposure calculator
 - Fixed autostretch strategy producing bright images when the original SER file has a large offset
 - Fixed contrast adjustment not stretching to the full range

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -7,6 +7,7 @@ Voici les nouvelles fonctionnalités de cette version :
 
 ## Modifications dans 2.5.1
 
+- Ajout d'une catégorie d'affichage séparée pour les décalages vers le rouge et promotion des images de débogage des décalages vers le rouge à cette catégorie
 - Affichage du nombre de FPS dans la calculatrice d'exposition optimale
 - Correction de la stratégie d'autostretch produisant des images lumineuses lorsque le fichier SER original a un offset trop grand
 - Correction de l'ajustement du contraste ne s'étendant pas sur toute la plage disponible


### PR DESCRIPTION
As they are fairly useful, the debug images are now promoted to normal images. In order to better classify images a new "redshift" category was added.