### PR TITLE
Fix excessive memory consumption of image analysis

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -262,7 +262,7 @@ public class SolexVideoProcessor implements Broadcaster {
         }
         long imageSizeInBytes = width * newHeight * 4L * 3;
         long maxMemory = Runtime.getRuntime().maxMemory();
-        int batchSize = (int) (Math.ceil(maxMemory / (1.5d * imageSizeInBytes)));
+        int batchSize = (int) (Math.ceil(maxMemory / (4d * imageSizeInBytes)));
         checkAvailableDiskSpace(imageList, imageSizeInBytes);
 
         var maybePolynomial = Optional.ofNullable(polynomial).or(() -> findPolynomial(width, height, averageImage, imageNamingStrategy));

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/ImageAnalysis.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/ImageAnalysis.java
@@ -18,8 +18,6 @@ package me.champeau.a4j.jsolex.processing.sun.tasks;
 import me.champeau.a4j.jsolex.processing.util.Histogram;
 import me.champeau.a4j.math.regression.Ellipse;
 
-import java.util.HashSet;
-
 /**
  * Represents the statistical analysis of an image.
  *
@@ -27,23 +25,20 @@ import java.util.HashSet;
  * @param stddev the standard deviation
  * @param min the minimum value
  * @param max the maximum value
- * @param distinctValues the number of distinct values
  */
-public record ImageAnalysis(float avg, float stddev, float min, float max, int distinctValues, Histogram histogram) {
+public record ImageAnalysis(float avg, float stddev, float min, float max, Histogram histogram) {
 
     public static ImageAnalysis of(float[] array) {
         float min = Float.MAX_VALUE;
         float max = Float.MIN_VALUE;
         float sum = 0.0f;
         var builder = Histogram.builder(65536);
-        var distinctValues = new HashSet<Float>();
 
         int n = array.length;
         for (float v : array) {
             sum += v;
             min = Math.min(min, v);
             max = Math.max(max, v);
-            distinctValues.add(v);
             builder.record(v);
         }
         float average = sum / n;
@@ -52,7 +47,7 @@ public record ImageAnalysis(float avg, float stddev, float min, float max, int d
             stddev += (v - average) * (v - average);
         }
         stddev = (float) Math.sqrt(stddev / (n - 1));
-        return new ImageAnalysis(average, stddev, min, max, distinctValues.size(), builder.build());
+        return new ImageAnalysis(average, stddev, min, max, builder.build());
     }
 
     public static ImageAnalysis masked(float[] array, int width, int height, Ellipse e) {
@@ -60,7 +55,6 @@ public record ImageAnalysis(float avg, float stddev, float min, float max, int d
         float max = Float.MIN_VALUE;
         float sum = 0.0f;
         var builder = Histogram.builder(65536);
-        var distinctValues = new HashSet<Float>();
 
         int n = 0;
         for (int y = 0; y < height; y++) {
@@ -71,7 +65,6 @@ public record ImageAnalysis(float avg, float stddev, float min, float max, int d
                     sum += v;
                     min = Math.min(min, v);
                     max = Math.max(max, v);
-                    distinctValues.add(v);
                     builder.record(v);
                 }
             }
@@ -82,6 +75,6 @@ public record ImageAnalysis(float avg, float stddev, float min, float max, int d
             stddev += (v - average) * (v - average);
         }
         stddev = (float) Math.sqrt(stddev / (n - 1));
-        return new ImageAnalysis(average, stddev, min, max, distinctValues.size(), builder.build());
+        return new ImageAnalysis(average, stddev, min, max, builder.build());
     }
 }


### PR DESCRIPTION
Counting the number of distinct pixel values is too expensive and wasn't used in any case.