### PR TITLE
Fix missing images when a shift is dynamic

### DIFF
--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -21,7 +21,8 @@ Here are the new features in this version:
 - Fixed autostretch strategy producing bright images when the original SER file has a large offset
 - Fixed contrast adjustment not stretching to the full range
 - Fixed min/max pixel shift in custom animations limited to the min of the two
-
+- Fixed missing images in scripts in case of composition with `find_shift` function result
+- 
 ## Custom animations and cropping
 
 It is now possible to crop and image to a manual selection or create animations of a region of a solar disk, or a panel of redshifts, by manually selecting a region of interest.

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -13,6 +13,7 @@ Voici les nouvelles fonctionnalités de cette version :
 - Correction de la lecture des métadonnées de Firecapture
 - Réduction de l'utilisation mémoire lors de l'analyse d'images
 - Remplacement du curseur de zoom par des boutons
+- Correction des images manquantes dans les scripts en cas de composition avec le résultat de la fonction `find_shift`
 
 ## Modifications dans 2.5.1
 


### PR DESCRIPTION
In some expressions like `find_shift(...)+1`, we can't precompute the pixel shift value. In this case, we introduce a fallback which will reconstruct the image on demand.