### PR TITLE
Fix redshift position when image is flipped or geometry corrected

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/GeometryCorrector.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/GeometryCorrector.java
@@ -148,11 +148,11 @@ public class GeometryCorrector extends AbstractTask<GeometryCorrector.Result> {
             // correct redshifts
             redshifts = new Redshifts(redshifts.redshifts().stream()
                 .map(r -> {
-                    var x1 = r.x1() + shift + r.y1() * shear;
+                    var x1 = r.x1() - shift + r.y1() * shear;
                     var y1 = r.y1();
-                    var x2 = r.x2() + shift + r.y2() * shear;
+                    var x2 = r.x2() - shift + r.y2() * shear;
                     var y2 = r.y2();
-                    var maxX = r.maxX() + shift + r.maxY() * shear;
+                    var maxX = r.maxX() - shift + r.maxY() * shear;
                     var maxY = r.maxY();
                     return new RedshiftArea(r.id(), r.pixelShift(), r.relPixelShift(), r.kmPerSec(), (int) (x1 * sx), (int) (y1 * finalSy), (int) (x2 *sx), (int) (y2 * finalSy), (int) (maxX * sx), (int) (maxY * finalSy));
                 })


### PR DESCRIPTION
This commit fixes a serious computation error of positions of redshifts when the geometry correction was important (e.g oval disks or high tilt) or flipped.

This caused the redshift images/panels/animations to be misplaced.