### PR TITLE
Make sure that requested pixel shifts are available

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/ImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/ImageExpressionEvaluator.java
@@ -16,10 +16,11 @@
 package me.champeau.a4j.jsolex.processing.expr;
 
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
-import me.champeau.a4j.jsolex.processing.util.ForkJoinContext;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 
 import java.util.function.Function;
+
+import static me.champeau.a4j.jsolex.processing.util.Constants.message;
 
 public class ImageExpressionEvaluator extends AbstractImageExpressionEvaluator {
     private final Function<Double, ImageWrapper> images;
@@ -32,7 +33,7 @@ public class ImageExpressionEvaluator extends AbstractImageExpressionEvaluator {
     protected ImageWrapper findImage(double shift) {
         var image = images.apply(shift);
         if (image == null) {
-            throw new IllegalArgumentException("Image for shift '" + shift + "' is missing");
+            throw new IllegalArgumentException(String.format(message("missing.shift"), shift));
         }
         return image;
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/SpectrumParams.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/SpectrumParams.java
@@ -37,4 +37,8 @@ public record SpectrumParams(
     public SpectrumParams withSwitchRedBlueChannels(boolean switchRedBlueChannels) {
         return new SpectrumParams(ray, pixelShift, dopplerShift, continuumShift, switchRedBlueChannels);
     }
+
+    public SpectrumParams withContinuumShift(double continuumShift) {
+        return new SpectrumParams(ray, pixelShift, dopplerShift, continuumShift, switchRedBlueChannels);
+    }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/LinearStrechingStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/LinearStrechingStrategy.java
@@ -17,7 +17,6 @@ package me.champeau.a4j.jsolex.processing.stretching;
 
 import me.champeau.a4j.jsolex.processing.util.Constants;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
-import me.champeau.a4j.jsolex.processing.util.RGBImage;
 
 public final class LinearStrechingStrategy implements StretchingStrategy {
     public static final LinearStrechingStrategy DEFAULT = new LinearStrechingStrategy(0, Constants.MAX_PIXEL_VALUE);
@@ -48,22 +47,6 @@ public final class LinearStrechingStrategy implements StretchingStrategy {
             return;
         }
         rescale(data, range, min);
-    }
-
-    @Override
-    public void stretch(RGBImage image) {
-        var r = image.r();
-        var g = image.g();
-        var b = image.b();
-        double min = Math.min(Math.min(min(r), min(g)), min(b));
-        double max = Math.max(Math.max(max(r), max(g)), max(b));
-        double range = max - min;
-        if (range == 0) {
-            return;
-        }
-        rescale(r, range, min);
-        rescale(g, range, min);
-        rescale(b, range, min);
     }
 
     private void rescale(float[] data, double range, double min) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/PixelShiftRange.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/PixelShiftRange.java
@@ -30,4 +30,7 @@ public record PixelShiftRange(
     double maxPixelShift,
     double step
 ) {
+    public boolean includes(double shift) {
+        return shift >= minPixelShift && shift <= maxPixelShift;
+    }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/SpectralLineFrameImageCreator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/SpectralLineFrameImageCreator.java
@@ -15,10 +15,12 @@
  */
 package me.champeau.a4j.jsolex.processing.util;
 
+import me.champeau.a4j.jsolex.processing.stretching.LinearStrechingStrategy;
 import me.champeau.a4j.jsolex.processing.sun.DistortionCorrection;
 import me.champeau.a4j.jsolex.processing.sun.SpectrumFrameAnalyzer;
 import me.champeau.a4j.math.Point2D;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.DoubleUnaryOperator;
@@ -118,6 +120,7 @@ public class SpectralLineFrameImageCreator {
     }
 
     public RGBImage generateSpectrumImage(DoubleUnaryOperator forcedPolynomial,
+                                          boolean stretch,
                                           Consumer<? super DebugImage> debugImageConsumer) {
         int size = width * height;
         Optional<DoubleUnaryOperator> polynomial = Optional.ofNullable(forcedPolynomial).or(analyzer::findDistortionPolynomial);
@@ -128,6 +131,12 @@ public class SpectralLineFrameImageCreator {
         float[] rr = new float[2 * size + spacing];
         float[] gg = new float[2 * size + spacing];
         float[] bb = new float[2 * size + spacing];
+        var src = original;
+        if (stretch) {
+            src = new float[src.length];
+            System.arraycopy(original, 0, src, 0, src.length);
+            LinearStrechingStrategy.DEFAULT.stretch(new ImageWrapper32(width, height, src, Map.of()));
+        }
         System.arraycopy(original, 0, rr, 0, size);
         System.arraycopy(original, 0, gg, 0, size);
         System.arraycopy(original, 0, bb, 0, size);

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
@@ -111,3 +111,6 @@ doppler.eclipse=Doppler eclipse
 skip.gamma.stretch=Image is too dark, skipping gamma stretch
 reference.coords=Reference coordinates:
 no.config.file.found=No customized configuration file found at {}, will use default {}
+missing.shift=Image for shift '%.1f' is missing
+invalid.continuum.shift=Continuum shift is greater than the maximum pixel shift allowed by the cropping window, setting it to {} instead. This can be avoided by making sure the spectral line is centered in the cropping window.
+restricting.range=Requested range goes beyond the maximum available range. Truncated to [%.2f, %.2f]

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr_FR.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr_FR.properties
@@ -110,3 +110,6 @@ doppler.eclipse=Eclipse Doppler
 skip.gamma.stretch=L'image est trop sombre, la correction gamma ne sera pas appliquée
 reference.coords=Référentiel : 
 no.config.file.found=Pas de fichier de configuration personnalisé trouvé à {}, utilisation de la configuration par défaut {}
+missing.shift=L'image au décalage '%.1f' n'a pas été trouvée
+invalid.continuum.shift=Le décalage du continuum est supérieur au décalage maximal autorisé par la fenêtre de rognage, il est donc ajusté à %f. Cela peut être évité en centrant la ligne spectrale dans votre fenêtre de rognage.
+restricting.range=L'intervalle demandé dépasse celui disponible. Restriction à [%.2f, %.2f]

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages.properties
@@ -107,3 +107,4 @@ imagemath.crop=Log ImageMath cropping call
 cancel=Cancel
 shift.hint=Wavelen N/A
 cropped.image=Cropped %d
+cropping.window.invalid.shift=Cropping window isn't large enough for pixel shift %.1f, replacing with %.1f. This can be avoided by making sure the spectral line is in the middle of the cropping window.

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages_fr_FR.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages_fr_FR.properties
@@ -107,3 +107,4 @@ imagemath.crop=Logger la fonction de rognage ImageMath
 cancel=Annuler
 shift.hint=Long. onde invalide
 cropped.image=Rognée %d
+cropping.window.invalid.shift=La fenêtre de rognage n'est pas assez grande pour le décalage %.1f, remplacement par %.1f. Cela peut être évité en s'assurant que la raie spectrale soit au milieu de la fenêtre de rognage.

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -5,7 +5,13 @@ Here are the new features in this version:
 - [Custom animations and cropping](#custom-animations-and-cropping)
 - [Bugfixes and improvements](#bugfixes-and-improvements)
 
-## Changes in 2.5.2
+## Changes in 2.5.4
+
+- Added warning when requested pixel shift isn't available
+- Replace invalid pixel shifts with best fit
+
+
+## Changes in 2.5.3
 
 - Improved exposure time calculator
 - Added more fields to the custom spectroheliographs editor
@@ -13,7 +19,7 @@ Here are the new features in this version:
 - Reduced memory usage when analyzing images
 - Replaced zoom slider with buttons
 
-## Changes in 2.5.3
+## Changes in 2.5.2
 
 - Fixed redshifts position that could be incorrect in case of strong tilt or horizontal/vertical flip
 - Fixed double-click not changing zoom

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -5,6 +5,11 @@ Voici les nouvelles fonctionnalités de cette version :
 - [Animations personnalisées et recadrage](#animations-personnalisees-et-recadrage)
 - [Corrections de bugs et améliorations](#corrections-de-bugs-et-ameliorations)
 
+## Changes in 2.5.4
+
+- Ajout d'un avertissement lorsque le décalage de pixel demandé n'est pas disponible
+- Remplacement des décalages de pixel invalides par le meilleur ajustement possible
+
 ## Modifications dans 2.5.3
 
 - Correction de la position des décalages vers le rouge qui pouvait être incorrecte en case de fort tilt ou d'inversion horizontale/verticale


### PR DESCRIPTION
In some cases, it's possible for the user to directly or indirectly request an image at some pixel shift which would go beyond the cropping window.

If that happens, the software will now warn the user and pick the closest available pixel shift.

Fixes #334