### PR TITLE
Fix dynamic cropping of composite images

### DIFF
--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SingleModeProcessingEventListener.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SingleModeProcessingEventListener.java
@@ -267,6 +267,10 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
                 @Override
                 public boolean supports(ActionKind kind) {
                     if (kind.isCrop()) {
+                        if (kind == ActionKind.IMAGEMATH_CROP) {
+                            var stretchedImage = addedImageViewer.getStretchedImage();
+                            return stretchedImage.findMetadata(ReferenceCoords.class).isPresent();
+                        }
                         return true;
                     }
                     if (adjustedParams == null) {
@@ -282,7 +286,7 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
                 public void onSelectRegion(ActionKind kind, int x, int y, int width, int height) {
                     BackgroundOperations.async(() -> {
                         var stretchedImage = addedImageViewer.getStretchedImage();
-                        stretchedImage.findMetadata(ReferenceCoords.class).ifPresent(coord -> {
+                        stretchedImage.findMetadata(ReferenceCoords.class).ifPresentOrElse(coord -> {
                             var cx = x + width / 2d;
                             var cy = y + height / 2d;
                             var orig = coord.determineOriginalCoordinates(new Point2D(cx, cy), new Point2D(stretchedImage.width() / 2d, stretchedImage.height() / 2d), ReferenceCoords.GEO_CORRECTION);
@@ -294,6 +298,10 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
                                 performCropping(stretchedImage, x, y, width, height);
                             } else if (kind == ActionKind.CREATE_ANIM_OR_PANEL) {
                                 createAnimationOrPanel(xx, yy, width, height);
+                            }
+                        }, () -> {
+                            if (kind == ActionKind.CROP) {
+                                performCropping(stretchedImage, x, y, width, height);
                             }
                         });
                     });

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -10,6 +10,7 @@ Here are the new features in this version:
 ## Changes in 2.6.2
 
 - Fixed the `rescale_rel` function which was converting color images to monochrome
+- Fixed dynamic crop menu item which did nothing on some images
 
 ## Changes in 2.6.1
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -11,6 +11,7 @@ Voici les nouvelles fonctionnalités de cette version :
 ## Changements dans la version 2.6.2
 
 - Correction de la fonction `rescale_rel` qui convertissait les images couleur en mono
+- Correction de l'élément de menu de rognage dynamique qui ne faisait rien sur certaines images
 
 ## Changements dans la version 2.6.1
 


### PR DESCRIPTION
Images which are composites (e.g a stack from multiple images) don't have the required reference information for logging the position in the source image. This caused the crop action to do nothing on images from batch mode, for example. This commit fixes the problem.