### PR TITLE
Fix alignment button behavior

### DIFF
--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ZoomableImageView.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ZoomableImageView.java
@@ -36,6 +36,7 @@ import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
 import javafx.util.Duration;
+import me.champeau.a4j.jsolex.processing.util.BackgroundOperations;
 import me.champeau.a4j.math.regression.Ellipse;
 
 import java.nio.file.Files;
@@ -339,8 +340,22 @@ public class ZoomableImageView extends HBox {
         }
         if (otherImage.getWidth() == img.getWidth() && otherImage.getHeight() == getImage().getHeight()) {
             setZoom(other.getZoom());
-            scrollPane.setHvalue(other.scrollPane.getHvalue());
-            scrollPane.setVvalue(other.scrollPane.getVvalue());
+            var hvalue = other.scrollPane.getHvalue();
+            var vvalue = other.scrollPane.getVvalue();
+            BackgroundOperations.async(() -> {
+                while (scrollPane.getHvalue() != hvalue || scrollPane.getVvalue() != vvalue) {
+                    BatchOperations.submit(() -> {
+                        scrollPane.setHvalue(hvalue);
+                        scrollPane.setVvalue(vvalue);
+                    });
+                    try {
+                        Thread.sleep(50);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
+            });
         }
     }
 

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -13,6 +13,7 @@ Here are the new features in this version:
 - Made artificial flat correction optional (issue #364)
 - Improve correction using artificial flat
 - Fix bad behavior of contrast slider in frame analyzer
+- Fixed alignment button not always aligning images
 
 ## Changes in 2.6.2
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -14,6 +14,7 @@ Voici les nouvelles fonctionnalités de cette version :
 - La correction par flat artificiel est maintenant optionnelle (issue #364)
 - Amélioration de la correction par flat artificiel
 - Correction du mauvais comportement du curseur de contraste dans l'analyseur de vidéo
+- Correction du bouton d'alignement n'alignant pas toujours les images
 
 ## Changements dans la version 2.6.2
 


### PR DESCRIPTION
When an image was eagerly loaded and that alignment was deferred, the scroll pane position was set too early.