### PR TITLE
Improve autostretch

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Crop.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Crop.java
@@ -19,10 +19,10 @@ import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.crop.Cropper;
 import me.champeau.a4j.jsolex.processing.sun.detection.RedshiftArea;
 import me.champeau.a4j.jsolex.processing.sun.detection.Redshifts;
-import me.champeau.a4j.jsolex.processing.sun.tasks.ImageAnalysis;
 import me.champeau.a4j.jsolex.processing.sun.workflow.ImageStats;
 import me.champeau.a4j.jsolex.processing.sun.workflow.ReferenceCoords;
 import me.champeau.a4j.jsolex.processing.util.FileBackedImage;
+import me.champeau.a4j.jsolex.processing.util.Histogram;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
@@ -183,7 +183,11 @@ public class Crop extends AbstractFunctionImpl {
         Object finalArg = arg;
         var blackpoint = getFromContext(ImageStats.class).map(ImageStats::blackpoint).orElseGet(() -> {
             if (finalArg instanceof ImageWrapper wrapper && wrapper.unwrapToMemory() instanceof ImageWrapper32 mono) {
-                return ImageAnalysis.of(mono.data()).min();
+                var histo = Histogram.builder(65536);
+                for (float v : mono.data()) {
+                    histo.record(v);
+                }
+                return (float) histo.build().cumulative().percentile(0.01);
             }
             return 0f;
         });

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -9,6 +9,7 @@ Here are the new features in this version:
 
 ## Changes in 2.6.3
 
+- Improved autostretch to avoid pixel saturation which often happens with calcium line processing
 - Improve spectral line detection accuracy (issue #360)
 - Made artificial flat correction optional (issue #364)
 - Improve correction using artificial flat

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -10,6 +10,7 @@ Voici les nouvelles fonctionnalités de cette version :
 
 ## Changements dans la version 2.6.3
 
+- Amélioration d'autostretch pour éviter les saturations de pixels en calcium notamment
 - Correction de la précision de la détection des lignes spectrales (issue #360)
 - La correction par flat artificiel est maintenant optionnelle (issue #364)
 - Amélioration de la correction par flat artificiel


### PR DESCRIPTION
This commit improves the autostretch algorithm to avoid saturation which often happens with calcium images.