### PR TITLE
Fix performance issue when collecting shifts

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/StretchingStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/StretchingStrategy.java
@@ -34,6 +34,9 @@ public sealed interface StretchingStrategy permits
     StretchingChain {
 
     default void stretch(ImageWrapper image) {
+        if (image.width() == 0 && image.height() == 0) {
+            return;
+        }
         switch (image) {
             case ImageWrapper32 mono -> stretch(mono);
             case RGBImage rgb -> stretch(rgb);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -366,6 +366,7 @@ public class SolexVideoProcessor implements Broadcaster {
             long sd = System.nanoTime();
             BackgroundOperations.exclusiveIO(() -> {
                 List<List<WorkflowState>> batches = batches(imageList, batchSize);
+                LOGGER.info(message("memory.pressure"), memoryRestrictionMultiplier);
                 if (batches.size() > 1) {
                     LOGGER.info(message("reconstruction.batches"), batches.size(), batchSize);
                 }

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
@@ -99,6 +99,7 @@ redshift.creator.kind.ANIMATION=Animation
 redshift.creator.kind.PANEL=Panel
 redshift.creator.kind.ALL=Animation and panel
 reconstruction.batches=In order to save memory, reconstruction will be performed in {} batches of {} pixel shifts.
+memory.pressure=Memory pressure factor {}
 processing.batch=Processing batch {}
 processing.disk.requirements=Processing will require approximatively {}{} of disk space
 not.enough.disk.space=Not enough disk space in %s. You need at least %s%s

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr_FR.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr_FR.properties
@@ -99,6 +99,7 @@ redshift.creator.kind.ANIMATION=Animation
 redshift.creator.kind.PANEL=Panneau
 redshift.creator.kind.ALL=Animation et panneau
 reconstruction.batches=Afin de sauver de la mémoire, la reconstruction va se faire en {} lots de {} pixel shifts.
+memory.pressure= Facteur de pression mémoire {}.
 processing.batch=Traitement du lot de pixel shifts {}
 processing.disk.requirements=Le traitement va nécessiter approximativement {}{} d'espace disque
 not.enough.disk.space=Espace disque disponible insuffisant sur %s. Vous devez avoir au moins %s%s de libre.

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/AdvancedParamsController.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/AdvancedParamsController.java
@@ -56,7 +56,7 @@ public class AdvancedParamsController {
         memoryRestrictionMultiplier.setValue(Configuration.getInstance().getMemoryRestrictionMultiplier());
     }
 
-    private static String computeMemoryUsageHelpLabel(Number value) {
+    public static String computeMemoryUsageHelpLabel(Number value) {
         if (value.doubleValue() < 4) {
             return I18N.string(JSolEx.class, "advanced-params", "memory.usage.high");
         }


### PR DESCRIPTION
The autostretch strategy in particular is very inefficient in case of "empty" images.