### PR TITLE
Use 2-dimensional arrays for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,17 +43,17 @@ They are provided as-is, without any warranty.
 You can also install the _development_ version of JSol'Ex as it can contain numerous bugfixes and improvements over the release versions.
 
 - Development versions (updated on each commit)
-  - [JSol'Ex (Linux, deb, AMD64)](https://jsolex.s3.eu-west-3.amazonaws.com/jsolex-ubuntu-latest/jsolex-devel_2.7.4_amd64.deb)
-  - [JSol'Ex (Windows)](https://jsolex.s3.eu-west-3.amazonaws.com/jsolex-windows-latest/jsolex-devel-2.7.4.msi)
-  - [JSol'Ex (MacOS)](https://jsolex.s3.eu-west-3.amazonaws.com/jsolex-macos-latest/jsolex-devel-2.7.4.pkg)
-  - [JSol'Ex (MacOS Intel)](https://jsolex.s3.eu-west-3.amazonaws.com/jsolex-macos-13/jsolex-devel-2.7.4.pkg)
-  - [JSol'Ex (Tarball)](https://jsolex.s3.eu-west-3.amazonaws.com/jsolex-macos-latest/jsolex-2.7.4-SNAPSHOT.tar.gz)
-  - [JSol'Ex (Zip)](https://jsolex.s3.eu-west-3.amazonaws.com/jsolex-macos-latest/jsolex-2.7.4-SNAPSHOT.zip)
-  - [Ser Player (Linux, deb, AMD64)](https://jsolex.s3.eu-west-3.amazonaws.com/ser-player-ubuntu-latest/ser-player-devel_2.7.4_amd64.deb)
-  - [Ser Player (Windows)](https://jsolex.s3.eu-west-3.amazonaws.com/ser-player-windows-latest/ser-player-devel-2.7.4.msi)
-  - [Ser Player (MacOS)](https://jsolex.s3.eu-west-3.amazonaws.com/ser-player-macos-latest/ser-player-devel-2.7.4.pkg)
-  - [Ser Player (Tarball)](https://jsolex.s3.eu-west-3.amazonaws.com/ser-player-macos-latest/ser-player-2.7.4-SNAPSHOT.tar.gz)
-  - [Ser Player (Zip)](https://jsolex.s3.eu-west-3.amazonaws.com/ser-player-macos-latest/ser-player-2.7.4-SNAPSHOT.zip)
+  - [JSol'Ex (Linux, deb, AMD64)](https://jsolex.s3.eu-west-3.amazonaws.com/jsolex-ubuntu-latest/jsolex-devel_2.8.0_amd64.deb)
+  - [JSol'Ex (Windows)](https://jsolex.s3.eu-west-3.amazonaws.com/jsolex-windows-latest/jsolex-devel-2.8.0.msi)
+  - [JSol'Ex (MacOS)](https://jsolex.s3.eu-west-3.amazonaws.com/jsolex-macos-latest/jsolex-devel-2.8.0.pkg)
+  - [JSol'Ex (MacOS Intel)](https://jsolex.s3.eu-west-3.amazonaws.com/jsolex-macos-13/jsolex-devel-2.8.0.pkg)
+  - [JSol'Ex (Tarball)](https://jsolex.s3.eu-west-3.amazonaws.com/jsolex-macos-latest/jsolex-2.8.0-SNAPSHOT.tar.gz)
+  - [JSol'Ex (Zip)](https://jsolex.s3.eu-west-3.amazonaws.com/jsolex-macos-latest/jsolex-2.8.0-SNAPSHOT.zip)
+  - [Ser Player (Linux, deb, AMD64)](https://jsolex.s3.eu-west-3.amazonaws.com/ser-player-ubuntu-latest/ser-player-devel_2.8.0_amd64.deb)
+  - [Ser Player (Windows)](https://jsolex.s3.eu-west-3.amazonaws.com/ser-player-windows-latest/ser-player-devel-2.8.0.msi)
+  - [Ser Player (MacOS)](https://jsolex.s3.eu-west-3.amazonaws.com/ser-player-macos-latest/ser-player-devel-2.8.0.pkg)
+  - [Ser Player (Tarball)](https://jsolex.s3.eu-west-3.amazonaws.com/ser-player-macos-latest/ser-player-2.8.0-SNAPSHOT.tar.gz)
+  - [Ser Player (Zip)](https://jsolex.s3.eu-west-3.amazonaws.com/ser-player-macos-latest/ser-player-2.8.0-SNAPSHOT.zip)
 
 Licensed under Apache License version 2.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 org.gradle.parallel=true
-version=2.7.4-SNAPSHOT
+version=2.8.0-SNAPSHOT
 systemProp.org.gradle.java.compile-classpath-packaging=true

--- a/jserfile/src/main/java/me/champeau/a4j/ser/EightBitConversionSupport.java
+++ b/jserfile/src/main/java/me/champeau/a4j/ser/EightBitConversionSupport.java
@@ -29,11 +29,19 @@ public class EightBitConversionSupport {
         return converted;
     }
 
-    public static byte[] to8BitImage(float[] image) {
-        byte[] converted = new byte[image.length];
-        for (int i = 0; i < image.length; i++) {
-            int value = Math.round(image[i]);
-            converted[i] = (byte) (value >> 8);
+    public static byte[] to8BitImage(float[][] image) {
+        if (image.length == 0) {
+            return new byte[0];
+        }
+        var height = image.length;
+        var width = image[1].length;
+
+        byte[] converted = new byte[width * height];
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                int value = Math.round(image[y][x]);
+                converted[y * width + x] = (byte) (value >> 8);
+            }
         }
         return converted;
     }

--- a/jserfile/src/main/java/me/champeau/a4j/ser/bayer/FloatPrecisionImageConverter.java
+++ b/jserfile/src/main/java/me/champeau/a4j/ser/bayer/FloatPrecisionImageConverter.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
  * This class is responsible for converting each byte into a float
  * value ranging from 0 to 65535.
  */
-public class FloatPrecisionImageConverter implements ImageConverter<float[]> {
+public class FloatPrecisionImageConverter implements ImageConverter<float[][]> {
     private final ImageConverter<short[]> delegate;
 
     public FloatPrecisionImageConverter(ImageConverter<short[]> delegate) {
@@ -33,17 +33,21 @@ public class FloatPrecisionImageConverter implements ImageConverter<float[]> {
     }
 
     @Override
-    public float[] createBuffer(ImageGeometry geometry) {
-        return new float[delegate.createBuffer(geometry).length];
+    public float[][] createBuffer(ImageGeometry geometry) {
+        return new float[geometry.height()][geometry.width()];
     }
 
 
     @Override
-    public void convert(int frameId, ByteBuffer frameData, ImageGeometry geometry, float[] outputData) {
+    public void convert(int frameId, ByteBuffer frameData, ImageGeometry geometry, float[][] outputData) {
         var intermediateBuffer = delegate.createBuffer(geometry);
         delegate.convert(frameId, frameData, geometry, intermediateBuffer);
-        for (int i = 0; i < intermediateBuffer.length; i++) {
-            outputData[i] = intermediateBuffer[i] & 0xFFFF;
+        var height = geometry.height();
+        var width = geometry.width();
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                outputData[y][x] = intermediateBuffer[y * width + x] & 0xFFFF;
+            }
         }
     }
 

--- a/jserfile/src/test/groovy/me/champeau/a4j/ser/bayer/FloatPrecisionImageConverterTest.groovy
+++ b/jserfile/src/test/groovy/me/champeau/a4j/ser/bayer/FloatPrecisionImageConverterTest.groovy
@@ -15,11 +15,13 @@
  */
 package me.champeau.a4j.ser.bayer
 
+import me.champeau.a4j.ser.ColorMode
 import me.champeau.a4j.ser.ImageGeometry
 import spock.lang.Specification
 import spock.lang.Subject
 
 import java.nio.ByteBuffer
+import java.nio.ByteOrder
 
 class FloatPrecisionImageConverterTest extends Specification {
     private static final double EPSILON = 0.000001d;
@@ -30,14 +32,15 @@ class FloatPrecisionImageConverterTest extends Specification {
     )
 
     def "converts to double array"() {
+        def geometry = new ImageGeometry(ColorMode.MONO, 3, 1, 8, ByteOrder.BIG_ENDIAN)
         when:
-        def buffer = converter.createBuffer(null)
-        converter.convert(0, null, null, buffer)
+        def buffer = converter.createBuffer(geometry)
+        converter.convert(0, null, geometry, buffer)
 
         then:
-        assertEquals(buffer[0], 0.0d)
-        assertEquals(buffer[1], 8000d)
-        assertEquals(buffer[2], 65535d)
+        assertEquals(buffer[0][0], 0.0d)
+        assertEquals(buffer[0][1], 8000d)
+        assertEquals(buffer[0][2], 65535d)
     }
 
     static void assertEquals(double a, double b) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/event/ProcessingDoneEvent.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/event/ProcessingDoneEvent.java
@@ -41,7 +41,7 @@ public final class ProcessingDoneEvent extends ProcessingEvent<ProcessingDoneEve
         ImageStats imageStats,
         List<RedshiftArea> redshifts,
         DoubleUnaryOperator polynomial,
-        float[] averageImage,
+        float[][] averageImage,
         ProcessParams processParams,
         PixelShiftRange pixelShiftRange) {
 
@@ -54,7 +54,7 @@ public final class ProcessingDoneEvent extends ProcessingEvent<ProcessingDoneEve
                                          ImageStats imageStats,
                                          List<RedshiftArea> redshifts,
                                          DoubleUnaryOperator polynomial,
-                                         float[] averageImage,
+                                         float[][] averageImage,
                                          ProcessParams processParams,
                                          PixelShiftRange pixelShiftRange) {
         return new ProcessingDoneEvent(new Outcome(timestamp, Collections.unmodifiableMap(images), customImageEmitter, ellipse, imageStats, redshifts, polynomial, averageImage, processParams, pixelShiftRange));

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/ImageMathScriptExecutor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/ImageMathScriptExecutor.java
@@ -50,7 +50,7 @@ public interface ImageMathScriptExecutor {
                         rgb.width(),
                         rgb.height(),
                         rgb.metadata(),
-                        () -> new float[][]{rgb.r(), rgb.g(), rgb.b()}
+                        () -> new float[][][]{rgb.r(), rgb.g(), rgb.b()}
                 );
             }
         }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/AbstractFunctionImpl.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/AbstractFunctionImpl.java
@@ -146,9 +146,11 @@ class AbstractFunctionImpl {
         return processed.stream().sorted(Comparator.comparingInt(IndexedObject::idx)).map(IndexedObject::image).toList();
     }
 
-    private static void applyFunction(float[] data, DoubleUnaryOperator function) {
-        for (var i = 0; i < data.length; i++) {
-            data[i] = (float) function.applyAsDouble(data[i]);
+    private static void applyFunction(int width, int height, float[][] data, DoubleUnaryOperator function) {
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                data[y][x] = (float) function.applyAsDouble(data[y][x]);
+            }
         }
     }
 
@@ -211,13 +213,13 @@ class AbstractFunctionImpl {
         }
         if (img instanceof ImageWrapper32 mono) {
             var copy = mono.copy();
-            applyFunction(copy.data(), unary);
+            applyFunction(mono.width(), mono.height(), copy.data(), unary);
             return copy;
         } else if (img instanceof RGBImage rgb) {
             var copy = rgb.copy();
-            applyFunction(copy.r(), unary);
-            applyFunction(copy.g(), unary);
-            applyFunction(copy.b(), unary);
+            applyFunction(rgb.width(), rgb.height(), copy.r(), unary);
+            applyFunction(rgb.width(), rgb.height(), copy.g(), unary);
+            applyFunction(rgb.width(), rgb.height(), copy.b(), unary);
             return copy;
         }
         throw new IllegalStateException("Unexpected image type " + img);
@@ -248,6 +250,6 @@ class AbstractFunctionImpl {
 
     @FunctionalInterface
     public interface MonoImageTransformer {
-        void transform(int width, int height, float[] data);
+        void transform(int width, int height, float[][] data);
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Animate.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Animate.java
@@ -148,7 +148,7 @@ public class Animate extends AbstractFunctionImpl {
         addColorFrame(encoder, image, colorChannelsStream, width, height);
     }
 
-    private static void addColorFrame(SequenceEncoder encoder, ImageWrapper image, Stream<float[]> colorChannelsStream, int width, int height) {
+    private static void addColorFrame(SequenceEncoder encoder, ImageWrapper image, Stream<float[][]> colorChannelsStream, int width, int height) {
         var bytes = colorChannelsStream.map(EightBitConversionSupport::to8BitImage).toArray(byte[][]::new);
         if (width != image.width() || height != image.height()) {
             for (int channel = 0; channel < 3; channel++) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Convolution.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Convolution.java
@@ -67,7 +67,7 @@ public class Convolution extends AbstractFunctionImpl {
         if (image instanceof ImageWrapper32 mono) {
             return new ImageWrapper32(mono.width(), mono.height(), imageMath.convolve(mono.asImage(), kernel).data(), mono.metadata());
         } else if (image instanceof RGBImage rgb) {
-            var hsl = ImageUtils.fromRGBtoHSL(new float[][] { rgb.r(), rgb.g(), rgb.b() });
+            var hsl = ImageUtils.fromRGBtoHSL(new float[][][] { rgb.r(), rgb.g(), rgb.b() });
             hsl[2] = imageMath.convolve(new Image(rgb.width(), rgb.height(), hsl[2]), kernel).data();
             var transformed = ImageUtils.fromHSLtoRGB(hsl);
             return new RGBImage(rgb.width(), rgb.height(), transformed[0], transformed[1], transformed[2], rgb.metadata());

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/DiskFill.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/DiskFill.java
@@ -54,18 +54,15 @@ public class DiskFill extends AbstractFunctionImpl {
         }
         if (img instanceof ImageWrapper32 mono) {
             var copy = mono.copy();
-            doFill(ellipse, copy.data(), copy.width(), fill, outsideFill);
+            doFill(ellipse, copy.data(), fill, outsideFill);
             return copy;
         } else if (img instanceof RGBImage rgb) {
-            var r = new float[rgb.r().length];
-            System.arraycopy(rgb.r(), 0, r, 0, r.length);
-            doFill(ellipse, r, rgb.width(), fill, outsideFill);
-            var g = new float[rgb.g().length];
-            System.arraycopy(rgb.g(), 0, g, 0, g.length);
-            doFill(ellipse, g, rgb.width(), fill, outsideFill);
-            var b = new float[rgb.b().length];
-            System.arraycopy(rgb.b(), 0, b, 0, b.length);
-            doFill(ellipse, b, rgb.width(), fill, outsideFill);
+            var r = ImageWrapper.copyData(rgb.r());
+            doFill(ellipse, r, fill, outsideFill);
+            var g = ImageWrapper.copyData(rgb.g());
+            doFill(ellipse, g, fill, outsideFill);
+            var b = ImageWrapper.copyData(rgb.b());
+            doFill(ellipse, b, fill, outsideFill);
             return new RGBImage(rgb.width(), rgb.height(), r, g, b, new LinkedHashMap<>(rgb.metadata()));
         }
         return null;
@@ -99,14 +96,14 @@ public class DiskFill extends AbstractFunctionImpl {
         }
     }
 
-    public static void doFill(Ellipse ellipse, float[] image, int width, float color, Float outsideColor) {
-        int height = image.length / width;
-        for (int x = 0; x < width; x++) {
-            for (int y = 0; y < height; y++) {
+    public static void doFill(Ellipse ellipse, float[][] image, float color, Float outsideColor) {
+        for (int y = 0; y < image.length; y++) {
+            var line = image[y];
+            for (int x = 0; x < line.length; x++) {
                 if (ellipse.isWithin(x, y)) {
-                    image[x + y * width] = color;
+                    image[y][x] = color;
                 } else if (outsideColor != null) {
-                    image[x + y * width] = outsideColor;
+                    image[y][x] = outsideColor;
                 }
             }
         }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ImageDraw.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ImageDraw.java
@@ -397,18 +397,26 @@ public class ImageDraw extends AbstractFunctionImpl {
     private static int maxValue(ImageWrapper wrapper) {
         float max = Integer.MIN_VALUE;
         if (wrapper instanceof ImageWrapper32 mono) {
-            for (float d : mono.data()) {
-                max = Math.max(max, d);
+            for (float[] line : mono.data()) {
+                for (float d : line) {
+                    max = Math.max(max, d);
+                }
             }
         } else if (wrapper instanceof RGBImage rgb) {
-            for (float d : rgb.r()) {
-                max = Math.max(max, d);
+            for (float[] line : rgb.r()) {
+                for (float d : line) {
+                    max = Math.max(max, d);
+                }
             }
-            for (float d : rgb.g()) {
-                max = Math.max(max, d);
+            for (float[] line : rgb.g()) {
+                for (float d : line) {
+                    max = Math.max(max, d);
+                }
             }
-            for (float d : rgb.b()) {
-                max = Math.max(max, d);
+            for (float[] line : rgb.b()) {
+                for (float d : line) {
+                    max = Math.max(max, d);
+                }
             }
         } else {
             max = Constants.MAX_PIXEL_VALUE;
@@ -501,8 +509,12 @@ public class ImageDraw extends AbstractFunctionImpl {
             var data = mono.data();
             image = new BufferedImage(mono.width(), mono.height(), BufferedImage.TYPE_USHORT_GRAY);
             short[] converted = ((DataBufferUShort) image.getRaster().getDataBuffer()).getData();
-            for (int i = 0; i < converted.length; i++) {
-                converted[i] = (short) round(data[i]);
+            var width = mono.width();
+            var height = mono.height();
+            for (int y = 0; y < height; y++) {
+                for (int x = 0; x < width; x++) {
+                    converted[y*width + x] = (short) round(data[y][x]);
+                }
             }
         } else if (wrapper instanceof RGBImage rgb) {
             image = toBufferedImage(rgb.width(), rgb.height(), rgb.r(), rgb.g(), rgb.b());
@@ -518,14 +530,14 @@ public class ImageDraw extends AbstractFunctionImpl {
         return null;
     }
 
-    private static BufferedImage toBufferedImage(int width, int height, float[] r, float[] g, float[] b) {
+    private static BufferedImage toBufferedImage(int width, int height, float[][] r, float[][] g, float[][] b) {
         BufferedImage image;
         image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
-                int rv = round(r[y * width + x]);
-                int gv = round(g[y * width + x]);
-                int bv = round(b[y * width + x]);
+                int rv = round(r[y][x]);
+                int gv = round(g[y][x]);
+                int bv = round(b[y][x]);
                 rv = (rv >> 8) & 0xFF;
                 gv = (gv >> 8) & 0xFF;
                 bv = (bv >> 8) & 0xFF;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Rotate.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Rotate.java
@@ -65,10 +65,10 @@ public class Rotate extends AbstractFunctionImpl {
     public Object hflip(List<Object> arguments) {
         assertExpectedArgCount(arguments, "hflip takes 1 arguments (image(s))", 1, 1);
         return applyUnary(arguments, "hflip", (width, height, data) -> {
-            var result = new float[width * height];
+            var result = new float[height][width];
             for (var y = 0; y < height; y++) {
                 for (var x = 0; x < width; x++) {
-                    result[y * width + x] = data[y * width + width - x - 1];
+                    result[y][x] = data[y][width - x - 1];
                 }
             }
             System.arraycopy(result, 0, data, 0, result.length);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Saturation.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Saturation.java
@@ -43,13 +43,15 @@ public class Saturation extends AbstractFunctionImpl {
             arg = fileBackedImage.unwrapToMemory();
         }
         if (arg instanceof RGBImage rgb) {
-            var hsl = ImageUtils.fromRGBtoHSL(new float[][]{rgb.r(), rgb.g(), rgb.b()});
+            var hsl = ImageUtils.fromRGBtoHSL(new float[][][]{rgb.r(), rgb.g(), rgb.b()});
             var s = hsl[1];
-            for (int i = 0; i < s.length; i++) {
-                var sat = Math.pow(s[i], exponent);
-                s[i] = (float) sat;
+            for (float[] line : s) {
+                for (int i = 0; i < s.length; i++) {
+                    var sat = Math.pow(line[i], exponent);
+                    line[i] = (float) sat;
+                }
             }
-            var output = new float[3][rgb.r().length];
+            var output = new float[3][rgb.height()][rgb.width()];
             ImageUtils.fromHSLtoRGB(hsl, output);
             return new RGBImage(rgb.width(), rgb.height(), output[0], output[1], output[2], new LinkedHashMap<>(rgb.metadata()));
         }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/SimpleFunctionCall.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/SimpleFunctionCall.java
@@ -81,10 +81,13 @@ public class SimpleFunctionCall extends AbstractFunctionImpl {
             if (images.stream().anyMatch(i -> i.data().length != length || i.width() != width || i.height() != height)) {
                 throw new IllegalArgumentException(name + " function call failed: all images must have the same dimensions");
             }
-            float[] result = new float[length];
-            for (int i = 0; i < length; i++) {
-                var idx = i;
-                result[i] = (float) operator.apply(images.stream().mapToDouble(img -> img.data()[idx])).orElse(0);
+            float[][] result = new float[height][width];
+            for (int y = 0; y < height; y++) {
+                for (int x = 0; x < width; x++) {
+                    int finalY = y;
+                    int finalX = x;
+                    result[y][x] = (float) operator.apply(images.stream().mapToDouble(img -> img.data()[finalY][finalX])).orElse(0);
+                }
             }
             Map<Class<?>, Object> metadata = new HashMap<>();
             CutoffStretchingStrategy.DEFAULT.stretch(new ImageWrapper32(width, height, result, metadata));

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/spectrum/SpectrumAnalyzer.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/spectrum/SpectrumAnalyzer.java
@@ -114,7 +114,7 @@ public class SpectrumAnalyzer {
                                                     int end,
                                                     int width,
                                                     int height,
-                                                    float[] data) {
+                                                    float[][] data) {
         var lambda0 = details.line().wavelength();
         var pixelSize = details.pixelSize();
         var binning = details.binning();
@@ -149,8 +149,8 @@ public class SpectrumAnalyzer {
                 int upperNy = (int) Math.ceil(exactNy);
 
                 if (lowerNy >= 0 && upperNy < height) {
-                    var lowerValue = data[width * lowerNy + x];
-                    var upperValue = data[width * upperNy + x];
+                    var lowerValue = data[lowerNy][x];
+                    var upperValue = data[upperNy][x];
                     var interpolatedValue = lowerValue + (upperValue - lowerValue) * (exactNy - lowerNy);
 
                     val += interpolatedValue;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/ClaheStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/ClaheStrategy.java
@@ -65,8 +65,7 @@ public final class ClaheStrategy implements StretchingStrategy {
         }
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
-                int offset = x + y * width;
-                float src = data[offset];
+                float src = data[y][x];
                 int bin = findHistogramBin(src);
                 int tileX = x / tileSize;
                 int tileY = y / tileSize;
@@ -145,7 +144,7 @@ public final class ClaheStrategy implements StretchingStrategy {
                     y2 = y1 + tileSize;
                     interpolatedValue = bilinearInterpolation(v11, v12, v21, v22, x1, y1, x2, y2, x, y);
                 }
-                data[offset] = MAX_PIXEL_VALUE * interpolatedValue;
+                data[y][x] = MAX_PIXEL_VALUE * interpolatedValue;
             }
         }
     }
@@ -220,7 +219,7 @@ public final class ClaheStrategy implements StretchingStrategy {
         return new CumulativeDistributionFunction(cumulative);
     }
 
-    private Histogram histogram(int width, int height, float[] data, int tileX, int tileY, int tileSize) {
+    private Histogram histogram(int width, int height, float[][] data, int tileX, int tileY, int tileSize) {
         int[] histogram = new int[bins];
         int xStart = tileX * tileSize;
         int xEnd = Math.min(width, (tileX + 1) * tileSize);
@@ -230,7 +229,7 @@ public final class ClaheStrategy implements StretchingStrategy {
         int max = -1;
         for (int y = yStart; y < yEnd; y++) {
             for (int x = xStart; x < xEnd; x++) {
-                float src = data[x + y * width];
+                float src = data[y][x];
                 int bin = findHistogramBin(src);
                 histogram[bin]++;
                 size++;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/ContrastAdjustmentStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/ContrastAdjustmentStrategy.java
@@ -48,20 +48,24 @@ public final class ContrastAdjustmentStrategy implements StretchingStrategy {
         truncate(data);
     }
 
-    private void truncate(float[] data) {
-        for (int i = 0; i < data.length; i++) {
-            if (data[i] < min) {
-                data[i] = 0;
-            } else if (data[i] > max) {
-                data[i] = max;
+    private void truncate(float[][] data) {
+        for (int y = 0; y < data.length; y++) {
+            var line = data[y];
+            for (int x = 0; x < line.length; x++) {
+                float v = line[x];
+                if (v < min) {
+                    line[x] = 0;
+                } else if (v > max) {
+                    line[x] = max;
+                }
             }
         }
     }
 
     @Override
     public void stretch(RGBImage image) {
-       truncate(image.r());
-       truncate(image.g());
-       truncate(image.b());
+        truncate(image.r());
+        truncate(image.g());
+        truncate(image.b());
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/CutoffStretchingStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/CutoffStretchingStrategy.java
@@ -55,11 +55,15 @@ public final class CutoffStretchingStrategy implements StretchingStrategy {
     @Override
     public void stretch(ImageWrapper32 image) {
         var data = image.data();
-        for (int i = 0; i < data.length; i++) {
-            if (data[i] < min) {
-                data[i] = zeroFill;
-            } else if (data[i] > max) {
-                data[i] = maxFill;
+        var height = image.height();
+        var width = image.width();
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                if (data[y][x] < min) {
+                    data[y][x] = zeroFill;
+                } else if (data[y][x] > max) {
+                    data[y][x] = maxFill;
+                }
             }
         }
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/DynamicStretchStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/DynamicStretchStrategy.java
@@ -52,9 +52,13 @@ public final class DynamicStretchStrategy implements StretchingStrategy {
         }
         var fit = PolynomialCurveFitter.create(4).fit(observations);
         var poly = new PolynomialFunction(fit);
-        for (int i = 0; i < data.length; i++) {
-            var v = data[i];
-            data[i] = (float) Math.clamp(poly.value(v), 0, MAX_PIXEL_VALUE);
+        var height = image.height();
+        var width = image.width();
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                var v = data[y][x];
+                data[y][x] = (float) Math.clamp(poly.value(v), 0, MAX_PIXEL_VALUE);
+            }
         }
         LinearStrechingStrategy.DEFAULT.stretch(image);
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/GammaStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/GammaStrategy.java
@@ -34,14 +34,21 @@ public final class GammaStrategy implements StretchingStrategy {
     public void stretch(ImageWrapper32 image) {
         var data = image.data();
         float max = 1e-7f;
-        for (float v : data) {
-            max = Math.max(v, max);
+        int width = image.width();
+        var height = image.height();
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                var v = data[y][x];
+                max = Math.max(v, max);
+            }
         }
-        for (int i = 0; i < data.length; i++) {
-            var v = data[i];
-            float normalized = v / max;
-            float corrected = (float) Math.pow(normalized, gamma);
-            data[i] = corrected * Constants.MAX_PIXEL_VALUE;
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                var v = data[y][x];
+                float normalized = v / max;
+                float corrected = (float) Math.pow(normalized, gamma);
+                data[y][x] = corrected * Constants.MAX_PIXEL_VALUE;
+            }
         }
     }
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/LinearStrechingStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/LinearStrechingStrategy.java
@@ -46,37 +46,43 @@ public final class LinearStrechingStrategy implements StretchingStrategy {
         if (range == 0) {
             return;
         }
-        rescale(data, range, min);
+        rescale(data, image.width(), image.height(), range, min);
     }
 
-    private void rescale(float[] data, double range, double min) {
-        for (int i = 0; i < data.length; i++) {
-            float v = (float) (hi / range * (data[i] - min));
-            data[i] = v;
+    private void rescale(float[][] data, int width, int height, double range, double min) {
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                float v = (float) (hi / range * (data[y][x] - min));
+                data[y][x] = v;
+            }
         }
     }
 
-    private double min(float[] array) {
+    private double min(float[][] array) {
         if (array.length == 0) {
             return lo;
         }
         double min = Double.MAX_VALUE;
-        for (float v : array) {
-            if (v < min) {
-                min = v;
+        for (float[] line : array) {
+            for (float v : line) {
+                if (v < min) {
+                    min = v;
+                }
             }
         }
         return min;
     }
 
-    private double max(float[] array) {
+    private double max(float[][] array) {
         if (array.length == 0) {
             return hi;
         }
         double max = -Double.MAX_VALUE;
-        for (float v : array) {
-            if (v > max) {
-                max = v;
+        for (float[] line : array) {
+            for (float v : line) {
+                if (v > max) {
+                    max = v;
+                }
             }
         }
         return max;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/NegativeImageStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/NegativeImageStrategy.java
@@ -28,11 +28,17 @@ public final class NegativeImageStrategy implements StretchingStrategy {
     public void stretch(ImageWrapper32 image) {
         var data = image.data();
         float max = 0;
-        for (float v : data) {
-            max = Math.max(max, v);
+        var height = image.height();
+        var width = image.width();
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                max = Math.max(max, data[y][x]);
+            }
         }
-        for (int i = 0; i < data.length; i++) {
-            data[i] = max - data[i];
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                data[y][x] = max - data[y][x];
+            }
         }
     }
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/RangeExpansionStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/RangeExpansionStrategy.java
@@ -30,13 +30,20 @@ public final class RangeExpansionStrategy implements StretchingStrategy {
     public void stretch(ImageWrapper32 image) {
         var data = image.data();
         double max = -Double.MAX_VALUE;
-        for (float v : data) {
-            if (v > max) {
-                max = v;
+        var height = image.height();
+        var width = image.width();
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                var v = data[y][x];
+                if (v > max) {
+                    max = v;
+                }
             }
         }
-        for (int i = 0; i < data.length; i++) {
-            data[i] = (float) ((MAX_VALUE / max) * data[i]);
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                data[y][x] = (float) ((MAX_VALUE / max) * data[y][x]);
+            }
         }
     }
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/StretchingStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/StretchingStrategy.java
@@ -50,16 +50,22 @@ public sealed interface StretchingStrategy permits
         var r = image.r();
         var g = image.g();
         var b = image.b();
-        var rgb = new float[][]{r, g, b};
-        float[][] hsl = ImageUtils.fromRGBtoHSL(rgb);
+        var rgb = new float[][][]{r, g, b};
+        float[][][] hsl = ImageUtils.fromRGBtoHSL(rgb);
         var lightness = hsl[2];
-        float[] rescaledL = new float[lightness.length];
-        for (int i = 0; i < lightness.length; i++) {
-            rescaledL[i] = lightness[i] * 65535f;
+        int height = hsl[0].length;
+        int width = hsl[0][0].length;
+        float[][] rescaledL = new float[height][width];
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                rescaledL[y][x] = lightness[y][x] * 65535f;
+            }
         }
         stretch(new ImageWrapper32(image.width(), image.height(), rescaledL, image.metadata()));
-        for (int i = 0; i < rescaledL.length; i++) {
-            lightness[i] = rescaledL[i] / 65535f;
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                lightness[y][x] = rescaledL[y][x] / 65535f;
+            }
         }
         ImageUtils.fromHSLtoRGB(hsl, rgb);
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/AverageImageCreator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/AverageImageCreator.java
@@ -33,12 +33,12 @@ import static me.champeau.a4j.jsolex.processing.util.Constants.message;
  * to a threshold.
  */
 public class AverageImageCreator {
-    private final ImageConverter<float[]> imageConverter;
+    private final ImageConverter<float[][]> imageConverter;
     private final Broadcaster broadcaster;
 
-    private float[] averageImage;
+    private float[][] averageImage;
 
-    public AverageImageCreator(ImageConverter<float[]> imageConverter,
+    public AverageImageCreator(ImageConverter<float[][]> imageConverter,
                                Broadcaster broadcaster) {
         this.imageConverter = imageConverter;
         this.broadcaster = broadcaster;
@@ -49,7 +49,7 @@ public class AverageImageCreator {
         ImageGeometry geometry = reader.header().geometry();
         var limbDetectionMessage = message("computing.average.image.limb.detect");
         var imageMath = ImageMath.newInstance();
-        averageImage = new float[geometry.width() * geometry.height()];
+        averageImage = new float[geometry.height()][geometry.width()];
         var counter = new AtomicInteger(0);
         // we start with sampling frames to find the one with the maximum intensity
         var sampling = Math.max(10, frameCount / 100);
@@ -93,7 +93,7 @@ public class AverageImageCreator {
         }
     }
 
-    public float[] getAverageImage() {
+    public float[][] getAverageImage() {
         return averageImage;
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/DistortionCorrection.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/DistortionCorrection.java
@@ -20,11 +20,11 @@ import me.champeau.a4j.math.image.Image;
 import java.util.function.DoubleUnaryOperator;
 
 public class DistortionCorrection {
-    private final float[] data;
+    private final float[][] data;
     private final int width;
     private final int height;
 
-    public DistortionCorrection(float[] data, int width, int height) {
+    public DistortionCorrection(float[][] data, int width, int height) {
         this.data = data;
         this.width = width;
         this.height = height;
@@ -42,7 +42,7 @@ public class DistortionCorrection {
      * @param p the coefficients of the polynomial
      * @return the corrected image
      */
-    public float[] polynomialCorrection(DoubleUnaryOperator p) {
+    public float[][] polynomialCorrection(DoubleUnaryOperator p) {
         return polynomialCorrection2(p, false);
     }
 
@@ -64,7 +64,7 @@ public class DistortionCorrection {
         for (int y = 0; y < height; y++) {
             boolean allPositive = true;
             for (int x = 0; x < width; x++) {
-                if (corrected[x + y * width] < 0) {
+                if (corrected[y][x] < 0) {
                     allPositive = false;
                     break;
                 }
@@ -78,7 +78,7 @@ public class DistortionCorrection {
         for (int y = height - 1; y >= 0; y--) {
             boolean allPositive = true;
             for (int x = 0; x < width; x++) {
-                if (corrected[x + y * width] < 0) {
+                if (corrected[y][x] < 0) {
                     allPositive = false;
                     break;
                 }
@@ -89,24 +89,22 @@ public class DistortionCorrection {
             }
         }
         int newHeight = maxY - minY;
-        float[] result = new float[width * newHeight];
+        float[][] result = new float[newHeight][width];
         for (int y = minY; y < maxY; y++) {
-            for (int x = 0; x < width; x++) {
-                result[x + (y - minY) * width] = corrected[x + y * width];
-            }
+            System.arraycopy(corrected[y], 0, result[(y - minY)], 0, width);
         }
         return new Image(width, newHeight, result);
     }
 
-    private float[] polynomialCorrection2(DoubleUnaryOperator p, boolean mark) {
-        float[] correctedImage = new float[data.length];
+    private float[][] polynomialCorrection2(DoubleUnaryOperator p, boolean mark) {
+        float[][] correctedImage = new float[height][width];
         double middle = height / 2.0;
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
                 // The amount of pixels that we need to shift the spectrum line vertically
                 double yCorrection = -p.applyAsDouble(x) + middle;
 
-                correctedImage[y * width + x] = (float) bilinearInterpolation(x, y - yCorrection, mark);
+                correctedImage[y][x] = (float) bilinearInterpolation(x, y - yCorrection, mark);
             }
         }
 
@@ -167,7 +165,7 @@ public class DistortionCorrection {
             }
             y = height - 1;
         }
-        return data[y * width + x];
+        return data[y][x];
     }
 
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/FlatCorrection.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/FlatCorrection.java
@@ -62,7 +62,7 @@ public class FlatCorrection {
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
                 if (ellipse.isWithin(x, y)) {
-                    var v = data[x + y * width];
+                    var v = data[y][x];
                     builder.record(v);
                     minX = Math.min(minX, x);
                     maxX = Math.max(maxX, x);
@@ -82,7 +82,7 @@ public class FlatCorrection {
             double count = 0;
             for (int x = 0; x < width; x++) {
                 if (ellipse.isWithin(x, y)) {
-                    var v = data[x + y * width];
+                    var v = data[y][x];
                     if (v > lo && v < hi) {
                         total += v;
                         count++;
@@ -132,12 +132,11 @@ public class FlatCorrection {
         int width = source.width();
         int height = source.height();
         var data = source.data();
-        var outData = new float[data.length];
+        var outData = new float[height][width];
         for (int y = 0; y < height; y++) {
             var correction = normalized[y];
             for (int x = 0; x < width; x++) {
-                var idx = x + y * width;
-                outData[idx] = (float) (data[idx] / correction);
+                outData[y][x] = (float) (data[y][x] / correction);
             }
         }
         return new ImageWrapper32(width, height, outData, new HashMap<>(source.metadata()));

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SpectrumFrameAnalyzer.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SpectrumFrameAnalyzer.java
@@ -35,7 +35,7 @@ public class SpectrumFrameAnalyzer {
     private final Double sunDetectionThreshold;
 
     private Result result;
-    private float[] data;
+    private float[][] data;
 
     public SpectrumFrameAnalyzer(int width,
                                  int height,
@@ -49,7 +49,7 @@ public class SpectrumFrameAnalyzer {
         return result;
     }
 
-    public Result analyze(float[] data) {
+    public Result analyze(float[][] data) {
         reset();
         this.data = data;
         if (sunDetectionThreshold != null) {
@@ -67,7 +67,7 @@ public class SpectrumFrameAnalyzer {
         for (int x = 0; x < width; x++) {
             double colSum = 0;
             for (int y = 0; y < height; y++) {
-                double value = data[y * width + x];
+                double value = data[y][x];
                 colSum += value;
             }
             columnAverages[x] = colSum / height;
@@ -98,7 +98,7 @@ public class SpectrumFrameAnalyzer {
         for (int x = 0; x < width; x++) {
             double lineAvg = 0;
             for (int y = 0; y < height; y++) {
-                double value = data[y * width + x];
+                double value = data[y][x];
                 lineAvg = lineAvg + (value - lineAvg) / (y + 1);
             }
             if (lineAvg > sunDetectionThreshold) {
@@ -115,12 +115,12 @@ public class SpectrumFrameAnalyzer {
         result = null;
     }
 
-    private int findYAtMinimalValue(float[] data, int x) {
+    private int findYAtMinimalValue(float[][] data, int x) {
         int minY = 0;
         double min = Double.MAX_VALUE;
         var margin = Math.min(height, 1);
         for (int y = margin; y < height - margin; y++) {
-            double value = data[y * width + x];
+            double value = data[y][x];
             if (value < min) {
                 minY = y;
                 min = value;
@@ -166,7 +166,7 @@ public class SpectrumFrameAnalyzer {
                 if (y >= 0) {
                     var yy = polynomial.applyAsDouble(x);
                     if (Math.abs(yy - y) <= range) {
-                        sampleToValue.put(new Point2D(x, y), data[y * width + x]);
+                        sampleToValue.put(new Point2D(x, y), data[y][x]);
                     }
                 }
             }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/align/HessianBoxFilter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/align/HessianBoxFilter.java
@@ -158,14 +158,14 @@ public class HessianBoxFilter {
     public HessianFilterResponse apply(int boxSize) {
         var width = integralImage.width();
         var height = integralImage.height();
-        var determinants = new float[width * height];
-        var laplacians = new byte[width * height];
+        var determinants = new float[height][width];
+        var laplacians = new byte[height][width];
         float max = 0;
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
                 var current = determinantAndLaplacian(x, y, boxSize);
-                determinants[x + y * width] = current.determinant;
-                laplacians[x + y * width] = current.laplacian;
+                determinants[y][x] = current.determinant;
+                laplacians[y][x] = current.laplacian;
                 if (current.determinant > max) {
                     max = current.determinant;
                 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/align/HessianFilterResponse.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/align/HessianFilterResponse.java
@@ -21,6 +21,6 @@ public record HessianFilterResponse(
         int boxSize,
         Image determinants,
         float maxValue,
-        byte[] laplacian
+        byte[][] laplacian
 ) {
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/crop/Cropper.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/crop/Cropper.java
@@ -57,14 +57,16 @@ public class Cropper {
         }
         LOGGER.info(message("diameter"), String.format("%.2f", diameter));
         var half = square / 2;
-        var cropped = new float[square * square];
-        Arrays.fill(cropped, blackPoint);
+        var cropped = new float[square][square];
+        for (float[] floats : cropped) {
+            Arrays.fill(floats, blackPoint);
+        }
         for (int yy = 0; yy < square; yy++) {
             for (int xx = 0; xx < square; xx++) {
                 int sourceX = (int) cx - half + xx;
                 int sourceY = (int) cy - half + yy;
                 if (sourceX >= 0 && sourceY >= 0 && sourceX < width && sourceY < height) {
-                    cropped[xx + yy * square] = source[sourceX + sourceY * width];
+                    cropped[yy][xx] = source[sourceY][sourceX];
                 }
             }
         }
@@ -83,14 +85,16 @@ public class Cropper {
         var cy = center.b();
         var offsetX = width / 2;
         var offsetY = height / 2;
-        var cropped = new float[width * height];
-        Arrays.fill(cropped, blackPoint);
+        var cropped = new float[height][width];
+        for (float[] line : cropped) {
+            Arrays.fill(line, blackPoint);
+        }
         for (int yy = 0; yy < height; yy++) {
             for (int xx = 0; xx < width; xx++) {
                 int sourceX = (int) cx - offsetX + xx;
                 int sourceY = (int) cy - offsetY + yy;
                 if (sourceX >= 0 && sourceY >= 0 && sourceX < sourceWidth && sourceY < sourceHeight) {
-                    cropped[xx + yy * width] = source[sourceX + sourceY * sourceWidth];
+                    cropped[yy][xx] = source[sourceY][sourceX];
                 }
             }
         }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/AbstractTask.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/AbstractTask.java
@@ -69,7 +69,7 @@ public abstract class AbstractTask<T> implements Callable<T>, Supplier<T> {
     /**
      * Returns this task image buffer
      */
-    public final float[] getBuffer() {
+    public final float[][] getBuffer() {
         return workImage.data();
     }
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/CoronagraphTask.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/CoronagraphTask.java
@@ -15,6 +15,7 @@
  */
 package me.champeau.a4j.jsolex.processing.sun.tasks;
 
+import me.champeau.a4j.jsolex.processing.expr.impl.DiskFill;
 import me.champeau.a4j.jsolex.processing.stretching.ArcsinhStretchingStrategy;
 import me.champeau.a4j.jsolex.processing.sun.BackgroundRemoval;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
@@ -39,7 +40,7 @@ public class CoronagraphTask extends AbstractTask<ImageWrapper32> {
     @Override
     protected ImageWrapper32 doCall() throws Exception {
         var buffer = getBuffer();
-        fill(fitting, buffer, width, 0);
+        DiskFill.doFill(fitting, buffer, 0, null);
         for (int i=0;i<2;i++) {
             workImage = BackgroundRemoval.neutralizeBackground(workImage);
         }
@@ -47,17 +48,6 @@ public class CoronagraphTask extends AbstractTask<ImageWrapper32> {
         new ArcsinhStretchingStrategy(0, 50, 50).stretch(workImage);
         workImage = new ImageWrapper32(width, height, buffer, workImage.metadata());
         return workImage;
-    }
-
-    private void fill(Ellipse ellipse, float[] image, int width, int color) {
-        int height = image.length / width;
-        for (int x = 0; x < width; x++) {
-            for (int y = 0; y < height; y++) {
-                if (ellipse.isWithin(x, y)) {
-                    image[x + y * width] = color;
-                }
-            }
-        }
     }
 
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/GeometryCorrector.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/GeometryCorrector.java
@@ -95,11 +95,11 @@ public class GeometryCorrector extends AbstractTask<GeometryCorrector.Result> {
         LOGGER.debug("a = {}, b={}, theta={}", a, b, theta);
         var maxDx = height * shear;
         var shift = maxDx < 0 ? maxDx : 0;
-        float[] newBuffer;
+        float[][] newBuffer;
         int extendedWidth;
         var buffer = getBuffer();
         extendedWidth = width + (int) Math.ceil(Math.abs(maxDx));
-        newBuffer = new float[height * extendedWidth];
+        newBuffer = new float[height][extendedWidth];
         for (int y = 0; y < height; y++) {
             var dx = y * shear;
             for (int x = 0; x < width; x++) {
@@ -108,17 +108,17 @@ public class GeometryCorrector extends AbstractTask<GeometryCorrector.Result> {
                 var x2 = x1 + 1;
                 var factor = nx - x1;
                 if (x1 >= 0 && x2 < extendedWidth) {
-                    newBuffer[x1 + y * extendedWidth] += (1 - factor) * buffer[x + y * width];
-                    newBuffer[x2 + y * extendedWidth] += factor * buffer[x + y * width];
+                    newBuffer[y][x1] += (1 - factor) * buffer[y][x];
+                    newBuffer[y][x2] += factor * buffer[y][x];
                 }
                 // reduce transform artifacts by filling with same border color
                 if (x == 0) {
                     for (int k = 0; k < nx; k++) {
-                        newBuffer[k + y * extendedWidth] = buffer[x + y * width];
+                        newBuffer[y][k] = buffer[y][x];
                     }
                 } else if (x == width - 1) {
                     for (int k = (int) nx; k < extendedWidth; k++) {
-                        newBuffer[k + y * extendedWidth] = buffer[x + y * width];
+                        newBuffer[y][k] = buffer[y][x];
                     }
                 }
             }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/ImageAnalysis.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/ImageAnalysis.java
@@ -28,29 +28,33 @@ import me.champeau.a4j.math.regression.Ellipse;
  */
 public record ImageAnalysis(float avg, float stddev, float min, float max, Histogram histogram) {
 
-    public static ImageAnalysis of(float[] array) {
+    public static ImageAnalysis of(float[][] array) {
         float min = Float.MAX_VALUE;
         float max = Float.MIN_VALUE;
         float sum = 0.0f;
         var builder = Histogram.builder(65536);
-
-        int n = array.length;
-        for (float v : array) {
-            sum += v;
-            min = Math.min(min, v);
-            max = Math.max(max, v);
-            builder.record(v);
+        int n = 0;
+        for (float[] line : array) {
+            for (float v : line) {
+                sum += v;
+                n++;
+                min = Math.min(min, v);
+                max = Math.max(max, v);
+                builder.record(v);
+            }
         }
         float average = sum / n;
         float stddev = 0;
-        for (float v : array) {
-            stddev += (v - average) * (v - average);
+        for (float[] line : array) {
+            for (float v : line) {
+                stddev += (v - average) * (v - average);
+            }
         }
         stddev = (float) Math.sqrt(stddev / (n - 1));
         return new ImageAnalysis(average, stddev, min, max, builder.build());
     }
 
-    public static ImageAnalysis masked(float[] array, int width, int height, Ellipse e) {
+    public static ImageAnalysis masked(float[][] array, int width, int height, Ellipse e) {
         float min = Float.MAX_VALUE;
         float max = Float.MIN_VALUE;
         float sum = 0.0f;
@@ -61,7 +65,7 @@ public record ImageAnalysis(float avg, float stddev, float min, float max, Histo
             for (int x = 0; x < width; x++) {
                 if (e.isWithin(x, y)) {
                     n++;
-                    var v = array[y * width + x];
+                    var v = array[y][x];
                     sum += v;
                     min = Math.min(min, v);
                     max = Math.max(max, v);
@@ -71,8 +75,10 @@ public record ImageAnalysis(float avg, float stddev, float min, float max, Histo
         }
         float average = sum / n;
         float stddev = 0;
-        for (float v : array) {
-            stddev += (v - average) * (v - average);
+        for (float[] line : array) {
+            for (float v : line) {
+                stddev += (v - average) * (v - average);
+            }
         }
         stddev = (float) Math.sqrt(stddev / (n - 1));
         return new ImageAnalysis(average, stddev, min, max, builder.build());

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/WriteColorizedImageTask.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/WriteColorizedImageTask.java
@@ -27,7 +27,7 @@ import java.util.function.Supplier;
 
 public class WriteColorizedImageTask extends AbstractImageWriterTask {
     private final Supplier<ImageWrapper32> mono;
-    private final Function<ImageWrapper32, float[][]> converter;
+    private final Function<ImageWrapper32, float[][][]> converter;
 
     public WriteColorizedImageTask(Broadcaster broadcaster,
                                    Supplier<ImageWrapper32> image,
@@ -35,7 +35,7 @@ public class WriteColorizedImageTask extends AbstractImageWriterTask {
                                    String title,
                                    String name,
                                    GeneratedImageKind kind,
-                                   Function<ImageWrapper32, float[][]> converter) {
+                                   Function<ImageWrapper32, float[][][]> converter) {
         super(broadcaster, image, outputDirectory, title, name, kind);
         this.mono = image;
         this.converter = converter;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/WriteRGBImageTask.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/WriteRGBImageTask.java
@@ -25,7 +25,7 @@ import java.io.File;
 import java.util.function.Supplier;
 
 public class WriteRGBImageTask extends AbstractImageWriterTask {
-    private final Supplier<float[][]> supplier;
+    private final Supplier<float[][][]> supplier;
 
     public WriteRGBImageTask(Broadcaster broadcaster,
                              Supplier<ImageWrapper32> ref,
@@ -33,7 +33,7 @@ public class WriteRGBImageTask extends AbstractImageWriterTask {
                              String title,
                              String name,
                              GeneratedImageKind kind,
-                             Supplier<float[][]> supplier) {
+                             Supplier<float[][][]> supplier) {
         super(broadcaster, ref, outputDirectory, title, name, kind);
         this.supplier = supplier;
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/AnalysisUtils.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/AnalysisUtils.java
@@ -31,7 +31,7 @@ public class AnalysisUtils {
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
                 if (!ellipse.isWithin(x, y)) {
-                    var v = buffer[x + y * width];
+                    var v = buffer[y][x];
                     if (v > 0) {
                         var offcenter = 2 * Math.sqrt((x - cx) * (x - cx) + (y - cy) * (y - cy)) / (width + height);
                         blackEstimate = blackEstimate + (offcenter * v - blackEstimate) / (++cpt);
@@ -51,7 +51,7 @@ public class AnalysisUtils {
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
                 if (!ellipse.isWithin(x, y)) {
-                    var v = buffer[x + y * width];
+                    var v = buffer[y][x];
                     if (v > 0) {
                         avg = avg + (v - avg) / (++cpt);
                     }
@@ -61,15 +61,15 @@ public class AnalysisUtils {
         return avg;
     }
 
-    public static float estimateSignalLevel(float[] data) {
+    public static float estimateSignalLevel(float[][] data) {
         return estimateSignalLevel(data, 32);
     }
 
-    public static float estimateBackgroundLevel(float[] data) {
+    public static float estimateBackgroundLevel(float[][] data) {
         return estimateBackgroundLevel(data, 64);
     }
 
-    public static float estimateBackgroundLevel(float[] data, int bins) {
+    public static float estimateBackgroundLevel(float[][] data, int bins) {
         var h = Histogram.of(data, bins);
         var values = h.values();
         float cur = values[0];
@@ -89,7 +89,7 @@ public class AnalysisUtils {
         return (65535f * idx) / bins;
     }
 
-    public static float estimateSignalLevel(float[] data, int bins) {
+    public static float estimateSignalLevel(float[][] data, int bins) {
         var h = Histogram.of(data, bins);
         var values = h.values();
         float cur = values[0];

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DefaultImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DefaultImageEmitter.java
@@ -54,7 +54,7 @@ public class DefaultImageEmitter implements ImageEmitter {
     }
 
     @Override
-    public void newMonoImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Consumer<? super float[]> bufferConsumer) {
+    public void newMonoImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Consumer<? super float[][]> bufferConsumer) {
         prepareOutput(name);
         storeMetadata(kind, title, name, image);
         new WriteMonoImageTask(broadcaster,
@@ -97,7 +97,7 @@ public class DefaultImageEmitter implements ImageEmitter {
     }
 
     @Override
-    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier) {
+    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][][]> rgbSupplier) {
         prepareOutput(name);
         storeMetadata(kind, title, name, image);
         new WriteColorizedImageTask(broadcaster,
@@ -110,7 +110,7 @@ public class DefaultImageEmitter implements ImageEmitter {
     }
 
     @Override
-    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
+    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
         newColorImage(kind, null, title, name, image, img -> {
             var rgb = rgbSupplier.apply(img);
             var r = rgb[0];
@@ -126,16 +126,16 @@ public class DefaultImageEmitter implements ImageEmitter {
             );
             var draw = new ImageDraw(Map.of(), broadcaster);
             RGBImage color = (RGBImage) draw.drawOnImage(copy, painter);
-            return new float[][]{color.r(), color.g(), color.b()};
+            return new float[][][]{color.r(), color.g(), color.b()};
         });
     }
 
     @Override
-    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][]> rgbSupplier) {
+    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][][]> rgbSupplier) {
         prepareOutput(name);
         new WriteRGBImageTask(broadcaster,
             () -> {
-                var image = new ImageWrapper32(width, height, new float[0], new HashMap<>(metadata));
+                var image = new ImageWrapper32(width, height, new float[0][], new HashMap<>(metadata));
                 storeMetadata(kind, title, name, image);
                 return image;
             },

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DiscardNonRequiredImages.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DiscardNonRequiredImages.java
@@ -40,7 +40,7 @@ public class DiscardNonRequiredImages implements ImageEmitter {
     }
 
     @Override
-    public void newMonoImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Consumer<? super float[]> bufferConsumer) {
+    public void newMonoImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Consumer<? super float[][]> bufferConsumer) {
         if (discard(kind)) {
             return;
         }
@@ -60,7 +60,7 @@ public class DiscardNonRequiredImages implements ImageEmitter {
     }
 
     @Override
-    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier) {
+    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][][]> rgbSupplier) {
         if (discard(kind)) {
             return;
         }
@@ -68,7 +68,7 @@ public class DiscardNonRequiredImages implements ImageEmitter {
     }
 
     @Override
-    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][]> rgbSupplier) {
+    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][][]> rgbSupplier) {
         if (discard(kind)) {
             return;
         }
@@ -76,7 +76,7 @@ public class DiscardNonRequiredImages implements ImageEmitter {
     }
 
     @Override
-    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
+    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
         if (discard(kind)) {
             return;
         }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/HeliumLineProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/HeliumLineProcessor.java
@@ -80,7 +80,7 @@ public class HeliumLineProcessor {
             imageEmitter.newMonoImage(GeneratedImageKind.GEOMETRY_CORRECTED_PROCESSED, "helium", message("helium.d3.direct"), "helium-direct", direct);
             if (evaluator.functionCall(BuiltinFunction.COLORIZE, List.of(direct, colorProfile)) instanceof RGBImage colorized) {
                 imageEmitter.newColorImage(GeneratedImageKind.COLORIZED, "helium",
-                    message("helium.d3.direct.colorized"), "helium-direct-colorized", colorized.width(), colorized.height(), new HashMap<>(colorized.metadata()), () -> new float[][] { colorized.r(), colorized.g(), colorized.b() });
+                    message("helium.d3.direct.colorized"), "helium-direct-colorized", colorized.width(), colorized.height(), new HashMap<>(colorized.metadata()), () -> new float[][][] { colorized.r(), colorized.g(), colorized.b() });
             }
         }
         var continuum = evaluator.createContinuumImage();
@@ -94,7 +94,7 @@ public class HeliumLineProcessor {
             imageEmitter.newMonoImage(GeneratedImageKind.GEOMETRY_CORRECTED_PROCESSED, "helium", message("helium.d3.processed"), "helium-extracted", image);
             if (evaluator.functionCall(BuiltinFunction.COLORIZE, List.of(image, colorProfile)) instanceof RGBImage colorized) {
                 imageEmitter.newColorImage(GeneratedImageKind.COLORIZED, "helium",
-                    message("helium.d3.processed.colorized"), "helium-extracted-colorized", image.width(), image.height(), new HashMap<>(image.metadata()), () -> new float[][] { colorized.r(), colorized.g(), colorized.b() });
+                    message("helium.d3.processed.colorized"), "helium-extracted-colorized", image.width(), image.height(), new HashMap<>(image.metadata()), () -> new float[][][] { colorized.r(), colorized.g(), colorized.b() });
             }
         }
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ImageEmitter.java
@@ -27,15 +27,15 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public interface ImageEmitter {
-    void newMonoImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Consumer<? super float[]> bufferConsumer);
+    void newMonoImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Consumer<? super float[][]> bufferConsumer);
 
     void newMonoImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image);
 
-    void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier);
+    void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][][]> rgbSupplier);
 
-    void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter);
+    void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter);
 
-    void newColorImage(GeneratedImageKind kind, String category, String title, String name, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][]> rgbSupplier);
+    void newColorImage(GeneratedImageKind kind, String category, String title, String name, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][][]> rgbSupplier);
 
     void newGenericFile(GeneratedImageKind kind, String category, String title, String name, Path file);
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/NamingStrategyAwareImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/NamingStrategyAwareImageEmitter.java
@@ -51,7 +51,7 @@ public class NamingStrategyAwareImageEmitter implements ImageEmitter {
     }
 
     @Override
-    public void newMonoImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Consumer<? super float[]> bufferConsumer) {
+    public void newMonoImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Consumer<? super float[][]> bufferConsumer) {
         delegate.newMonoImage(kind, null, title, rename(name, category), image, bufferConsumer);
     }
 
@@ -61,17 +61,17 @@ public class NamingStrategyAwareImageEmitter implements ImageEmitter {
     }
 
     @Override
-    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier) {
+    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][][]> rgbSupplier) {
         delegate.newColorImage(kind, null, title, rename(name, category), image, rgbSupplier);
     }
 
     @Override
-    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][]> rgbSupplier) {
+    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][][]> rgbSupplier) {
         delegate.newColorImage(kind, null, title, rename(name, category), width, height, metadata, rgbSupplier);
     }
 
     @Override
-    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
+    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
         delegate.newColorImage(kind, null, title, rename(name, category), image, rgbSupplier, painter);
     }
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/NoOpImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/NoOpImageEmitter.java
@@ -32,7 +32,7 @@ import java.util.function.Supplier;
 public class NoOpImageEmitter implements ImageEmitter {
 
     @Override
-    public void newMonoImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Consumer<? super float[]> bufferConsumer) {
+    public void newMonoImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Consumer<? super float[][]> bufferConsumer) {
     }
 
     @Override
@@ -40,16 +40,16 @@ public class NoOpImageEmitter implements ImageEmitter {
     }
 
     @Override
-    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier) {
+    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][][]> rgbSupplier) {
     }
 
     @Override
-    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
+    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
 
     }
 
     @Override
-    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][]> rgbSupplier) {
+    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][][]> rgbSupplier) {
     }
 
     @Override

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/RenamingImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/RenamingImageEmitter.java
@@ -42,7 +42,7 @@ public class RenamingImageEmitter implements ImageEmitter {
     }
 
     @Override
-    public void newMonoImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Consumer<? super float[]> bufferConsumer) {
+    public void newMonoImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Consumer<? super float[][]> bufferConsumer) {
         delegate.newMonoImage(kind, null, titleRenamer.apply(title), fileRenamer.apply(name), image, bufferConsumer);
     }
 
@@ -52,17 +52,17 @@ public class RenamingImageEmitter implements ImageEmitter {
     }
 
     @Override
-    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier) {
+    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][][]> rgbSupplier) {
         delegate.newColorImage(kind, null, titleRenamer.apply(title), fileRenamer.apply(name), image, rgbSupplier);
     }
 
     @Override
-    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
+    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, ImageWrapper32 image, Function<ImageWrapper32, float[][][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
         delegate.newColorImage(kind, null, titleRenamer.apply(title), fileRenamer.apply(name), image, rgbSupplier, painter);
     }
 
     @Override
-    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][]> rgbSupplier) {
+    public void newColorImage(GeneratedImageKind kind, String category, String title, String name, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][][]> rgbSupplier) {
         delegate.newColorImage(kind, null, titleRenamer.apply(title), fileRenamer.apply(name), width, height, metadata, rgbSupplier);
     }
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/DebugImageHelper.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/DebugImageHelper.java
@@ -52,9 +52,9 @@ public class DebugImageHelper {
         }
     }
 
-    private static void produceOverlayImage(ImageEmitter processedImagesEmitter, int width, int height, float[] newData, float[] original, Map<Class<?>, Object> metadata) {
+    private static void produceOverlayImage(ImageEmitter processedImagesEmitter, int width, int height, float[][] newData, float[][] original, Map<Class<?>, Object> metadata) {
         processedImagesEmitter.newColorImage(GeneratedImageKind.DEBUG, null, message("tilt.detection"), "tilt", width, height, metadata, () -> {
-            float[][] rgb = new float[3][];
+            float[][][] rgb = new float[3][][];
             rgb[0] = newData;
             rgb[1] = original;
             rgb[2] = original;
@@ -62,7 +62,7 @@ public class DebugImageHelper {
         });
     }
 
-    public static void drawEllipse(int width, int height, Ellipse ellipse, float[] buffer) {
+    public static void drawEllipse(int width, int height, Ellipse ellipse, float[][] buffer) {
         var center = ellipse.center();
         var cx = (int) center.a();
         var cy = (int) center.b();
@@ -95,7 +95,7 @@ public class DebugImageHelper {
         }
     }
 
-    public static void drawCircle(int cx, int cy, int radius, int width, int height, float[] data) {
+    public static void drawCircle(int cx, int cy, int radius, int width, int height, float[][] data) {
         for (double angle = 0; angle <= 2 * Math.PI; angle += 0.01) {
             var x = cx + radius * Math.cos(angle);
             var y = cy + radius * Math.sin(angle);
@@ -103,18 +103,18 @@ public class DebugImageHelper {
         }
     }
 
-    public static void plot(int x, int y, int width, int height, float[] data) {
+    public static void plot(int x, int y, int width, int height, float[][] data) {
         plot(x, y, width, height, data, 1);
     }
 
-    public static void plot(Point2D p, int width, int height, float[] data, int size) {
+    public static void plot(Point2D p, int width, int height, float[][] data, int size) {
         plot((int) p.x(), (int) p.y(), width, height, data, size);
     }
 
-    public static void plot(int x, int y, int width, int height, float[] data, int size) {
+    public static void plot(int x, int y, int width, int height, float[][] data, int size) {
         for (int yy = Math.max(0, y - size); yy < Math.min(height, y + size + 1); yy++) {
             for (int xx = Math.max(0, x - size); xx < Math.min(width, x + size + 1); xx++) {
-                data[xx + yy * width] = Constants.MAX_PIXEL_VALUE;
+                data[yy][xx] = Constants.MAX_PIXEL_VALUE;
             }
         }
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/DrawUtils.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/DrawUtils.java
@@ -34,7 +34,7 @@ public class DrawUtils {
     }
 
 
-    public static void drawLine(float[] image, int width, int height, int x1, int y1, int x2, int y2, int thickness) {
+    public static void drawLine(float[][] image, int width, int height, int x1, int y1, int x2, int y2, int thickness) {
         var dx = x2 - x1;
         var dy = y2 - y1;
         var length = Math.max(Math.abs(dx), Math.abs(dy));
@@ -48,22 +48,11 @@ public class DrawUtils {
                 if (x >= 0 && x < width && y >= 0 && y < height) {
                     int idx = y * width + x;
                     if (idx >= 0 && idx < image.length) {
-                        image[idx] = 65535;
+                        image[y][x] = 65535;
                     }
                 }
             }
         }
     }
 
-    public static float[][] asTile(float[] data, int x, int y, int width, int tileSize) {
-        float[][] result = new float[tileSize][tileSize];
-        for (int dy = 0; dy < tileSize; dy++) {
-            for (int dx = 0; dx < tileSize; dx++) {
-                if (y * width + x < data.length) {
-                    result[dy][dx] = data[y * width + x];
-                }
-            }
-        }
-        return result;
-    }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/Histogram.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/Histogram.java
@@ -32,17 +32,15 @@ public record Histogram(
     int maxValue
 ) {
     public static Histogram of(Image image, int bins) {
-        var builder = builder(bins);
-        for (float d : image.data()) {
-            builder.record(d);
-        }
-        return builder.build();
+        return of(image.data(), bins);
     }
 
-    public static Histogram of(float[] image, int bins) {
+    public static Histogram of(float[][] image, int bins) {
         var builder = builder(bins);
-        for (float d : image) {
-            builder.record(d);
+        for (float[] line : image) {
+            for (float d : line) {
+                builder.record(d);
+            }
         }
         return builder.build();
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ImageWrapper.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ImageWrapper.java
@@ -21,8 +21,11 @@ import java.util.function.Function;
 
 public sealed interface ImageWrapper permits ImageWrapper32, RGBImage, FileBackedImage {
     int width();
+
     int height();
+
     Map<Class<?>, Object> metadata();
+
     default <T> Optional<T> findMetadata(Class<T> clazz) {
         var metadata = metadata();
         if (metadata.containsKey(clazz)) {
@@ -47,5 +50,18 @@ public sealed interface ImageWrapper permits ImageWrapper32, RGBImage, FileBacke
 
     default ImageWrapper wrap() {
         return FileBackedImage.wrap(this);
+    }
+
+    static float[][] copyData(float[][] source) {
+        if (source.length == 0) {
+            return new float[0][];
+        }
+        int height = source.length;
+        int width = source[0].length;
+        float[][] result = new float[height][width];
+        for (int y = 0; y < height; y++) {
+            System.arraycopy(source[y], 0, result[y], 0, width);
+        }
+        return result;
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ImageWrapper32.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ImageWrapper32.java
@@ -29,7 +29,7 @@ import java.util.Map;
 public record ImageWrapper32(
         int width,
         int height,
-        float[] data,
+        float[][] data,
         Map<Class<?>, Object> metadata
 ) implements ImageWrapper {
 
@@ -39,7 +39,7 @@ public record ImageWrapper32(
      * @return a new empty image
      */
     public static ImageWrapper32 createEmpty() {
-        return new ImageWrapper32(0, 0, new float[0], MutableMap.of());
+        return new ImageWrapper32(0, 0, new float[0][0], MutableMap.of());
     }
 
     public Image asImage() {
@@ -55,8 +55,7 @@ public record ImageWrapper32(
     }
 
     public ImageWrapper32 copy() {
-        float[] copy = new float[data.length];
-        System.arraycopy(data, 0, copy, 0, data.length);
+        float[][] copy = ImageWrapper.copyData(data);
         return new ImageWrapper32(width, height, copy, new LinkedHashMap<>(metadata));
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/RGBImage.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/RGBImage.java
@@ -20,37 +20,34 @@ import java.util.Map;
 import java.util.function.Function;
 
 public record RGBImage(
-        int width,
-        int height,
-        float[] r,
-        float[] g,
-        float[] b,
-        Map<Class<?>, Object> metadata
+    int width,
+    int height,
+    float[][] r,
+    float[][] g,
+    float[][] b,
+    Map<Class<?>, Object> metadata
 ) implements ImageWrapper {
     @Override
     public RGBImage copy() {
-        return new RGBImage(width, height, copyOf(r), copyOf(g), copyOf(b), new LinkedHashMap<>(metadata));
+        return new RGBImage(width, height, ImageWrapper.copyData(r), ImageWrapper.copyData(g), ImageWrapper.copyData(b), new LinkedHashMap<>(metadata));
     }
 
-    private static float[] copyOf(float[] array) {
-        float[] rcopy = new float[array.length];
-        System.arraycopy(array, 0, rcopy, 0, array.length);
-        return rcopy;
-    }
-
-    public static RGBImage fromMono(ImageWrapper32 mono, Function<ImageWrapper32, float[][]> converter) {
+    public static RGBImage fromMono(ImageWrapper32 mono, Function<ImageWrapper32, float[][][]> converter) {
         return fromMono(mono, converter, new LinkedHashMap<>(mono.metadata()));
     }
 
-    public static RGBImage fromMono(ImageWrapper32 mono, Function<ImageWrapper32, float[][]> converter, Map<Class<?>, Object> metadata) {
+    public static RGBImage fromMono(ImageWrapper32 mono, Function<ImageWrapper32, float[][][]> converter, Map<Class<?>, Object> metadata) {
         var rgb = converter.apply(mono);
         return new RGBImage(mono.width(), mono.height(), rgb[0], rgb[1], rgb[2], metadata);
     }
 
     public ImageWrapper32 toMono() {
-        float[] monoData = new float[width * height];
-        for (int i = 0; i < width * height; i++) {
-            monoData[i] = 0.299f * r[i] + 0.587f * g[i] + 0.114f * b[i];
+        float[][] monoData = new float[height][width];
+        for (int y = 0; y < height; y++) {
+            monoData[y] = new float[width];
+            for (int x = 0; x < width; x++) {
+                monoData[y][x] = 0.299f * r[y][x] + 0.587f * g[y][x] + 0.114f * b[y][x];
+            }
         }
         return new ImageWrapper32(width, height, monoData, new LinkedHashMap<>(metadata));
     }

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/ImageExpressionEvaluatorTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/ImageExpressionEvaluatorTest.groovy
@@ -27,7 +27,7 @@ class ImageExpressionEvaluatorTest extends Specification {
     @Subject
     ImageExpressionEvaluator evaluator
 
-    private Map<Integer, ImageWrapper32> images = [:].withDefault { new ImageWrapper32(0, 0, new float[0], [:]) }
+    private Map<Integer, ImageWrapper32> images = [:].withDefault { new ImageWrapper32(0, 0, new float[0][], [:]) }
 
     def "can collect image shifts from expression"() {
         given:

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/impl/StackingTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/impl/StackingTest.groovy
@@ -128,14 +128,14 @@ class StackingTest extends Specification {
     private static Image translate(Image image, int dx, int dy) {
         var refW = image.width()
         var refH = image.height()
-        var translated = new float[refW * refH]
+        var translated = new float[refH][refW]
         def source = image.data()
         for (int x = 0; x < refW; x++) {
             for (int y = 0; y < refH; y++) {
                 def xx = x + dx
                 def yy = y + dy
                 if (xx >= 0 && xx < refW && yy >= 0 && yy < refH) {
-                    translated[xx + yy * refW] = source[x + y * refW]
+                    translated[yy][xx] = source[y][x]
                 }
             }
         }

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/sun/SpectrumFrameAnalyzerTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/sun/SpectrumFrameAnalyzerTest.groovy
@@ -36,10 +36,10 @@ class SpectrumFrameAnalyzerTest extends Specification {
     def "analyzes spectrum frame"() {
         given:
         def image = ImageIO.read(getClass().getResourceAsStream("/spectrum.tif"))
-        float[] data = new float[image.width * image.height]
+        float[][] data = new float[image.height][image.width]
         for (int x = 0; x < image.width; x++) {
             for (int y = 0; y < image.height; y++) {
-                data[x + y * image.width] = image.getRGB(x, y) & 0xFF
+                data[y][x] = image.getRGB(x, y) & 0xFF
             }
         }
         def analyzer = new SpectrumFrameAnalyzer(image.width, image.height, 50d)
@@ -71,7 +71,7 @@ class SpectrumFrameAnalyzerTest extends Specification {
         def corrected = imageCorrector.polynomialCorrection(p)
         for (int x = 0; x < image.width; x++) {
             for (int y = 0; y < image.height; y++) {
-                int correctedValue = (corrected[x + y * image.width] as int) & 0xFF
+                int correctedValue = (corrected[y][x] as int) & 0xFF
                 int greyScale = (correctedValue << 16) | (correctedValue << 8) | correctedValue
                 image.setRGB(x, y, greyScale)
             }

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/util/ImageIOUtils.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/util/ImageIOUtils.groovy
@@ -27,10 +27,10 @@ class ImageIOUtils {
         var img = ImageIO.read(AlignerTest.getResource(name))
         var refW = img.width
         var refH = img.height
-        var loaded = new float[refW * refH]
+        var loaded = new float[refH][refW]
         for (int x = 0; x < refW; x++) {
             for (int y = 0; y < refH; y++) {
-                loaded[x + y * refW] = (img.getRGB(x, y) & 0xFF) << 8
+                loaded[y][x] = (img.getRGB(x, y) & 0xFF) << 8
             }
         }
         new Image(refW, refH, loaded)

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/Corrector.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/Corrector.java
@@ -67,9 +67,9 @@ public class Corrector {
                 verticalFlip(copy.data(), copy.width(), copy.height());
                 return copy;
             } else if (img instanceof RGBImage rgb) {
-                var r = copy(rgb.r());
-                var g = copy(rgb.r());
-                var b = copy(rgb.r());
+                var r = ImageWrapper.copyData(rgb.r());
+                var g = ImageWrapper.copyData(rgb.g());
+                var b = ImageWrapper.copyData(rgb.b());
                 verticalFlip(r, rgb.width(), rgb.height());
                 verticalFlip(g, rgb.width(), rgb.height());
                 verticalFlip(b, rgb.width(), rgb.height());
@@ -81,20 +81,10 @@ public class Corrector {
         return result;
     }
 
-    private static float[] copy(float[] data) {
-        var copy = new float[data.length];
-        System.arraycopy(data, 0, copy, 0, data.length);
-        return copy;
-    }
-
-    private static void verticalFlip(float[] data, int width, int height) {
-        var tmp = new float[width];
-        for (int y = 0; y < height / 2; y++) {
-            int y1 = y * width;
-            int y2 = (height - y - 1) * width;
-            System.arraycopy(data, y1, tmp, 0, width);
-            System.arraycopy(data, y2, data, y1, width);
-            System.arraycopy(tmp, 0, data, y2, width);
+    private static void verticalFlip(float[][] data, int width, int height) {
+        var tmp = ImageWrapper.copyData(data);
+        for (int y = 0; y < height; y++) {
+            System.arraycopy(tmp[height - y - 1], 0, data[y], 0, width);
         }
     }
 }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
@@ -243,7 +243,7 @@ public class ImageViewer implements WithRootNode {
                     if (idx < 0 || idx >= mono.data().length) {
                         return;
                     }
-                    var pixelValue = mono.data()[idx];
+                    var pixelValue = mono.data()[y.intValue()][x.intValue()];
                     extra = ", " + String.format("%.0f", pixelValue);
                 }
                 coordinatesLabel.setText("(" + x.intValue() + ", " + y.intValue() + extra + ")");

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/SpectralRayEditor.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/SpectralRayEditor.java
@@ -205,18 +205,22 @@ public class SpectralRayEditor {
                 var mono = monoImage.data();
                 var rgbColor = newRay.toRGB();
                 if (rgbColor[0] == 0 && rgbColor[1] == 0 && rgbColor[2] == 0) {
-                    return new float[][]{mono, mono, mono};
+                    return new float[][][]{mono, mono, mono};
                 }
-                var r = new float[mono.length];
-                var g = new float[mono.length];
-                var b = new float[mono.length];
-                for (int i = 0; i < mono.length; i++) {
-                    var gray = mono[i];
-                    r[i] = gray * rgbColor[0] / 255f;
-                    g[i] = gray * rgbColor[1] / 255f;
-                    b[i] = gray * rgbColor[2] / 255f;
+                var height = monoImage.height();
+                var width = monoImage.width();
+                var r = new float[height][width];
+                var g = new float[height][width];
+                var b = new float[height][width];
+                for (int y = 0; y < height; y++) {
+                    for (int x = 0; x < width; x++) {
+                        var gray = mono[y][x];
+                        r[y][x] = gray * rgbColor[0] / 255f;
+                        g[y][x] = gray * rgbColor[1] / 255f;
+                        b[y][x] = gray * rgbColor[2] / 255f;
+                    }
                 }
-                return new float[][]{r, g, b};
+                return new float[][][]{r, g, b};
             }
         });
         var r = colorImage.r();
@@ -288,10 +292,12 @@ public class SpectralRayEditor {
             }
             var width = image.getWidth();
             var height = image.getHeight();
-            var data = new float[width * height];
+            var data = new float[height][width];
             var rgb = image.getRGB(0, 0, width, height, null, 0, width);
-            for (int i = 0; i < data.length; i++) {
-                data[i] = rgb[i] & 0xFF;
+            for (int y = 0; y < height; y++) {
+                for (int x = 0; x < width; x++) {
+                    data[y][x] = rgb[y * width + x] & 0xFF;
+                }
             }
             var result = new ImageWrapper32(width, height, data, MutableMap.of());
             LinearStrechingStrategy.DEFAULT.stretch(result);

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/RedshiftImagesProcessor.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/RedshiftImagesProcessor.java
@@ -82,7 +82,7 @@ public class RedshiftImagesProcessor {
     private final ImageEmitter imageEmitter;
     private final List<RedshiftArea> redshifts;
     private final DoubleUnaryOperator polynomial;
-    private final float[] averageImage;
+    private final float[][] averageImage;
     private final int imageWidth;
     private final int imageHeight;
 
@@ -95,7 +95,7 @@ public class RedshiftImagesProcessor {
                                    ImageEmitter imageEmitter,
                                    List<RedshiftArea> redshifts,
                                    DoubleUnaryOperator polynomial,
-                                   float[] averageImage) {
+                                   float[][] averageImage) {
         this.shiftImages = shiftImages;
         this.params = params;
         this.serFile = serFile;
@@ -370,7 +370,7 @@ public class RedshiftImagesProcessor {
             panelHeight,
             Map.of(),
             () -> {
-                var rgb = new float[3][panelWidth * panelHeight];
+                var rgb = new float[3][panelHeight][panelWidth];
                 var r = rgb[0];
                 var g = rgb[1];
                 var b = rgb[2];
@@ -381,7 +381,8 @@ public class RedshiftImagesProcessor {
                     var data = mono.data();
                     var row = i / cols;
                     var col = i % cols;
-                    var offset = row * height * panelWidth + col * width;
+                    var yOffset = row * height;
+                    var xOffset = col * width;
                     var pixelShift = snap.findMetadata(PixelShift.class).map(PixelShift::pixelShift).orElse(0d);
                     var angstroms = 10 * pixelShift * dispersion;
                     var legend = String.format(Locale.US, "%.2fÅ (%.2f km/s)", angstroms, Math.abs(PhenomenaDetector.speedOf(pixelShift, dispersion, lambda0)));
@@ -391,18 +392,16 @@ public class RedshiftImagesProcessor {
                     var legendPixel = new int[1];
                     for (int y = 0; y < height; y++) {
                         for (int x = 0; x < width; x++) {
-                            var idx = y * width + x;
-                            var panelIdx = offset + y * panelWidth + x;
-                            var gray = data[idx];
+                            var gray = data[y][x];
                             legendOverlay.getPixel(x, y, legendPixel);
                             if (legendPixel[0] > 0) {
-                                r[panelIdx] = 60395;
-                                g[panelIdx] = 53970;
-                                b[panelIdx] = 13364;
+                                r[yOffset + y][xOffset + x] = 60395;
+                                g[yOffset + y][xOffset + x] = 53970;
+                                b[yOffset + y][xOffset + x] = 13364;
                             } else {
-                                r[panelIdx] = gray;
-                                g[panelIdx] = gray;
-                                b[panelIdx] = gray;
+                                r[yOffset + y][xOffset + x] = gray;
+                                g[yOffset + y][xOffset + x] = gray;
+                                b[yOffset + y][xOffset + x] = gray;
                             }
                         }
                     }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SingleModeProcessingEventListener.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SingleModeProcessingEventListener.java
@@ -154,7 +154,7 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
     private final Tab metadataTab;
     private final WeakHashMap<ImageWrapper, List<CachedHistogram>> cachedHistograms = new WeakHashMap<>();
     private final LocalDateTime processingDate;
-    private float[] averageImage;
+    private float[][] averageImage;
 
     private ProcessParams params;
     private ProcessParams adjustedParams;
@@ -361,7 +361,7 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
         int max = 0;
         for (int yy = 0; yy < spectrum.height(); yy++) {
             for (int xx = 0; xx < spectrum.width(); xx++) {
-                int v = (int) (255 * spectrum.data()[yy * spectrum.width() + xx] / Constants.MAX_PIXEL_VALUE);
+                int v = (int) (255 * spectrum.data()[yy][xx] / Constants.MAX_PIXEL_VALUE);
                 max = Math.max(max, v);
             }
         }
@@ -369,7 +369,7 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
         for (int yy = 0; yy < spectrum.height(); yy++) {
             for (int xx = 0; xx < spectrum.width(); xx++) {
                 var offset = 3 * (yy * spectrum.width() + xx);
-                double v = 255 * spectrum.data()[yy * spectrum.width() + xx] / Constants.MAX_PIXEL_VALUE;
+                double v = 255 * spectrum.data()[yy][xx] / Constants.MAX_PIXEL_VALUE;
                 byte s = (byte) (255 * v / max);
                 spectrumBuffer[offset] = s;
                 spectrumBuffer[offset + 1] = s;
@@ -537,10 +537,10 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
                     new Image(mono.width(), mono.height(), mono.data()), BINS
                 ), "grey"));
             } else if (imageWrapper instanceof RGBImage rgbImage) {
-                var rgb = new float[][]{rgbImage.r(), rgbImage.g(), rgbImage.b()};
+                var rgb = new float[][][]{rgbImage.r(), rgbImage.g(), rgbImage.b()};
                 List<CachedHistogram> result = new ArrayList<>(rgb.length);
                 for (int i = 0; i < rgb.length; i++) {
-                    float[] channel = rgb[i];
+                    float[][] channel = rgb[i];
                     result.add(new CachedHistogram(Histogram.of(
                         new Image(rgbImage.width(), rgbImage.height(), channel), BINS
                     ), RGB_COLORS[i]));
@@ -902,8 +902,8 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
                     int upperNy = (int) Math.ceil(exactNy);
 
                     if (lowerNy >= 0 && upperNy < height) {
-                        var lowerValue = data[width * lowerNy + x];
-                        var upperValue = data[width * upperNy + x];
+                        var lowerValue = data[lowerNy][x];
+                        var upperValue = data[upperNy][x];
                         var interpolatedValue = lowerValue + (upperValue - lowerValue) * (exactNy - lowerNy);
 
                         val += interpolatedValue;

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -1,33 +1,6 @@
 # Welcome to JSol'Ex {{version}}!
 
-## Changes in 2.7.4
+## Changes in 2.8.0
 
 - Fixed bug in alignment button which didn't always sync zoom and position
-
-## Changes in 2.7.3
-
-- Fix polynomial detection when multiple dark lines are found in crop window
-- Strech colors of reconstruction view when reconstruction is done
-- Add a "select and process" file which doesn't even ask for process params
-
-## Changes in 2.7.2
-
-- Fixed reconstruction bug causing artifacts particularly visible in Helium
-- Added `disk_mask` function which allows creating a mask of the solar disk
-- Added a new ImageMath sample for enhanced inverted image creation
-- Fixed ImageMath "save" button which didn't remember the directory used
-
-## Changes in 2.7.1
-
-- Added MacOS x86 installer
-- Improved artificial flat correction
-- Added `flat_correction` ImageMath function
-
-## Changes in 2.7.0
-
-- Fixed auto-contrast being a bit too agressive on prominences
-- Improve quality of reconstruction using bilinear interpolation instead of linear
-- Enhanced reconstruction view which allows finding which frame is the source for a particular pixel (issue #386)
-- Improve spectral line identification in spectrum browser
-- Add `filter` ImageMath function, which allows filtering a list of images, for example to keep only these which are after a certain date
-- Add a memory usage limit parameter for reconstruction
+- Internal image format changes to make future changes easier to implement

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -1,36 +1,9 @@
 # Bienvenue dans JSol'Ex {{version}} !
 
-## Nouveautés de la version 2.7.4
+## Nouveautés de la version 2.8.0
 
 - Correction du bouton "aligner les images" qui ne fonctionnait pas toujours
-
-## Nouveautés de la version 2.7.3
-
-- Correction d'un bug de détection du polynôme lorsqu'il y a plusieurs lignes sombres dans la fenêtre de capture
-- Étirement des couleurs de la vue reconstruction lorsque la reconstruction est terminée
-- Ajout d'un bouton "sélectionner et traiter" qui permet de ne plus avoir à passer par les paramétrages
-
-## Nouveautés de la version 2.7.2
-
-- Correction d'un bug de reconstruction qui provoque des artéfacts (particulièrement visible en Hélium)
-- Ajout d'une fonction `disk_mask` permettant de créer un masque du disque solaire
-- Ajout d'un nouvel exemple de script ImageMath pour créer une image inverse améliorée
-- Correction du bouton script "Sauvegarder" qui ne conservait pas le dernier répertoire utilisé 
-
-## Nouveautés de la version 2.7.1
-
-- Ajout d'un installeur pour MacOS x86
-- Amélioration de la correction de flat artificiels
-- Ajout d'une fonction ImageMath `flat_correction`
-
-## Nouveautés de la version 2.7.0
-
-- Correction de l'auto-contraste trop agressif sur les protubérances
-- Amélioration de la qualité de la reconstruction en utilisant une interpolation bilinéaire au lieu de linéaire
-- Vue reconstruction améliorée permettant de retrouver les trames à l'origine d'un point précis (demande #386)
-- Amélioration de la détection de région dans l'explorateur de spectre
-- Ajout de la fonction ImageMath `filter`, qui permet de filtrer une liste d'images, par exemple pour ne garder que celles qui sont postérieures à une certaine date
-- Ajout d'un paramètre de limitation de l'utilisation mémoire lors de la reconstruction
+- Modifications des structures de données internes pour faciliter de futures évolutions
 
 ## Message aux utilisateurs français
 

--- a/math/src/main/java/me/champeau/a4j/math/image/Deconvolution.java
+++ b/math/src/main/java/me/champeau/a4j/math/image/Deconvolution.java
@@ -36,7 +36,7 @@ public class Deconvolution {
     public static Image generateGaussianPSF(double radius, double sigma) {
         int width = (int) (2 * (radius + .5));
         int height = width;
-        var psf = new float[width * height];
+        var psf = new float[height][width];
         double cx = width / 2.0;
         double cy = height / 2.0;
         double sigmaFactor = radius / sigma;
@@ -47,7 +47,7 @@ public class Deconvolution {
                 double dx = x - cx;
                 double distanceSquared = dx * dx + dy * dy;
                 double value = Math.exp(-distanceSquared / (2 * sigmaFactor * sigmaFactor));
-                psf[y * width + x] = (float) (MAX_VALUE * value);
+                psf[y][x] = (float) (MAX_VALUE * value);
             }
         }
         return new Image(width, height, psf);
@@ -55,7 +55,7 @@ public class Deconvolution {
 
     public Image richardsonLucy(Image image, Image psf, int iterations) {
         var estimate = image;
-        var psfFlipped = flip(psf);
+        var psfFlipped = imageMath.mirror(psf, false, true);
         var psfKernel = ImageKernel.of(psf);
         var psfFlippedKernel = ImageKernel.of(psfFlipped);
         for (int i = 0; i < iterations; i++) {
@@ -73,28 +73,18 @@ public class Deconvolution {
 
     private static void clampData(Image image) {
         var data = image.data();
-        for (int j = 0; j < data.length; j++) {
-            if (data[j] > MAX_VALUE) {
-                data[j] = MAX_VALUE;
-            } else if (data[j] < 0) {
-                data[j] = 0;
-            }
-        }
-    }
-
-    private static Image flip(Image image) {
-        var data = image.data();
-        var width = image.width();
         var height = image.height();
-        var flipped = new float[width * height];
+        var width = image.width();
         for (int y = 0; y < height; y++) {
-            var row = new float[width];
-            System.arraycopy(data, y * width, row, 0, width);
             for (int x = 0; x < width; x++) {
-                flipped[y * width + x] = row[width - x - 1];
+                var v = data[y][x];
+                if (v > MAX_VALUE) {
+                    data[y][x] = MAX_VALUE;
+                } else if (v < 0) {
+                    data[y][x] = 0;
+                }
             }
         }
-        return new Image(width, height, flipped);
     }
 
 }

--- a/math/src/main/java/me/champeau/a4j/math/image/Image.java
+++ b/math/src/main/java/me/champeau/a4j/math/image/Image.java
@@ -17,25 +17,29 @@ package me.champeau.a4j.math.image;
 
 import java.util.Arrays;
 
-public record Image(int width, int height, float[] data) {
+public record Image(int width, int height, float[][] data) {
 
-    int length() {
-        return data.length;
-    }
-
-    public Image withData(float[] data) {
-        return new Image(width, height, data);
+    public Image withData(float[][] newData) {
+        var copyData = deepCopy(newData);
+        return new Image(width, height, copyData);
     }
 
     public Image copy() {
-        var copy = new float[data.length];
-        System.arraycopy(data, 0, copy, 0, data.length);
-        return new Image(width, height, copy);
+        var copyData = deepCopy(data);
+        return new Image(width, height, copyData);
     }
 
-    @Override
-    public String toString() {
-        return "{ width = " + width + ", height = " + height + "}";
+    private float[][] deepCopy(float[][] original) {
+        if (original.length==0) {
+            return new float[0][];
+        }
+        var copy = new float[original.length][];
+        for (int i = 0; i < original.length; i++) {
+            var length = original[i].length;
+            copy[i] = new float[length];
+            System.arraycopy(original[i], 0, copy[i], 0, length);
+        }
+        return copy;
     }
 
     @Override
@@ -55,14 +59,29 @@ public record Image(int width, int height, float[] data) {
         if (height != image.height) {
             return false;
         }
-        return Arrays.equals(data, image.data);
+        for (int i = 0; i < data.length; i++) {
+            float[] line = data[i];
+            float[] other = image.data[i];
+            if (!Arrays.equals(line, other)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
     public int hashCode() {
         int result = width;
         result = 31 * result + height;
-        result = 31 * result + Arrays.hashCode(data);
+        for (float[] line : data) {
+            result = 31 * result + Arrays.hashCode(line);
+        }
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "{ width = " + width + ", height = " + height + " }";
+    }
+
 }

--- a/math/src/main/java/me/champeau/a4j/math/image/ImageKernel.java
+++ b/math/src/main/java/me/champeau/a4j/math/image/ImageKernel.java
@@ -29,7 +29,7 @@ public class ImageKernel implements Kernel {
         float sum = 0;
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
-                var value = data[y * width + x] / 65535f;
+                var value = data[y][x] / 65535f;
                 sum += value;
                 kernel[y][x] = value;
             }

--- a/math/src/test/groovy/me/champeau/a4j/math/image/DeconvolutionTest.groovy
+++ b/math/src/test/groovy/me/champeau/a4j/math/image/DeconvolutionTest.groovy
@@ -58,7 +58,7 @@ class DeconvolutionTest extends Specification {
         )
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
-                int grayScale = Math.round(data[x + y * width]) >> 8
+                int grayScale = Math.round(data[y][x]) >> 8
                 int pixelValue = (grayScale << 16) | (grayScale << 8) | grayScale
                 output.setRGB(x, y, pixelValue);
             }
@@ -74,10 +74,10 @@ class DeconvolutionTest extends Specification {
         var img = ImageIO.read(DeconvolutionTest.getResource(name))
         var refW = img.width
         var refH = img.height
-        var loaded = new float[refW * refH]
+        var loaded = new float[refH][refW]
         for (int x = 0; x < refW; x++) {
             for (int y = 0; y < refH; y++) {
-                loaded[x + y * refW] = (img.getRGB(x, y) & 0xFF) << 8
+                loaded[y][x] = (img.getRGB(x, y) & 0xFF) << 8
             }
         }
         new Image(refW, refH, loaded)

--- a/math/src/test/groovy/me/champeau/a4j/math/image/ImageMathTest.groovy
+++ b/math/src/test/groovy/me/champeau/a4j/math/image/ImageMathTest.groovy
@@ -19,22 +19,22 @@ import spock.lang.Specification
 
 class ImageMathTest extends Specification {
     def "tests integral image (#label)"() {
-        var image = new Image(5, 4, new float[]{
-                4, 1, 2, 2, 1,
-                0, 4, 1, 3, 5,
-                3, 1, 0, 4, 2,
-                2, 1, 3, 2, 1
+        var image = new Image(5, 4, new float[][]{
+                new float[]{4, 1, 2, 2, 1},
+                new float[]{0, 4, 1, 3, 5},
+                new float[]{3, 1, 0, 4, 2},
+                new float[]{2, 1, 3, 2, 1}
         })
 
         when:
         def integral = imageMath.integralImage(image)
 
         then:
-        integral == new Image(5, 4, new float[]{
-                4, 5, 7, 9, 10,
-                4, 9, 12, 17, 23,
-                7, 13, 16, 25, 33,
-                9, 16, 22, 33, 42
+        integral == new Image(5, 4, new float[][]{
+                new float[]{4, 5, 7, 9, 10},
+                new float[]{4, 9, 12, 17, 23},
+                new float[]{7, 13, 16, 25, 33},
+                new float[]{9, 16, 22, 33, 42}
         })
 
         when:
@@ -86,30 +86,30 @@ class ImageMathTest extends Specification {
     }
 
     def "computes incremental average (#label)"() {
-        float[] current = new float[333]
-        for (int i = 0; i < current.length; i++) {
-            current[i] = i
+        float[][] current = new float[1][333]
+        for (int i = 0; i < 333; i++) {
+            current[0][i] = i
         }
-        float[] average = new float[333]
+        float[][] average = new float[1][333]
 
         when:
         imageMath.incrementalAverage(current, average, 10)
 
         then:
-        average[0] == 0
-        average[1] == 0.1f
-        average[2] == 0.2f
-        average[120] == 12f
-        average[332] == 33.2f
+        average[0][0] == 0
+        average[0][1] == 0.1f
+        average[0][2] == 0.2f
+        average[0][120] == 12f
+        average[0][332] == 33.2f
 
         when:
         imageMath.incrementalAverage(current, average, 11)
 
         then:
-        average[0] == 0
-        average[1] == 0.18181819f
-        average[120] == 21.818182f
-        average[332] == 60.363636f
+        average[0][0] == 0
+        average[0][1] == 0.18181819f
+        average[0][120] == 21.818182f
+        average[0][332] == 60.363636f
 
         where:
         label        | imageMath
@@ -118,11 +118,10 @@ class ImageMathTest extends Specification {
     }
 
     static Image newImage(int width, int height) {
-        var size = width * height
-        var data = new float[size]
+        var data = new float[height][width]
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
-                data[y * width + x] = y + x
+                data[y][x] = y + x
             }
         }
         return new Image(width, height, data)


### PR DESCRIPTION
This commit changes the internal data structure used for images. So far, it was using a 1d-array, which was optimal in terms of memory consumption, but not very "user friendly" in the sense that it required passing the width to many methods in order to interpret the data.

With the idea of introducing Python scripting in the future, there will be a need for lower-level data access, and it's going to be easier for users to reason about with a 2d array.