### PR TITLE
Stabilize stacking algorithm

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Loader.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Loader.java
@@ -97,7 +97,7 @@ public class Loader extends AbstractFunctionImpl {
             var color = image.getRGB(0, 0, width, height, null, 0, width);
             for (int y = 0; y < height; y++) {
                 for (int x = 0; x < width; x++) {
-                    var pixel = color[y*width + x];
+                    var pixel = color[y * width + x];
                     r[y][x] = ((pixel >> 16) & 0xFF) << 8;
                     g[y][x] = ((pixel >> 8) & 0xFF) << 8;
                     b[y][x] = (pixel & 0xFF) << 8;
@@ -115,10 +115,11 @@ public class Loader extends AbstractFunctionImpl {
                     }
                 }
             } else {
-                var rgb = image.getRGB(0, 0, width, height, null, 0, width);
+                var raster = image.getRaster();
                 for (int y = 0; y < height; y++) {
                     for (int x = 0; x < width; x++) {
-                        data[y][x] = rgb[y * width + x] & 0xFF;
+                        // Get raw sample value and scale to 16-bit
+                        data[y][x] = raster.getSample(x, y, 0) << 8;
                     }
                 }
             }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/MosaicComposition.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/MosaicComposition.java
@@ -237,7 +237,7 @@ public class MosaicComposition extends AbstractFunctionImpl {
                     threshold = threshold / 4;
                 } else if (reassembled || !updated || step == maxSteps) {
                     corrected.remove(1);
-                    var mosaic = stacking.doStack(List.of(first, second), tileSize, overlap, assembled, 0);
+                    var mosaic = stacking.doStack(List.of(first, second), tileSize, overlap, assembled);
                     corrected.set(0, mosaic);
                     break;
                 }

--- a/jsolex-scripting/build.gradle.kts
+++ b/jsolex-scripting/build.gradle.kts
@@ -47,6 +47,6 @@ tasks.withType<JavaExec>().configureEach {
     args(listOf(
         "-o", "/tmp/out2",
         "-s", "/home/cchampeau/DEV/PROJECTS/GITHUB/astro4j/stacking.math",
-        "-p", "input_dir=/tmp/scaled"
+        "-p", "input_dir=/home/cchampeau/Downloads/stack_191124/stack_191124"
     ))
 }

--- a/jsolex-scripting/src/main/java/me/champeau/a4j/jsolex/cli/ScriptingEntryPoint.java
+++ b/jsolex-scripting/src/main/java/me/champeau/a4j/jsolex/cli/ScriptingEntryPoint.java
@@ -23,7 +23,7 @@ import me.champeau.a4j.jsolex.processing.event.ProgressEvent;
 import me.champeau.a4j.jsolex.processing.expr.DefaultImageScriptExecutor;
 import me.champeau.a4j.jsolex.processing.expr.ImageMathScriptExecutor;
 import me.champeau.a4j.jsolex.processing.params.ProcessParams;
-import me.champeau.a4j.jsolex.processing.stretching.LinearStrechingStrategy;
+import me.champeau.a4j.jsolex.processing.stretching.CutoffStretchingStrategy;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.util.ImageFormat;
 import me.champeau.a4j.jsolex.processing.util.ImageSaver;
@@ -90,7 +90,7 @@ public class ScriptingEntryPoint implements Runnable {
             var result = scriptExecutor.execute(sourceScriptPath, ImageMathScriptExecutor.SectionKind.SINGLE);
             var processParams = ProcessParams.loadDefaults();
             processParams = processParams.withExtraParams(processParams.extraParams().withImageFormats(Set.of(ImageFormat.FITS, ImageFormat.JPG, ImageFormat.PNG, ImageFormat.TIF)));
-            var saver = new ImageSaver(LinearStrechingStrategy.DEFAULT, processParams);
+            var saver = new ImageSaver(CutoffStretchingStrategy.DEFAULT, processParams);
             var directory = outputDir == null ? new File(".") : outputDir;
             result.imagesByLabel().forEach((name, image) -> {
                 var saved = saver.save(image, new File(directory, name + ".png"));

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -4,5 +4,8 @@
 
 - Fixed bug in alignment button which didn't always sync zoom and position
 - Added `GET_R`, `GET_G`, `GET_B` and `MONO` functions which respectively extract the R, G and B channels of an image, and converts it to mono for the last one
+- Fixed loading of 8-bit mono JPEGs which didn't account for gamma correction
+- Improved stacking stability
 - Internal image format changes to make future changes easier to implement
+- Added module to run scripts from command-line
 - Upgrade to Java 23

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -4,7 +4,10 @@
 
 - Correction du bouton "aligner les images" qui ne fonctionnait pas toujours
 - Ajout des fonctions `GET_R`, `GET_G`, `GET_B` et `MONO` qui extraient respectivement les canaux rouge, vert et bleu d'une image couleur, et convertissent une image couleur en mono pour la dernière
+- Correction du chargement des images JPEG mono 8-bit qui ne prenait pas en compte la correction gamma
+- Amélioration de la stabilité de l'empilement
 - Modifications des structures de données internes pour faciliter de futures évolutions
+- Ajout d'un module permettant de lancer des scripts depuis la ligne de commande
 - Passage à Java 23
 
 ## Message aux utilisateurs français


### PR DESCRIPTION
This commit fixes an issue with the stacking algorithm: in case several tiles had the same value for the minimal error, then we would pick a random (first seen) tile alignment, instead of picking the one which is closest to the reference tile.