### PR TITLE
Fix panel/animation creation with large files

### DIFF
--- a/build-logic/src/main/kotlin/me.champeau.astro4j.jfxapp.gradle.kts
+++ b/build-logic/src/main/kotlin/me.champeau.astro4j.jfxapp.gradle.kts
@@ -12,7 +12,7 @@ javafx {
 }
 
 val os = System.getProperty("os.name").lowercase(Locale.ENGLISH)
-val jvmMemorySettings = listOf("-XX:MaxRAMPercentage=80", "-XX:+UseParallelGC")
+val jvmMemorySettings = listOf("-XX:MaxRAMPercentage=80", "-XX:+UseG1GC", "-XX:+HeapDumpOnOutOfMemoryError")
 
 application {
     applicationDefaultJvmArgs = jvmMemorySettings + listOf("--enable-preview")

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/AbstractFunctionImpl.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/AbstractFunctionImpl.java
@@ -137,7 +137,7 @@ class AbstractFunctionImpl {
                 var p = progress.incrementAndGet();
                 broadcaster.broadcast(ProgressEvent.of(p / (double) array.length, "ImageMath: " + currentFunction));
                 var result = function.apply(allArgs);
-                if (result instanceof ImageWrapper img && !(result instanceof FileBackedImage)) {
+                if (result instanceof ImageWrapper img) {
                     // save memory!
                     result = FileBackedImage.wrap(img);
                 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
@@ -178,11 +178,11 @@ public class ProcessingWorkflow {
             processedImagesEmitter.newMonoImage(kind, null, message("disk"), "disk", geometryFixed);
         }
         g = performEnhancements(g);
-        var enhanced = (ImageWrapper32) g.enhanced().unwrapToMemory();
         state.recordResult(WorkflowResults.GEOMETRY_CORRECTION, g);
         if (state.isInternal()) {
             return;
         }
+        var enhanced = (ImageWrapper32) g.enhanced().unwrapToMemory();
         broadcaster.broadcast(OutputImageDimensionsDeterminedEvent.of(message("geometry.corrected"), geometryFixed.width(), geometryFixed.height()));
         var stretched = produceStretchedImage(enhanced, processParams.claheParams(), processParams.autoStretchParams(), processParams.contrastEnhancement());
         processedImagesEmitter.newMonoImage(GeneratedImageKind.GEOMETRY_CORRECTED_PROCESSED, null, message("processed"), processParams.contrastEnhancement().name().toLowerCase(Locale.US), stretched);

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -3,6 +3,9 @@
 ## Changes in 2.8.0
 
 - Fixed bug in alignment button which didn't always sync zoom and position
+- Reduced memory pressure when generating animations or panels
+- Limited panels size to 7680x7680 pixels
+- Fixed duplicate animation creation when FFMPEG was available
 - Added `GET_R`, `GET_G`, `GET_B` and `MONO` functions which respectively extract the R, G and B channels of an image, and converts it to mono for the last one
 - Fixed loading of 8-bit mono JPEGs which didn't account for gamma correction
 - Improved stacking stability

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -3,6 +3,9 @@
 ## Nouveautés de la version 2.8.0
 
 - Correction du bouton "aligner les images" qui ne fonctionnait pas toujours
+- Réduction de la pression mémoire lors de la génération d'animations ou de panneaux
+- Limitation de la taille des panneaux à 7680x7680 pixels
+- Correction de la double création d'animations lorsque FFMPEG était disponible
 - Ajout des fonctions `GET_R`, `GET_G`, `GET_B` et `MONO` qui extraient respectivement les canaux rouge, vert et bleu d'une image couleur, et convertissent une image couleur en mono pour la dernière
 - Correction du chargement des images JPEG mono 8-bit qui ne prenait pas en compte la correction gamma
 - Amélioration de la stabilité de l'empilement


### PR DESCRIPTION
This commit reduces the amount of memory used when creating large animation or panels. Panels are now limited to a maximum size of 7680 pixels.