### PR TITLE
Improve reconstruction to mitigate artifacts

### DIFF
--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
@@ -198,7 +198,7 @@ public class ImageViewer implements WithRootNode {
 
     private void saveImage() {
         var image = applyTransformations(this.image);
-        var files = new ImageSaver(stretchingStrategy, processParams).save(image, imageFile);
+        var files = new ImageSaver(new StretchingChain(stretchingStrategy, RangeExpansionStrategy.DEFAULT), processParams).save(image, imageFile);
         files.stream()
             .findFirst()
             .ifPresent(file -> imageView.setImagePathForOpeningInExplorer(file.toPath()));


### PR DESCRIPTION
Linear reconstruction can cause artifacts in narrow lines. This commit introduces averaging with +=0.5 pixels in order to reduce these artifacts.