### PR TITLE
Rework temporary folder cleanup

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Animate.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Animate.java
@@ -23,6 +23,7 @@ import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.ProcessingException;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
+import me.champeau.a4j.jsolex.processing.util.TemporaryFolder;
 import me.champeau.a4j.ser.EightBitConversionSupport;
 import org.jcodec.api.SequenceEncoder;
 import org.jcodec.common.io.NIOUtils;
@@ -33,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +66,7 @@ public class Animate extends AbstractFunctionImpl {
         }
         var delay = arguments.size() == 1 ? DEFAULT_DELAY : doubleArg(arguments, 1);
         try {
-            var tempFile = Files.createTempFile("video_jsolex", ".mp4");
+            var tempFile = TemporaryFolder.newTempFile("video_jsolex", ".mp4");
             var frames = (List) arguments.get(0);
             if (FfmegEncoder.isAvailable()) {
                 if (encodeWithFfmpeg(broadcaster, frames, tempFile, (int) delay)) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/FfmegEncoder.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/FfmegEncoder.java
@@ -22,6 +22,7 @@ import me.champeau.a4j.jsolex.processing.util.FileBackedImage;
 import me.champeau.a4j.jsolex.processing.util.ImageFormat;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
+import me.champeau.a4j.jsolex.processing.util.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +51,7 @@ public class FfmegEncoder {
                               int msBetweenFrames) throws IOException {
         // first step is to export each image in a temporary directory
         // and each frame must be named with a sequence number, eg. frame-0001.png
-        var tempDir = Files.createTempDirectory("jsolex-ffmpeg-");
+        var tempDir = TemporaryFolder.newTempDir("jsolex-ffmpeg-");
         List<File> frames = null;
         try {
             broadcaster.broadcast(ProgressEvent.of(0, "Exporting frames"));

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -79,6 +79,7 @@ import me.champeau.a4j.jsolex.processing.util.RGBImage;
 import me.champeau.a4j.jsolex.processing.util.SolarParameters;
 import me.champeau.a4j.jsolex.processing.util.SolarParametersUtils;
 import me.champeau.a4j.jsolex.processing.util.SpectralLineFrameImageCreator;
+import me.champeau.a4j.jsolex.processing.util.TemporaryFolder;
 import me.champeau.a4j.math.Point2D;
 import me.champeau.a4j.math.image.Image;
 import me.champeau.a4j.math.image.ImageMath;
@@ -711,7 +712,7 @@ public class SolexVideoProcessor implements Broadcaster {
         }
         LOGGER.info(message("processing.disk.requirements"), String.format("%.2f", requiredDiskSpace), unit);
         try {
-            var path = Path.of(System.getProperty("java.io.tmpdir"));
+            var path = TemporaryFolder.tempDir();
             var freespace = Files.getFileStore(path)
                 .getUsableSpace();
             if (freespace < requiredDiskSpace) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImage.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImage.java
@@ -69,10 +69,7 @@ public final class FileBackedImage implements ImageWrapper {
         var width = wrapper.width();
         var height = wrapper.height();
         try {
-            var tempDir = Path.of(System.getProperty("java.io.tmpdir")).resolve("jsolex");
-            Files.createDirectories(tempDir);
-            var backingFile = Files.createTempFile(tempDir, "jsolex", ".img");
-            backingFile.toFile().deleteOnExit();
+            var backingFile = TemporaryFolder.newTempFile("jsolex", ".img");
             try (var raf = new RandomAccessFile(backingFile.toFile(), "rw")) {
                 var channel = raf.getChannel();
                 if (wrapper instanceof ImageWrapper32 mono) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/TemporaryFolder.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/TemporaryFolder.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class TemporaryFolder {
+    private static final Path TEMP_DIR = tempDir(ProcessHandle.current().pid());
+    private static final String JSOLEX_PREFIX = "jsolex";
+
+    private TemporaryFolder() {
+    }
+
+    static {
+        var baseTempDir = tempDir(null);
+        if (Files.isDirectory(baseTempDir)) {
+            try (var list = Files.list(baseTempDir)) {
+                list.forEach(p -> Thread.startVirtualThread(() -> {
+                    try {
+                        if (!Files.isDirectory(p)) {
+                            // old temp file, old version of JSol'Ex, delete it!
+                            Files.delete(p);
+                        } else {
+                            try {
+                                var pid = Long.parseLong(p.toFile().getName());
+                                if (ProcessHandle.of(pid).isEmpty()) {
+                                    deleteRecursively(p);
+                                }
+                            } catch (NumberFormatException e) {
+                                // not a PID, delete
+                                deleteRecursively(p);
+                            }
+                        }
+                    } catch (IOException e) {
+                        // ignore
+                    }
+                }));
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+    }
+
+    private static Path tempDir(Long pid) {
+        var baseDir = Path.of(System.getProperty("java.io.tmpdir")).resolve(JSOLEX_PREFIX);
+        var dir = pid == null ? baseDir : baseDir.resolve(pid.toString());
+        dir.toFile().deleteOnExit();
+        return dir;
+    }
+
+    public static Path tempDir() {
+        return TEMP_DIR;
+    }
+
+    public static Path newTempFile(String prefix, String suffix) throws IOException {
+        Files.createDirectories(TEMP_DIR);
+        var tempFile = Files.createTempFile(TEMP_DIR, prefix, suffix);
+        tempFile.toFile().deleteOnExit();
+        return tempFile;
+    }
+
+
+    private static void deleteRecursively(Path path) throws IOException {
+        if (Files.isDirectory(path)) {
+            try (var list = Files.list(path)) {
+                list.forEach(p -> {
+                    try {
+                        deleteRecursively(p);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+            }
+        }
+        Files.delete(path);
+    }
+
+    public static Path newTempDir(String dirName) throws IOException {
+        var tempDir = TEMP_DIR.resolve(dirName);
+        tempDir.toFile().deleteOnExit();
+        Files.createDirectories(tempDir);
+        return tempDir;
+    }
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/VersionUtil.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/VersionUtil.java
@@ -73,7 +73,7 @@ public class VersionUtil {
         if (System.getProperty("tmp.home") != null) {
             try {
                 if (TEMPORARY_HOME == null) {
-                    TEMPORARY_HOME = Files.createTempDirectory("jsolex");
+                    TEMPORARY_HOME = TemporaryFolder.newTempDir("jsolex");
                 }
                 path = TEMPORARY_HOME;
             } catch (IOException e) {

--- a/jsolex-server/src/main/java/me/champeau/a4j/jsolex/server/ImagesStore.java
+++ b/jsolex-server/src/main/java/me/champeau/a4j/jsolex/server/ImagesStore.java
@@ -25,8 +25,8 @@ import me.champeau.a4j.jsolex.processing.sun.workflow.GeneratedImageKind;
 import me.champeau.a4j.jsolex.processing.sun.workflow.SourceInfo;
 import me.champeau.a4j.jsolex.processing.util.ImageFormat;
 import me.champeau.a4j.jsolex.processing.util.ImageSaver;
+import me.champeau.a4j.jsolex.processing.util.TemporaryFolder;
 
-import java.nio.file.Path;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -62,7 +62,7 @@ public class ImagesStore implements ProcessingEventListener {
     @Override
     public void onImageGenerated(ImageGeneratedEvent event) {
         var payload = event.getPayload();
-        var tempDir = Path.of(System.getProperty("java.io.tmpdir")).resolve("jsolex/server-images");
+        var tempDir = TemporaryFolder.tempDir().resolve("server-images");
         var id = currentId.incrementAndGet();
         var name = id + "_" + payload.path().toFile().getName() + ".jpg";
         var saved = tempDir.resolve(name).toFile();

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
@@ -125,6 +125,7 @@ import me.champeau.a4j.jsolex.processing.util.FilesUtils;
 import me.champeau.a4j.jsolex.processing.util.LoggingSupport;
 import me.champeau.a4j.jsolex.processing.util.MutableMap;
 import me.champeau.a4j.jsolex.processing.util.ProcessingException;
+import me.champeau.a4j.jsolex.processing.util.TemporaryFolder;
 import me.champeau.a4j.jsolex.processing.util.VersionUtil;
 import me.champeau.a4j.math.VectorApiSupport;
 import me.champeau.a4j.ser.Header;
@@ -1110,7 +1111,7 @@ public class JSolEx extends Application implements JSolExInterface {
                 var useFullRangePanels = fullRangePanels.isSelected();
                 var annotate = annotateAnimations.isSelected();
                 try {
-                    if (Files.getFileStore(Path.of(System.getProperty("java.io.tmpdir"))).getUsableSpace() < processor.estimateRequiredBytesForProcessingWithMargin(margin)) {
+                    if (Files.getFileStore(TemporaryFolder.tempDir()).getUsableSpace() < processor.estimateRequiredBytesForProcessingWithMargin(margin)) {
                         var alert = AlertFactory.confirmation(message("disk.space.error.confirm"));
                         var result = alert.showAndWait();
                         if (result.isPresent() && result.get() == ButtonType.CANCEL) {

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/CustomAnimationCreator.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/CustomAnimationCreator.java
@@ -31,10 +31,10 @@ import me.champeau.a4j.jsolex.app.listeners.RedshiftImagesProcessor;
 import me.champeau.a4j.jsolex.processing.params.ProcessParams;
 import me.champeau.a4j.jsolex.processing.sun.workflow.PixelShiftRange;
 import me.champeau.a4j.jsolex.processing.util.BackgroundOperations;
+import me.champeau.a4j.jsolex.processing.util.TemporaryFolder;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 
 import static me.champeau.a4j.jsolex.app.JSolEx.message;
 
@@ -215,7 +215,7 @@ public class CustomAnimationCreator {
     private void generate() {
         double imageCount = Double.parseDouble(maxShift.getText())-Double.parseDouble(minShift.getText());
         try {
-            if (Files.getFileStore(Path.of(System.getProperty("java.io.tmpdir"))).getUsableSpace() < redshiftProcessor.estimateRequiredBytesForProcessing(imageCount)) {
+            if (Files.getFileStore(TemporaryFolder.tempDir()).getUsableSpace() < redshiftProcessor.estimateRequiredBytesForProcessing(imageCount)) {
                 var alert = AlertFactory.error(message("disk.space.error"));
                 alert.showAndWait();
                 return;

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
@@ -61,11 +61,11 @@ import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.ProcessingException;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
 import me.champeau.a4j.jsolex.processing.util.SolarParametersUtils;
+import me.champeau.a4j.jsolex.processing.util.TemporaryFolder;
 import me.champeau.a4j.math.regression.Ellipse;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.List;
@@ -486,7 +486,7 @@ public class ImageViewer implements WithRootNode {
     private File createTmpFile() {
         File tmpImage;
         try {
-            tmpImage = Files.createTempFile(imageFile.getName(), "jsolex.png").toFile();
+            tmpImage = TemporaryFolder.newTempFile(imageFile.getName(), "jsolex.png").toFile();
         } catch (IOException e) {
             throw new ProcessingException(e);
         }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/MultipleImagesViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/MultipleImagesViewer.java
@@ -37,6 +37,7 @@ import me.champeau.a4j.jsolex.processing.sun.workflow.DisplayCategory;
 import me.champeau.a4j.jsolex.processing.sun.workflow.GeneratedImageKind;
 import me.champeau.a4j.jsolex.processing.sun.workflow.PixelShift;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
+import me.champeau.a4j.jsolex.processing.util.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
@@ -123,16 +124,16 @@ public class MultipleImagesViewer extends Pane {
     }
 
     public <T extends WithRootNode> T addImage(ProcessingEventListener listener,
-                                String title,
-                                String baseName,
-                                GeneratedImageKind kind,
-                                ImageWrapper imageWrapper,
-                                File file,
-                                ProcessParams params,
-                                Map<String, ImageViewer> popupViews,
-                                PixelShift pixelShift,
-                                Function<? super ImageViewer, T> transformer,
-                                Consumer<? super ImageViewer> onShow) {
+                                               String title,
+                                               String baseName,
+                                               GeneratedImageKind kind,
+                                               ImageWrapper imageWrapper,
+                                               File file,
+                                               ProcessParams params,
+                                               Map<String, ImageViewer> popupViews,
+                                               PixelShift pixelShift,
+                                               Function<? super ImageViewer, T> transformer,
+                                               Consumer<? super ImageViewer> onShow) {
         var category = getOrCreateCategory(kind);
         var viewer = newImageViewer();
         var transformed = transformer.apply(viewer);
@@ -220,9 +221,7 @@ public class MultipleImagesViewer extends Pane {
             // for example because of re-running a script which writes the file in the same location,
             // file writing will fail because the media player has locked the file
             try {
-                var tempDir = Path.of(System.getProperty("java.io.tmpdir")).resolve("jsolex");
-                Files.createDirectories(tempDir);
-                var tempFile = Files.createTempFile(tempDir, "jsolex", ".mp4");
+                var tempFile = TemporaryFolder.newTempFile("jsolex", ".mp4");
                 Files.copy(filePath, tempFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
                 return new Media(tempFile.toUri().toString());
             } catch (IOException e) {
@@ -271,7 +270,7 @@ public class MultipleImagesViewer extends Pane {
     }
 
     private CategoryPane addCategory(DisplayCategory category) {
-        var categoryPane = new CategoryPane(message("displayCategory." + category.name()), e ->{
+        var categoryPane = new CategoryPane(message("displayCategory." + category.name()), e -> {
             categories.remove(e);
             safeCategories.remove(e);
         });

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/SpectralLineDebugger.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/SpectralLineDebugger.java
@@ -60,6 +60,7 @@ import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.MutableMap;
 import me.champeau.a4j.jsolex.processing.util.ProcessingException;
 import me.champeau.a4j.jsolex.processing.util.SpectralLineFrameImageCreator;
+import me.champeau.a4j.jsolex.processing.util.TemporaryFolder;
 import me.champeau.a4j.math.Point2D;
 import me.champeau.a4j.math.regression.LinearRegression;
 import me.champeau.a4j.math.tuples.DoublePair;
@@ -70,7 +71,6 @@ import me.champeau.a4j.ser.bayer.ImageConverter;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -227,9 +227,8 @@ public class SpectralLineDebugger {
             reader = SerFileReader.of(file);
             detector.computeAverageImage(reader);
             averageImage = detector.getAverageImage();
-            var tmpPath = Files.createTempFile("debug_", ".png");
+            var tmpPath = TemporaryFolder.newTempFile("debug_", ".png");
             File imageFile = tmpPath.toFile();
-            imageFile.deleteOnExit();
             Platform.runLater(() -> {
                 status.setDisable(false);
                 progressBox.setVisible(false);

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/SpectralRayEditor.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/SpectralRayEditor.java
@@ -40,6 +40,7 @@ import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.MutableMap;
 import me.champeau.a4j.jsolex.processing.util.ProcessingException;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
+import me.champeau.a4j.jsolex.processing.util.TemporaryFolder;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -228,7 +229,7 @@ public class SpectralRayEditor {
         var b = colorImage.b();
         Path tmpFile;
         try {
-            tmpFile = Files.createTempFile("img", ".png");
+            tmpFile = TemporaryFolder.newTempFile("img", ".png");
             ImageUtils.writeRgbImage(colorImage.width(), colorImage.height(), r, g, b, tmpFile.toFile(), EnumSet.of(ImageFormat.PNG));
             sunPreview.setImage(new Image(tmpFile.toFile().toURI().toString()));
             Files.delete(tmpFile);

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -1,5 +1,9 @@
 # Welcome to JSol'Ex {{version}}!
 
+## What's New in Version 2.10.1
+
+- Improved handling of temporary files to avoid them accumulating
+
 ## What's New in Version 2.10.0
 
 - Added ability to [trim the processed SER files](#trimming-processed-ser-files)

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -1,5 +1,9 @@
 # Bienvenue dans JSol'Ex {{version}} !
 
+## Nouveautés de la version 2.10.1
+
+- Amélioration de la gestion des fichiers temporaires pour éviter qu'ils ne s'accumulent
+
 ## Nouveautés de la version 2.10.0
 
 - Ajout de la possibilité de [réduire les fichiers SER traités](#réduction-des-fichiers-ser)


### PR DESCRIPTION
This commit reworks the temporary folder handling, so that we delete files from old sessions. We do this by restructuring the folder, so that it's named against the current PID. If a process is still alive, then we won't delete it.

Fixes #500