### PR TITLE
Make SER pixel depth recognition more robust

### DIFF
--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -1,5 +1,9 @@
 # Welcome to JSol'Ex {{version}}!
 
+## What's New in Version 2.11.2
+
+- Made SER file pixel depth detection more robust
+
 ## What's New in Version 2.11.1
 
 - Added a description to the generated images

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -1,5 +1,9 @@
 # Bienvenue dans JSol'Ex {{version}} !
 
+## Nouveautés de la version 2.11.2
+
+- Amélioration de la détection de la profondeur de pixel des fichiers SER
+
 ## Nouveautés de la version 2.11.1
 
 - Ajout d'une description aux images générées


### PR DESCRIPTION
Before this change, we were looking for the maximum pixel depth only around the middle of the SER file. While this worked for most cases, it didn't when, for example, the SER file consisted of a long black range of frames, then the sun only in the end (or the other way around). Now sampling is regular around the whole SER file, we take a look at 10% of the frames.

Fixes a bug discovered while processing a file from @splanquart

