### PR TITLE
Make stretching configurable in image view

### DIFF
--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages.properties
@@ -121,3 +121,6 @@ trimming.success.title=Trimming successful
 trimming.success=Trimmed file written to %s\n   - Initial size %.2f MB\n   - Final size %.2f MB\n   - Reduced by %.2f%%.\n\nDo you want to process the trimmed file?
 trimmiing.failed=Failed to trim file.
 server=Server
+stretching.linear=Linear stretch
+stretching.no_stretch=No stretch
+stretching.label=Stretching

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages_fr.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages_fr.properties
@@ -123,3 +123,6 @@ trimming.success.title=Opération réussie
 delete.ser.file.tooltip=Supprime le fichier SER traité
 trim.ser.file.tooltip=Réduit le fichier SER traité pour réduire l'espace disque utilisé
 server=Serveur
+stretching.linear=Étirement linéaire
+stretching.no_stretch=Aucun étirement
+stretching.label=Étirement

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -1,7 +1,8 @@
 # Welcome to JSol'Ex {{version}}!
 
-# What's New in Version 2.12.0
+# What's New in Version 3.0.0
 
+- Add ability to disable stretching in image display
 - Add background neutralization to the automatic contrast enhancement image to remove residual reflections
 - Introduced new `BG_MODEL` function to model the background of the image
 - Added `A2PX` and `PX2A` to convert from Angstroms to pixels and vice versa, based on the computed spectral dispersion
@@ -10,65 +11,6 @@
 - Added `WAVELEN` function which returns the wavelength of an image, based on its pixel shift, dispersion and reference wavelength
 - Fixed bug where the detected ellipse wasn't reused when computing images at different shifts, which could cause disks or images of different sizes
 - Fixed histogram not opening correctly in a new window
-
-## What's New in Version 2.11.2
-
-- Made SER file pixel depth detection more robust
-- Added geometry corrected image (no contrast enhancement) to the quick mode
-- Improve performance of SER conversion
-- Let user use decimal numbers for focal length and slew rates
-- Add sunscan to the list of setups
-- Adjust focal length of MLAstro SHG700 to 72mm
-
-## What's New in Version 2.11.1
-
-- Added a description to the generated images
-- Fixed loading of TIF images in the image reviewing tool
-- Fixed selection of images in the list of the reviewing tool which could be lost when clicking next/previous
-
-## What's New in Version 2.11.0
-
-- Added an image reviewing tool to quickly browse through processed images in batch mode and reject bad scans
-- Improve responsiveness of the UI
-
-## What's New in Version 2.10.1
-
-- Improved handling of temporary files to avoid them accumulating
-- Fixed `continuum` function which could fail in some rare cases
-- Support binary operation on lists of same size: for example min(list1, list2) applies `min` on each element of the lists
-- Added `concat` function to concatenate lists
-- Save `CENTER_X`, `CENTER_Y` and `SOLAR_R` in FITS header for INTI compatibility
-
-## What's New in Version 2.10.0
-
-- Added ability to [trim the processed SER files](#trimming-processed-ser-files)
-- Added an embedded [web server](#embedded-web-server)
-- Added convolution kernel size for `SHARPEN` and `BLUR` functions
-- Fixed rare bug where ellipse fitting would fail despite being detected
-- Process files sequentially in batch mode instead of concurrently to reduce pressure on lower end machines
-
-### Trimming Processed SER Files
-
-Sometimes, for practical reasons, the SER files that you are processing may contain a lot of empty frames at the beginning or end of the file, for example if you are using a mount that takes a few seconds to stabilize before starting the acquisition.
-Sometimes, you may also have used a large cropping window, which contains significantly more spectral lines than useful for the processing.
-
-In these cases, it is possible to trim the processed SER files to remove these empty frames and reduce the size of the files.
-At the end of processing, the "Trim SER file" button will be enabled, and will suggest a range of frames to keep, as well as a portion of each frame to crop.
-These are based on the detection of the solar disk in the frames, with a 10% margin.
-In addition, the trimmed SER file will have "smile" correction applied, which means that all lines will be perfectly horizontal.
-You have the option to choose how many pixels you want to keep around the center line.
-
-## Embedded Web Server
-
-JSol'Ex is sometimes used in public settings, where it can be interesting to show the sun live.
-For this purpose, JSol'Ex offered an option to open images in a separate window (by right-clicking on it), which would make it possible, for example, to move that window on an external screen.
-However, the limitation is that your computer has to be wired to an external monitor.
-With this release, a new, simplified UI is available via the "Tools" menu.
-You can start an embedded web server which will serve images being processed.
-The advantage is that you can share the URL to the server to people on the same network: each of them can see the images on their own devices.
-This also makes it possible to use an external screen from a remote computer.
-
-The web server listens by default on port `9122`, and can be activated by going to the "Tools" menu.
 
 ## Message to US citizen and far right supporters
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -1,7 +1,8 @@
 # Bienvenue dans JSol'Ex {{version}} !
 
-## Nouveautés de la version 2.12.0
+## Nouveautés de la version 3.0.0
 
+- Ajout de la possibilité de désactiver l'étirement dans l'affichage des images
 - Ajout de la neutralisation de fond dans l'algorithme d'amélioration du contraste pour supprimer les réflexions résiduelles
 - Introduction de la nouvelle fonction `BG_MODEL` pour modéliser l'arrière-plan de l'image
 - Ajout de `A2PX` et `PX2A` pour convertir d'Angströms en pixels et vice versa, basé sur la dispersion spectrale calculée
@@ -10,67 +11,6 @@
 - Ajout de la fonction `WAVELEN` qui retourne la longueur d'onde d'une image, basée sur son décalage de pixel, sa dispersion et la longueur d'onde de référence
 - Correction d'un bug avec lequel l'ellipse détectée n'était pas réutilisée lors du calcul d'images à des décalages différents, ce qui pouvait causer des disques ou des images de tailles différentes
 - Correction de l'histogramme ne s'ouvrant pas correctement dans une nouvelle fenêtre
-
-## Nouveautés de la version 2.11.2
-
-- Amélioration de la détection de la profondeur de pixel des fichiers SER
-- Ajout de l'image corrigée géométriquement (sans amélioration du contraste) dans le mode rapide
-- Amélioration des performances de la conversion SER
-- Utilisation de la version française pour tous les pays francophones (et non uniquement la France)
-- Possibilité d'utiliser des nombres décimaux pour la focale et les vitesses de déplacement
-- Ajout du Sunscan dans la liste des équipements
-- Ajustement de la focale du MLAstro SHG700 à 72mm
-
-## Nouveautés de la version 2.11.1
-
-- Ajout d'une description aux images générées
-- Correction du chargement des images TIF dans l'outil de revue d'images
-- Correction de la sélection des images dans la liste de l'outil de revue qui pouvait être perdue lors du clic sur suivant/précédent
-
-## Nouveautés de la version 2.11.0
-
-- Ajout d'un outil de revue d'images pour parcourir rapidement les images traitées en mode batch et rejeter les mauvais scans
-- Amélioration de la réactivité de l'interface utilisateur
-
-## Nouveautés de la version 2.10.1
-
-- Amélioration de la gestion des fichiers temporaires pour éviter qu'ils ne s'accumulent
-- Correction de la fonction `continuum` qui pouvait échouer dans certains cas rares
-- Support des opérations binaires sur des listes de même taille : par exemple `min(list1, list2)` applique `min` sur chaque élément des listes
-- Ajout de la fonction `concat` pour concaténer des listes
-- Ajout de `CENTER_X`, `CENTER_Y` et `SOLAR_R` dans l'en-tête FITS pour la compatibilité avec les outils INTI
-
-## Nouveautés de la version 2.10.0
-
-- Ajout de la possibilité de [réduire les fichiers SER traités](#réduction-des-fichiers-ser)
-- Ajout d'un [serveur web embarqué](#serveur-web-embarqué)
-- Ajout de la taille du noyau de convolution pour les fonctions `SHARPEN` et `BLUR`
-- Correction d'un bug rare où la régression d'ellipse échouait malgré sa détection
-- Traitement des fichiers en séquence dans le mode batch, pour réduire la pression sur les machines moins puissantes
-
-### Réduction des fichiers SER
-
-De temps en temps, pour des raisons pratiques, les fichiers SER que vous traitez peuvent contenir beaucoup de trames vides au début ou à la fin du fichier, par exemple si vous utilisez une monture qui met quelques secondes à se stabiliser avant de commencer l'acquisition.
-D'autres fois, vous avez peut-être utilisé une fenêtre de recadrage large, qui contient significativement plus de lignes spectrales que nécessaire pour le traitement.
-
-Dans ces situations, il est possible de réduire les fichiers SER traités pour supprimer ces trames vides et réduire la taille des fichiers.
-A la fin du traitement, le bouton "Réduire le fichier SER" sera activé, et proposera une plage de trames à conserver, ainsi qu'une portion de chaque trame à recadrer.
-Ces valeurs sont basées sur la détection du disque solaire dans les trames, avec une marge de 10%.
-De plus, le fichier SER réduit aura une correction du "sourire" appliquée, ce qui signifie que toutes les lignes seront parfaitement horizontales.
-Vous disposez de la possibilité de choisir combien de pixels vous souhaitez conserver autour de la ligne centrale.
-
-## Serveur Web embarqué
-
-JSol'Ex est parfois utilisé dans des événements publics, où il peut être intéressant de projeter le soleil en direct avec un vidéoprojecteur par exemple.
-Pour cela, JSol'Ex proposait déja une option permettant d'ouvrir les images dans une fenêtre séparée (en faisant un clic droit dessus), ce qui permettrait par exemple de déplacer cette fenêtre sur un écran externe.
-Cependant, la limitation est que votre ordinateur doit être connecté à un moniteur externe.
-
-Avec cette nouvelle version, une interface web simplifiée est disponible via le menu "Outils".
-Vous pouvez démarrer un serveur Web embarqué qui servira les images en cours de traitement.
-L'avantage est que vous pouvez partager l'URL du serveur avec des personnes du même réseau : chacune d'entre elles peut voir les images sur son propre appareil par exemple.
-Cela permet également d'utiliser un écran externe depuis un ordinateur distant.
-
-Le serveur Web écoute par défaut sur le port `9122` et peut être activé en allant dans le menu "Outils".
 
 ## Message aux utilisateurs français
 


### PR DESCRIPTION
This can be useful when using scripts and that you need to see the result of an image _without_ any post-processing.