### PR TITLE
Improve prominence stretching

### DIFF
--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -4,6 +4,7 @@
 
 - Add ability to disable stretching in image display
 - Add background neutralization to the automatic contrast enhancement image to remove residual reflections
+- Improve prominence stretching in automatic contrast enhancement
 - Introduced new `BG_MODEL` function to model the background of the image
 - Added `A2PX` and `PX2A` to convert from Angstroms to pixels and vice versa, based on the computed spectral dispersion
 - Added an optional parameter to `FIND_SHIFT` corresponding to the reference wavelength

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -4,6 +4,7 @@
 
 - Ajout de la possibilité de désactiver l'étirement dans l'affichage des images
 - Ajout de la neutralisation de fond dans l'algorithme d'amélioration du contraste pour supprimer les réflexions résiduelles
+- Amélioration de l'étirement des protubérances dans l'amélioration automatique du contraste
 - Introduction de la nouvelle fonction `BG_MODEL` pour modéliser l'arrière-plan de l'image
 - Ajout de `A2PX` et `PX2A` pour convertir d'Angströms en pixels et vice versa, basé sur la dispersion spectrale calculée
 - Ajout d'un paramètre optionnel à `FIND_SHIFT` correspondant à la longueur d'onde de référence


### PR DESCRIPTION
This algorithm improves prominence stretching, now that we use background modeling, we can more reliably use arcsin stretching for the prominences, then blend the result.