### PR TITLE
Support for named parameters

### DIFF
--- a/jsolex-cli/src/main/java/me/champeau/a4j/jsolex/cli/Main.java
+++ b/jsolex-cli/src/main/java/me/champeau/a4j/jsolex/cli/Main.java
@@ -47,6 +47,8 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Set;
 
+import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectoriesIfNeeded;
+
 
 @Command(name = "jsolex", description = "Sol'Ex spectroheliograph video processing",
         mixinStandardHelpOptions = true)
@@ -120,7 +122,7 @@ public class Main implements Runnable {
             }
         }
         try (var ioExecutor = ForkJoinParallelExecutor.newExecutor(1)) {
-            Files.createDirectories(outputDir.toPath());
+            createDirectoriesIfNeeded(outputDir.toPath());
             var processor = new SolexVideoProcessor(
                     inputFile,
                     outputDir.toPath(),

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/BuiltinFunction.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/BuiltinFunction.java
@@ -15,100 +15,136 @@
  */
 package me.champeau.a4j.jsolex.expr;
 
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public enum BuiltinFunction {
-    A2PX,
-    ADJUST_CONTRAST,
-    ADJUST_GAMMA,
-    ANIM,
-    ASINH_STRETCH,
-    AUTO_CONTRAST,
-    AUTOCROP,
-    AUTOCROP2,
-    AVG,
-    BG_MODEL,
-    MEDIAN,
-    BLUR,
-    CLAHE,
-    CHOOSE_FILE,
-    CHOOSE_FILES,
-    COLORIZE,
-    CONCAT,
-    CONTINUUM,
-    CROP,
-    CROP_RECT,
-    CROP_AR,
-    DEDISTORT,
-    DISK_FILL,
-    DISK_MASK,
-    DRAW_ARROW,
-    DRAW_CIRCLE,
-    DRAW_RECT,
-    DRAW_GLOBE,
-    DRAW_OBS_DETAILS,
-    DRAW_SOLAR_PARAMS,
-    DRAW_TEXT,
-    DRAW_EARTH,
-    ELLIPSE_FIT,
-    EXP,
-    FIND_SHIFT,
-    FIX_BANDING,
-    FIX_GEOMETRY,
-    FLAT_CORRECTION,
-    GET_AT,
-    GET_B,
-    GET_G,
-    GET_R,
-    HFLIP,
-    IMG,
-    INVERT,
-    LINEAR_STRETCH,
-    LIST,
-    LOAD,
-    LOAD_MANY,
-    LOG,
-    MAX,
-    MIN,
-    MONO,
-    MOSAIC,
-    NEUTRALIZE_BG,
-    POW,
-    PX2A,
-    RADIUS_RESCALE,
-    RANGE,
-    REMOVE_BG,
-    REMOTE_SCRIPTGEN,
-    RESCALE_ABS,
-    RESCALE_REL,
-    RL_DECON,
-    RGB,
-    ROTATE_LEFT,
-    ROTATE_RIGHT,
-    ROTATE_DEG,
-    ROTATE_RAD,
-    SATURATE,
-    SHARPEN,
-    STACK,
-    STACK_REF,
-    AR_OVERLAY,
-    SORT,
-    TRANSITION,
-    VFLIP,
-    FILTER,
-    VIDEO_DATETIME,
-    WAVELEN,
-    WEIGHTED_AVG,
-    WORKDIR(true);
+
+    A2PX(req("a", "angstroms"), opt("ref", "reference wavelength")),
+    ADJUST_CONTRAST(Parameter.IMG, req("min", "min value"), req("max", "max value")),
+    ADJUST_GAMMA(Parameter.IMG, req("gamma", "gamma value")),
+    ANIM(req("images", "list of images"), opt("delay", "delay (ms)")),
+    AR_OVERLAY(Parameter.IMG, opt("labels", "show labels")),
+    ASINH_STRETCH(Parameter.IMG, req("bp", "black point"), req("stretch", "stretch value")),
+    AUTOCROP(Parameter.IMG, opt("ellipse", "ellipse")),
+    AUTOCROP2(Parameter.IMG, opt("factor", "factor"), opt("rounding", "rounding"), opt("ellipse", "ellipse")),
+    AUTO_CONTRAST(Parameter.IMG, req("gamma", "gamma value")),
+    AVG(Parameter.SPREAD_LIST),
+    BG_MODEL(Parameter.IMG, opt("order", "order"), opt("sigma", "sigma")),
+    BLUR(Parameter.IMG, opt("kernel", "kernel size")),
+    CHOOSE_FILE(req("id", "identifier"), req("message", "title")),
+    CHOOSE_FILES(req("id", "identifier"), req("message", "title")),
+    CLAHE(Parameter.IMG, req("ts", "tile size"), req("bins", "bins"), req("clip", "clip limit")),
+    COLORIZE(Parameter.IMG, req("rIn"), req("rOut"), req("gIn"), req("gOut"), req("bIn"), req("bOut"), req("color")),
+    CONCAT(Parameter.SPREAD_LIST),
+    CONTINUUM(),
+    CROP(Parameter.IMG, req("left"), req("top"), req("width"), req("height")),
+    CROP_AR(Parameter.IMG, opt("ms", "minimum size"), opt("margin", "margin (%)")),
+    CROP_RECT(Parameter.IMG, req("width"), req("height"), opt("ellipse")),
+    DEDISTORT(req("ref"), Parameter.IMG, opt("ts", "tile size"), opt("sampling"), opt("threshold")),
+    DISK_FILL(Parameter.IMG, opt("color"), opt("ellipse")),
+    DISK_MASK(Parameter.IMG, opt("invert", "0 or 1")),
+    DRAW_ARROW(Parameter.IMG, req("x1"), req("y1"), req("x2"), req("y2"), opt("thickness"), opt("color")),
+    DRAW_CIRCLE(Parameter.IMG, req("cx", "center x"), req("cy", "center y"), req("radius"), opt("thickness"), opt("color")),
+    DRAW_EARTH(Parameter.IMG, opt("x", "x coordinate"), opt("y", "y coordinate")),
+    DRAW_GLOBE(Parameter.IMG, opt("angleP"), opt("b0"), opt("ellipse")),
+    DRAW_OBS_DETAILS(Parameter.IMG, opt("x", "x coordinate"), opt("y", "y coordinate")),
+    DRAW_RECT(Parameter.IMG, req("x", "x coordinate"), req("y", "y coordinate"), req("width"), req("height"), opt("thickness"), opt("color")),
+    DRAW_SOLAR_PARAMS(Parameter.IMG, opt("x", "x coordinate"), opt("y", "y coordinate"), opt("ellipse")),
+    DRAW_TEXT(Parameter.IMG, req("x", "x coordinate"), req("y", "y coordinate"), req("text"), opt("fs", "font size"), opt("color")),
+    ELLIPSE_FIT(Parameter.IMG),
+    EQUALIZE(req("list")),
+    EXP(Parameter.ANY, req("exp", "exponent")),
+    FILTER(Parameter.IMG, req("subject"), req("function"), req("value")),
+    FIND_SHIFT(req("wl", "wavelength in angstroms or spectral ray name"), opt("ref", "wavelength or spectral ray of reference")),
+    FIX_BANDING(Parameter.IMG, req("bs", "band size"), req("passes"), opt("ellipse")),
+    FIX_GEOMETRY(Parameter.IMG),
+    FLAT_CORRECTION(Parameter.IMG, opt("lo", "low percentile"), opt("hi", "high percentile"), opt("order")),
+    GET_AT(req("list"), req("index", "index")),
+    GET_B(Parameter.IMG),
+    GET_G(Parameter.IMG),
+    GET_R(Parameter.IMG),
+    HFLIP(Parameter.IMG),
+    IMG(req("ps", "pixel shift")),
+    INVERT(Parameter.IMG),
+    LINEAR_STRETCH(Parameter.IMG, opt("lo", "low value"), opt("hi", "high value")),
+    LIST(Parameter.SPREAD_LIST),
+    LOAD(req("file", "file path")),
+    LOAD_MANY(req("dir", "directory"), opt("pattern")),
+    LOG(Parameter.ANY, req("exp", "exponent")),
+    MAX(Parameter.SPREAD_LIST),
+    MEDIAN(Parameter.SPREAD_LIST),
+    MIN(Parameter.SPREAD_LIST),
+    MONO(Parameter.IMG),
+    MOSAIC(req("images"), opt("ts", "tile size"), opt("sampling")),
+    NEUTRALIZE_BG(Parameter.IMG, opt("iterations")),
+    POW(Parameter.ANY, req("exp", "exponent")),
+    PX2A(req("px", "pixels"), opt("ref", "reference wavelength in angstroms")),
+    RADIUS_RESCALE(req("images")),
+    RANGE(req("from"), req("to"), opt("step")),
+    REMOTE_SCRIPTGEN(req("url")),
+    REMOVE_BG(Parameter.IMG, opt("tolerance"), opt("ellipse")),
+    RESCALE_ABS(Parameter.IMG, req("width"), req("height")),
+    RESCALE_REL(Parameter.IMG, req("sx", "scale x"), req("sy", "scale y")),
+    RGB(req("r", "red"), req("g", "green"), req("b", "blue")),
+    RL_DECON(Parameter.IMG, opt("radius"), opt("sigma"), opt("iterations")),
+    ROTATE_DEG(Parameter.IMG, req("angle", "angle in degrees"), opt("bp", "black point"), opt("resize")),
+    ROTATE_LEFT(Parameter.IMG),
+    ROTATE_RAD(Parameter.IMG, req("angle", "angle in radians"), opt("bp", "black point"), opt("resize")),
+    ROTATE_RIGHT(Parameter.IMG),
+    SATURATE(Parameter.IMG, req("factor", "saturation factor")),
+    SHARPEN(Parameter.IMG, opt("kernel", "kernel size")),
+    SORT(req("images"), req("order", "sort order")),
+    STACK(req("images"), opt("ts", "tile size"), opt("sampling"), opt("select", "reference selection")),
+    STACK_REF(req("images"), opt("select", "reference selection")),
+    TRANSITION(req("images"), req("steps", "nb of steps"), opt("type", "transition type"), opt("unit" , "ips/ipm/iph")),
+    VFLIP(Parameter.IMG),
+    VIDEO_DATETIME(Parameter.IMG, opt("format")),
+    WAVELEN(Parameter.IMG),
+    WEIGHTED_AVG(req("images"), opt("weights")),
+    WORKDIR(true, List.of(req("dir", "directory")));
 
     private final boolean hasSideEffect;
+    private final List<Parameter> parameters;
 
-    BuiltinFunction(boolean hasSideEffect) {
-        this.hasSideEffect = hasSideEffect;
+
+    private static Parameter req(String name) {
+        return req(name, name);
+    }
+
+    private static Parameter req(String name, String description) {
+        return new Parameter(name, description, true);
+    }
+
+    private static Parameter opt(String name) {
+        return opt(name, name);
+    }
+
+    private static Parameter opt(String name, String description) {
+        return new Parameter(name, description, false);
     }
 
     BuiltinFunction() {
-        this(false);
+        this(false, List.of());
+    }
+
+    BuiltinFunction(boolean hasSideEffect, List<Parameter> parameters) {
+        this.hasSideEffect = hasSideEffect;
+        this.parameters = parameters;
+    }
+
+    BuiltinFunction(Parameter... parameters) {
+        this(false, Arrays.stream(parameters).toList());
+    }
+
+    BuiltinFunction(String... parameters) {
+        this(false, Arrays.stream(parameters).map(s -> new Parameter(s, null, true)).toList());
     }
 
     public String lowerCaseName() {
@@ -121,5 +157,121 @@ public enum BuiltinFunction {
 
     public boolean hasSideEffect() {
         return hasSideEffect;
+    }
+
+    public void validateArgs(Map<String, Object> args) {
+        if (this.parameters.size() == 1 && Parameter.SPREAD_LIST.equals(this.parameters.getFirst())) {
+            return;
+        }
+        var keys = args.keySet();
+        var required = parameters.stream().filter(Parameter::required).map(Parameter::name).collect(Collectors.toSet());
+        var missing = required.stream().filter(k -> !keys.contains(k)).collect(Collectors.toSet());
+        if (!missing.isEmpty()) {
+            var sb = new StringBuilder();
+            sb.append("Function '")
+                    .append(name())
+                    .append("' is missing required arguments: ");
+            for (String key : missing) {
+                sb.append(key).append(", ");
+            }
+            sb.setLength(sb.length() - 2); // remove last comma
+            throw new IllegalArgumentException(sb.toString());
+        }
+        var unknown = keys.stream().filter(k -> parameters.stream().noneMatch(p -> p.name.equals(k))).collect(Collectors.toSet());
+        if (!unknown.isEmpty()) {
+            var sb = new StringBuilder();
+            sb.append("Function '")
+                    .append(name())
+                    .append("' has unknown arguments: ");
+            for (String key : unknown) {
+                sb.append(key).append(", ");
+            }
+            sb.setLength(sb.length() - 2); // remove last comma
+            throw new IllegalArgumentException(sb.toString());
+        }
+    }
+
+    /**
+     * Maps the positional arguments to a map of named arguments.
+     * @param args the positional arguments
+     * @return a map of named arguments
+     */
+    public Map<String, Object> mapPositionalArguments(List<Object> args) {
+        if (this.parameters.size() == 1 && Parameter.SPREAD_LIST.equals(this.parameters.getFirst())) {
+            return Map.of("list", args);
+        }
+        // special case for colorize
+        if (this == COLORIZE) {
+            if (args.size() == 7) {
+                return Map.of(
+                        "img", args.getFirst(),
+                        "rIn", args.get(1),
+                        "rOut", args.get(2),
+                        "gIn", args.get(3),
+                        "gOut", args.get(4),
+                        "bIn", args.get(5),
+                        "bOut", args.get(6)
+                );
+            } else if (args.size() == 2) {
+                return Map.of(
+                        "img", args.getFirst(),
+                        "color", args.get(1)
+                );
+            }
+        }
+        var minArgs = parameters.stream().filter(p -> p.required).count();
+        var totalArgs = parameters.size();
+        if (args.size() < minArgs || args.size() > totalArgs) {
+            var sb = new StringBuilder();
+            sb.append("Function '")
+                    .append(name());
+            if (minArgs == totalArgs) {
+                sb.append("' expects ").append(totalArgs).append(" argument")
+                        .append(totalArgs > 1 ? "s" : "").append(": ");
+            } else {
+                sb.append("' expects between ")
+                        .append(minArgs)
+                        .append(" and ")
+                        .append(totalArgs)
+                        .append(" arguments: ");
+            }
+            for (int i = 0; i < parameters.size(); i++) {
+                var parameter = parameters.get(i);
+                if (!parameter.required()) {
+                    sb.append("[");
+                }
+                sb.append(parameter.name());
+                if (parameter.description != null) {
+                    sb.append(": (").append(parameter.description).append(")");
+                }
+                if (!parameter.required()) {
+                    sb.append("]");
+                }
+                if (i < parameters.size() - 1) {
+                    sb.append(", ");
+                }
+            }
+            throw new IllegalArgumentException(sb.toString());
+        }
+        return IntStream.range(0, args.size())
+                .mapToObj(i -> new Object() {
+                    final String name = parameters.get(i).name();
+                    final Object value = args.get(i);
+                })
+                .collect(Collectors.toMap(i -> i.name, i -> i.value, (e1, e2) -> e1, LinkedHashMap::new));
+    }
+
+    public Set<String> getAllParameterNames() {
+        return parameters.stream().map(Parameter::name).collect(Collectors.toSet());
+    }
+
+    private record Parameter(
+            String name,
+            String description,
+            boolean required
+    ) {
+        private static final Parameter SPREAD_LIST = new Parameter("list", "list", true);
+        private static final Parameter IMG = new Parameter("img", "image", true);
+        private static final Parameter ANY = new Parameter("v", "value", true);
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/ShiftCollectingImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/ShiftCollectingImageExpressionEvaluator.java
@@ -25,7 +25,6 @@ import me.champeau.a4j.jsolex.processing.util.Wavelen;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -63,7 +62,7 @@ public class ShiftCollectingImageExpressionEvaluator extends ImageExpressionEval
     }
 
     @Override
-    public Object functionCall(BuiltinFunction function, List<Object> arguments) {
+    public Object functionCall(BuiltinFunction function, Map<String, Object> arguments) {
         if (function == BuiltinFunction.CONTINUUM) {
             autoContinuum = true;
         }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/AdjustContrast.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/AdjustContrast.java
@@ -15,53 +15,126 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.stretching.AutohistogramStrategy;
 import me.champeau.a4j.jsolex.processing.stretching.ContrastAdjustmentStrategy;
 import me.champeau.a4j.jsolex.processing.stretching.GammaStrategy;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
+import me.champeau.a4j.jsolex.processing.sun.tasks.ImageAnalysis;
+import me.champeau.a4j.jsolex.processing.util.Constants;
+import me.champeau.a4j.jsolex.processing.util.FileBackedImage;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class AdjustContrast extends AbstractFunctionImpl {
     public AdjustContrast(Map<Class<?>, Object> context, Broadcaster broadcaster) {
         super(context, broadcaster);
     }
 
-    public Object adjustContrast(List<Object> arguments) {
-        if (arguments.size() != 3) {
-            throw new IllegalArgumentException("adjust_contrast takes 3 arguments (image(s), min, max)");
-        }
-        int min = intArg(arguments, 1);
-        int max = intArg(arguments, 2);
+    public Object adjustContrast(Map<String ,Object> arguments) {
+        BuiltinFunction.ADJUST_CONTRAST.validateArgs(arguments);
+        int min = intArg(arguments, "min", 0);
+        int max = intArg(arguments, "max", 255);
         if (min < 0 || min > 255) {
             throw new IllegalArgumentException("adjust_contrast min must be between 0 and 255");
         }
         if (max < 0 || max > 255) {
             throw new IllegalArgumentException("adjust_contrast max must be between 0 and 255");
         }
-        return monoToMonoImageTransformer( "adjust_contrast", 3, arguments, image -> new ContrastAdjustmentStrategy(min << 8, max << 8).stretch(image));
+        return monoToMonoImageTransformer( "adjust_contrast", "img", arguments, image -> new ContrastAdjustmentStrategy(min << 8, max << 8).stretch(image));
     }
 
-    public Object adjustGamma(List<Object> arguments) {
-        if (arguments.size() != 2) {
-            throw new IllegalArgumentException("adjust_gamma takes 2 arguments (image(s), gamma)");
-        }
-        double gamma = doubleArg(arguments, 1);
+    public Object adjustGamma(Map<String ,Object> arguments) {
+        BuiltinFunction.ADJUST_GAMMA.validateArgs(arguments);
+        double gamma = doubleArg(arguments, "gamma", 1);
         if (gamma <= 0) {
             throw new IllegalArgumentException("gamma must be positive");
         }
-        return monoToMonoImageTransformer( "adjust_gamma", 3, arguments, image -> new GammaStrategy(gamma).stretch(image));
+        return monoToMonoImageTransformer( "adjust_gamma", "img", arguments, image -> new GammaStrategy(gamma).stretch(image));
     }
 
-    public Object autoContrast(List<Object> arguments) {
-        if (arguments.size() != 2) {
-            throw new IllegalArgumentException("auto_contrast takes 2 arguments (image(s), gamma)");
-        }
-        double gamma = doubleArg(arguments, 1);
+    public Object autoContrast(Map<String ,Object> arguments) {
+        BuiltinFunction.AUTO_CONTRAST.validateArgs(arguments);
+        double gamma = doubleArg(arguments, "gamma", 1);
         if (gamma < 1) {
             throw new IllegalArgumentException("gamma must be greater than 1");
         }
-        return monoToMonoImageTransformer( "auto_contrast", 3, arguments, image -> new AutohistogramStrategy(gamma).stretch(image));
+        return monoToMonoImageTransformer( "auto_contrast", "img", arguments, image -> new AutohistogramStrategy(gamma).stretch(image));
+    }
+
+    public Object equalize(Map<String ,Object> arguments) {
+        BuiltinFunction.EQUALIZE.validateArgs(arguments);
+        if (!(arguments.get("list") instanceof List<?> topLevel) || topLevel.size() != 1) {
+            throw new IllegalArgumentException("equalize requires a list of images");
+        }
+        if (!(topLevel.getFirst() instanceof List<?> list)) {
+            throw new IllegalArgumentException("equalize requires a list of images");
+        }
+        if (list.size() < 2) {
+            return list;
+        }
+        // compute stats of all images
+        var stats = list.stream()
+                .parallel()
+                .map(i -> {
+                    var img = ((ImageWrapper)i).unwrapToMemory();
+                    if (!(img instanceof ImageWrapper32 mono)) {
+                        throw new IllegalArgumentException("equalize only supports mono images");
+                    }
+                    return new Object() {
+                        private final ImageWrapper32 image = mono.copy();
+                        private final ImageAnalysis analysis = ImageAnalysis.of(image.data());
+                    };
+                })
+                .collect(Collectors.toMap(o -> o.image, o -> o.analysis, (e1, e2) -> e1, LinkedHashMap::new));
+        // compute the average of all averages
+        var average = stats.values().stream()
+                .mapToDouble(ImageAnalysis::avg)
+                .average()
+                .orElse(0);
+        // compute the average of all standard deviations
+        var stddev = stats.values().stream()
+                .mapToDouble(ImageAnalysis::stddev)
+                .average()
+                .orElse(0);
+        // now "rescale" all images to the average and stddev
+        return stats.entrySet()
+                .stream()
+                .map(e -> {
+                    var image = e.getKey();
+                    var analysis = e.getValue();
+                    var data = image.data();
+                    for (int y=0; y < image.height(); y++) {
+                        for (int x=0; x < image.width(); x++) {
+                            double v = data[y][x] - analysis.avg();
+                            // scale by stddev
+                            v = v * stddev / analysis.stddev();
+                            // add target mean
+                            v += average;
+                            data[y][x] = (float) Math.clamp(v, 0, Constants.MAX_PIXEL_VALUE);
+                        }
+                    }
+                    return FileBackedImage.wrap(image);
+                })
+                .toList();
+    }
+
+    public static void equalize(ImageWrapper32 image, ImageAnalysis analysis, float average, float stddev) {
+        var data = image.data();
+        for (int y=0; y < image.height(); y++) {
+            for (int x=0; x < image.width(); x++) {
+                double v = data[y][x] - analysis.avg();
+                // scale by stddev
+                v = v * stddev / analysis.stddev();
+                // add target mean
+                v += average;
+                data[y][x] = (float) Math.clamp(v, 0, Constants.MAX_PIXEL_VALUE);
+            }
+        }
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ArtifificialFlatCorrector.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ArtifificialFlatCorrector.java
@@ -15,6 +15,7 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.FlatCorrection;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
@@ -28,18 +29,19 @@ public class ArtifificialFlatCorrector extends AbstractFunctionImpl {
         super(context, broadcaster);
     }
 
-    public Object performFlatCorrection(List<Object> arguments) {
+    public Object performFlatCorrection(Map<String ,Object> arguments) {
+        BuiltinFunction.FLAT_CORRECTION.validateArgs(arguments);
         if (arguments.isEmpty() || arguments.size() > 4) {
             throw new IllegalArgumentException("flat_correction takes 1 to 4 arguments (image(s), [percentileLo], [percentileHi], [order])");
         }
-        if (arguments.getFirst() instanceof List) {
-            return expandToImageList("flat_correction", arguments, this::performFlatCorrection);
+        if (arguments.get("img") instanceof List) {
+            return expandToImageList("flat_correction", "img", arguments, this::performFlatCorrection);
         }
-        if (arguments.getFirst() instanceof ImageWrapper wrapper) {
+        if (arguments.get("img") instanceof ImageWrapper wrapper) {
             if (wrapper.unwrapToMemory() instanceof ImageWrapper32 mono) {
-                double loPercentile = arguments.size()>= 2 ? doubleArg(arguments, 1) : FlatCorrection.DEFAULT_LO_PERCENTILE;
-                double hiPercentile = arguments.size() >= 3 ? doubleArg(arguments, 2) : FlatCorrection.DEFAULT_HI_PERCENTILE;
-                int order = arguments.size() >= 4 ? intArg(arguments, 3) : FlatCorrection.DEFAULT_ORDER;
+                double loPercentile = doubleArg(arguments, "lo", FlatCorrection.DEFAULT_LO_PERCENTILE);
+                double hiPercentile = doubleArg(arguments, "hi", FlatCorrection.DEFAULT_HI_PERCENTILE);
+                int order = intArg(arguments, "order", FlatCorrection.DEFAULT_ORDER);
                 var corrector = new FlatCorrection(loPercentile, hiPercentile, order);
                 return corrector.correctImage(mono);
             }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Clahe.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Clahe.java
@@ -15,10 +15,10 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.stretching.ClaheStrategy;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 
-import java.util.List;
 import java.util.Map;
 
 public class Clahe extends AbstractFunctionImpl {
@@ -27,21 +27,14 @@ public class Clahe extends AbstractFunctionImpl {
         super(context, broadcaster);
     }
 
-    public Object clahe(List<Object> arguments) {
-        if (arguments.size() != 4 && arguments.size() != 2) {
-            throw new IllegalArgumentException("clahe takes either 2 or 4 arguments (image(s), [tile_size, bins], clip)");
-        }
-        if (arguments.size() == 2) {
-            double clip = doubleArg(arguments, 1);
-            return monoToMonoImageTransformer("clahe", 2, arguments, image -> new ClaheStrategy(ClaheStrategy.DEFAULT_TILE_SIZE, ClaheStrategy.DEFAULT_BINS, clip).stretch(image));
-
-        }
-        int tileSize = intArg(arguments, 1);
-        int bins = intArg(arguments, 2);
-        double clip = doubleArg(arguments, 3);
+    public Object clahe(Map<String ,Object> arguments) {
+        BuiltinFunction.CLAHE.validateArgs(arguments);
+        int tileSize = intArg(arguments, "ts", ClaheStrategy.DEFAULT_TILE_SIZE);
+        int bins = intArg(arguments, "bins", ClaheStrategy.DEFAULT_BINS);
+        double clip = doubleArg(arguments, "clip", 1.0);
         if (tileSize * tileSize / (double) bins < 1.0) {
             throw new IllegalArgumentException("The number of bins is too high given the size of the tiles. Either reduce the bin count or increase the tile size");
         }
-        return monoToMonoImageTransformer("clahe", 4, arguments, image -> new ClaheStrategy(tileSize, bins, clip).stretch(image));
+        return monoToMonoImageTransformer("clahe", "img", arguments, image -> new ClaheStrategy(tileSize, bins, clip).stretch(image));
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Colorize.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Colorize.java
@@ -36,21 +36,20 @@ public class Colorize extends AbstractFunctionImpl {
         super(context, broadcaster);
     }
 
-    public Object colorize(List<Object> arguments) {
-        if (arguments.size() != 7 && arguments.size() != 2) {
-            throw new IllegalArgumentException("colorize takes 3 arguments (image, rIn, rOut, gIn, gOut, bIn, bOut) or 2 arguments (image, profile name)");
-        }
-        var arg = arguments.get(0);
+    public Object colorize(Map<String ,Object> arguments) {
+        //BuiltinFunction.COLORIZE.validateArgs(arguments);
+        var arg = arguments.get("img");
         if (arg instanceof List<?>) {
-            return expandToImageList("colorize", arguments, this::colorize);
+            return expandToImageList("colorize", "img", arguments, this::colorize);
         }
-        if (arguments.size() == 7) {
-            int rIn = intArg(arguments, 1);
-            int rOut = intArg(arguments, 2);
-            int gIn = intArg(arguments, 3);
-            int gOut = intArg(arguments, 4);
-            int bIn = intArg(arguments, 5);
-            int bOut = intArg(arguments, 6);
+        var color = stringArg(arguments, "color", null);
+        if (color == null) {
+            int rIn = intArg(arguments, "rIn", 0);
+            int rOut = intArg(arguments, "rOut", 255);
+            int gIn = intArg(arguments, "gIn", 0);
+            int gOut = intArg(arguments, "gOut", 255);
+            int bIn = intArg(arguments, "bIn", 0);
+            int bOut = intArg(arguments, "bOut", 255);
             if (arg instanceof FileBackedImage fileBackedImage) {
                 arg = fileBackedImage.unwrapToMemory();
             }
@@ -64,10 +63,9 @@ public class Colorize extends AbstractFunctionImpl {
             if (arg instanceof FileBackedImage fileBackedImage) {
                 arg = fileBackedImage.unwrapToMemory();
             }
-            String profile = arguments.get(1).toString();
             var rays = SpectralRayIO.loadDefaults();
             for (SpectralRay ray : rays) {
-                if (ray.label().equalsIgnoreCase(profile) && (arg instanceof ImageWrapper32 mono)) {
+                if (ray.label().equalsIgnoreCase(color) && (arg instanceof ImageWrapper32 mono)) {
                     var curve = ray.colorCurve();
                     if (curve != null) {
                         return RGBImage.fromMono(mono, data -> doColorize(mono.width(), mono.height(), data.data(), curve));
@@ -77,7 +75,7 @@ public class Colorize extends AbstractFunctionImpl {
                     }
                 }
             }
-            throw new IllegalArgumentException("Cannot find color profile '" + profile + "'");
+            throw new IllegalArgumentException("Cannot find color profile '" + color + "'");
         }
         throw new IllegalArgumentException("colorize first argument must be an image or a list of images");
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/EllipseFit.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/EllipseFit.java
@@ -15,6 +15,7 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.params.ProcessParams;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.tasks.EllipseFittingTask;
@@ -32,13 +33,11 @@ public class EllipseFit extends AbstractFunctionImpl {
         super(context, broadcaster);
     }
 
-    public Object fit(List<Object> arguments) {
-        if (arguments.size() != 1) {
-            throw new IllegalArgumentException("ellipse_fit takes 1 arguments (image(s))");
-        }
-        var arg = arguments.get(0);
+    public Object fit(Map<String ,Object> arguments) {
+        BuiltinFunction.ELLIPSE_FIT.validateArgs(arguments);
+        var arg = arguments.get("img");
         if (arg instanceof List<?>) {
-            return expandToImageList("ellipse_fit", arguments, this::fit);
+            return expandToImageList("ellipse_fit", "img", arguments, this::fit);
         }
         if (arg instanceof FileBackedImage fileBackedImage) {
             arg = fileBackedImage.unwrapToMemory();

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Filtering.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Filtering.java
@@ -15,6 +15,7 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.workflow.PixelShift;
 import me.champeau.a4j.jsolex.processing.sun.workflow.SourceInfo;
@@ -32,16 +33,16 @@ public class Filtering extends AbstractFunctionImpl {
         super(context, broadcaster);
     }
 
-    public Object filter(List<Object> arguments) {
-        assertExpectedArgCount(arguments, "filter takes 4 arguments (images, subject, function, value)", 4, 4);
-        var arg = arguments.get(0);
+    public Object filter(Map<String ,Object> arguments) {
+        BuiltinFunction.FILTER.validateArgs(arguments);
+        var arg = arguments.get("img");
         if (arg instanceof List<?>) {
-            return expandToImageList("filter", arguments, this::filter).stream().filter(Objects::nonNull).toList();
+            return expandToImageList("filter", "img", arguments, this::filter).stream().filter(Objects::nonNull).toList();
         }
-        var image = getArgument(ImageWrapper.class, arguments, 0).get();
-        var subject = stringArg(arguments, 1);
-        var function = stringArg(arguments, 2);
-        var value = stringArg(arguments, 3);
+        var image = getArgument(ImageWrapper.class, arguments, "img").get();
+        var subject = stringArg(arguments, "subject", null);
+        var function = stringArg(arguments, "function", null);
+        var value = stringArg(arguments, "value", null);
         if (test(image, subject, function, value)) {
             return image;
         }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/FixBanding.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/FixBanding.java
@@ -15,12 +15,12 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.sun.BandingReduction;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.ProcessingException;
 
-import java.util.List;
 import java.util.Map;
 
 public class FixBanding extends AbstractFunctionImpl {
@@ -28,12 +28,12 @@ public class FixBanding extends AbstractFunctionImpl {
         super(context, broadcaster);
     }
 
-    public Object fixBanding(List<Object> arguments) {
-        assertExpectedArgCount(arguments, "fix_banding takes 3 or 4 arguments (image, band size, passes, [ellipse])", 3, 4);
-        var ellipse = getEllipse(arguments, 3);
-        int bandSize = intArg(arguments, 1);
-        int passes = intArg(arguments, 2);
-        return monoToMonoImageTransformer( "fix_banding", 3, arguments, src -> {
+    public Object fixBanding(Map<String ,Object> arguments) {
+        BuiltinFunction.FIX_BANDING.validateArgs(arguments);
+        var ellipse = getEllipse(arguments, "ellipse");
+        int bandSize = intArg(arguments, "bs", 32);
+        int passes = intArg(arguments, "passes", 1);
+        return monoToMonoImageTransformer( "fix_banding", "img", arguments, src -> {
             if (src instanceof ImageWrapper32 image) {
                 var width = image.width();
                 var height = image.height();

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/GeometryCorrection.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/GeometryCorrection.java
@@ -15,6 +15,7 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.params.ProcessParams;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.WorkflowState;
@@ -42,10 +43,11 @@ public class GeometryCorrection extends AbstractFunctionImpl {
         this.ellipseFit = ellipseFit;
     }
 
-    public Object fixGeometry(List<Object> arguments) {
-        var arg = arguments.get(0);
+    public Object fixGeometry(Map<String, Object> arguments) {
+        BuiltinFunction.FIX_GEOMETRY.validateArgs(arguments);
+        var arg = arguments.get("img");
         if (arg instanceof List<?>) {
-            return expandToImageList("fix_geometry", arguments, this::fixGeometry);
+            return expandToImageList("fix_geometry", "img", arguments, this::fixGeometry);
         }
         if (arg instanceof FileBackedImage fbi) {
             arg = fbi.unwrapToMemory();
@@ -66,18 +68,18 @@ public class GeometryCorrection extends AbstractFunctionImpl {
         var state = new WorkflowState(image.width(), image.height(), 0);
         state.recordResult(WorkflowResults.RECONSTRUCTED, image);
         var task = new GeometryCorrector(
-            getFromContext(Broadcaster.class).orElse(Broadcaster.NO_OP),
-            newOperation(),
-            () -> image,
-            image.findMetadata(Ellipse.class).orElse(null),
-            null,
-            null,
-            null,
-            0,
-            getFromContext(ProcessParams.class).orElse(ProcessParams.loadDefaults()),
-            getFromContext(ImageEmitter.class).orElse(null),
-            state,
-            null
+                getFromContext(Broadcaster.class).orElse(Broadcaster.NO_OP),
+                newOperation(),
+                () -> image,
+                image.findMetadata(Ellipse.class).orElse(null),
+                null,
+                null,
+                null,
+                0,
+                getFromContext(ProcessParams.class).orElse(ProcessParams.loadDefaults()),
+                getFromContext(ImageEmitter.class).orElse(null),
+                state,
+                null
         );
         try {
             return (ImageWrapper32) task.get().corrected().unwrapToMemory();

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ImageDraw.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ImageDraw.java
@@ -15,6 +15,7 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.params.ProcessParams;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.detection.ActiveRegion;
@@ -87,19 +88,19 @@ public class ImageDraw extends AbstractFunctionImpl {
         }
     }
 
-    public Object drawObservationDetails(List<Object> arguments) {
-        assertExpectedArgCount(arguments, "draw_obs_details takes 1, 2, or 3 (image(s), [x], [y])", 1, 3);
-        var arg = arguments.get(0);
+    public Object drawObservationDetails(Map<String ,Object> arguments) {
+        BuiltinFunction.DRAW_OBS_DETAILS.validateArgs(arguments);
+        var arg = arguments.get("img");
         if (arg instanceof List<?>) {
-            return expandToImageList("draw_obs_details", arguments, this::drawObservationDetails);
+            return expandToImageList("draw_obs_details", "img", arguments, this::drawObservationDetails);
         }
-        var x = getArgument(Number.class, arguments, 1).map(Number::intValue).orElse(50);
-        var y = getArgument(Number.class, arguments, 2).map(Number::intValue).orElse(50);
+        var x = getArgument(Number.class, arguments, "x").map(Number::intValue).orElse(50);
+        var y = getArgument(Number.class, arguments, "y").map(Number::intValue).orElse(50);
         if (arg instanceof ImageWrapper img) {
             var processParams = findProcessParams(img);
             if (processParams.isPresent()) {
                 return drawOnImage(img, (g, image) -> {
-                    getEllipse(arguments, 3).ifPresent(ellipse -> {
+                    getEllipse(arguments, "ellipse").ifPresent(ellipse -> {
                         var semiAxis = ellipse.semiAxis();
                         var radius = (semiAxis.a() + semiAxis.b()) / 2;
                         autoScaleFont(g, 1.2d, radius);
@@ -137,17 +138,17 @@ public class ImageDraw extends AbstractFunctionImpl {
         throw new IllegalArgumentException("Unexpected image type: " + arg);
     }
 
-    public Object drawText(List<Object> arguments) {
-        assertExpectedArgCount(arguments, "draw_text takes 4 to 6 arguments (image(s), x, y, text, [font size], [color])", 4, 6);
-        var arg = arguments.get(0);
+    public Object drawText(Map<String ,Object> arguments) {
+        BuiltinFunction.DRAW_TEXT.validateArgs(arguments);
+        var arg = arguments.get("img");
         if (arg instanceof List<?>) {
-            return expandToImageList("draw_text", arguments, this::drawText);
+            return expandToImageList("draw_text", "img", arguments, this::drawText);
         }
-        var x = getArgument(Number.class, arguments, 1).map(Number::intValue).orElseThrow();
-        var y = getArgument(Number.class, arguments, 2).map(Number::intValue).orElseThrow();
-        var text = getArgument(String.class, arguments, 3).orElseThrow();
-        var fontSize = getArgument(Number.class, arguments, 4).map(Number::intValue).orElse(-1);
-        var color = getArgument(String.class, arguments, 5).orElse(null);
+        var x = getArgument(Number.class, arguments, "x").map(Number::intValue).orElseThrow();
+        var y = getArgument(Number.class, arguments, "y").map(Number::intValue).orElseThrow();
+        var text = getArgument(String.class, arguments, "text").orElseThrow();
+        var fontSize = getArgument(Number.class, arguments, "fs").map(Number::intValue).orElse(-1);
+        var color = getArgument(String.class, arguments, "color").orElse(null);
         if (arg instanceof ImageWrapper img) {
             return drawText(img, text, x, y, color, fontSize);
         } else {
@@ -200,18 +201,18 @@ public class ImageDraw extends AbstractFunctionImpl {
         }
     }
 
-    public Object drawArrow(List<Object> arguments) {
-        assertExpectedArgCount(arguments, "draw_arrow takes 5 to 7 arguments (image(s), x1, y1, x2, y2, [thickness], [color])", 5, 7);
-        var arg = arguments.get(0);
+    public Object drawArrow(Map<String ,Object> arguments) {
+        BuiltinFunction.DRAW_ARROW.validateArgs(arguments);
+        var arg = arguments.get("img");
         if (arg instanceof List<?>) {
-            return expandToImageList("draw_arrow", arguments, this::drawArrow);
+            return expandToImageList("draw_arrow", "img", arguments, this::drawArrow);
         }
-        var x1 = getArgument(Number.class, arguments, 1).map(Number::intValue).orElseThrow();
-        var y1 = getArgument(Number.class, arguments, 2).map(Number::intValue).orElseThrow();
-        var x2 = getArgument(Number.class, arguments, 3).map(Number::intValue).orElseThrow();
-        var y2 = getArgument(Number.class, arguments, 4).map(Number::intValue).orElseThrow();
-        var thickness = getArgument(Number.class, arguments, 5).map(Number::intValue).orElse(1);
-        var color = getArgument(String.class, arguments, 6).orElse(null);
+        var x1 = getArgument(Number.class, arguments, "x1").map(Number::intValue).orElseThrow();
+        var y1 = getArgument(Number.class, arguments, "y1").map(Number::intValue).orElseThrow();
+        var x2 = getArgument(Number.class, arguments, "x2").map(Number::intValue).orElseThrow();
+        var y2 = getArgument(Number.class, arguments, "y2").map(Number::intValue).orElseThrow();
+        var thickness = getArgument(Number.class, arguments, "thickness").map(Number::intValue).orElse(1);
+        var color = getArgument(String.class, arguments, "color").orElse(null);
         if (arg instanceof ImageWrapper img) {
             return drawArrow(img, x1, y1, x2, y2, color, thickness);
         } else {
@@ -269,17 +270,17 @@ public class ImageDraw extends AbstractFunctionImpl {
         });
     }
 
-    public Object drawCircle(List<Object> arguments) {
-        assertExpectedArgCount(arguments, "draw_circle takes 4 to 6 arguments (image(s), cx, cy, radius, [color], [thickness])", 4, 6);
-        var arg = arguments.get(0);
+    public Object drawCircle(Map<String ,Object> arguments) {
+        BuiltinFunction.DRAW_CIRCLE.validateArgs(arguments);
+        var arg = arguments.get("img");
         if (arg instanceof List<?>) {
-            return expandToImageList("draw_circle", arguments, this::drawCircle);
+            return expandToImageList("draw_circle", "img", arguments, this::drawCircle);
         }
-        var cx = getArgument(Number.class, arguments, 1).map(Number::intValue).orElseThrow();
-        var cy = getArgument(Number.class, arguments, 2).map(Number::intValue).orElseThrow();
-        var radius = getArgument(Number.class, arguments, 3).map(Number::intValue).orElseThrow();
-        var thickness = getArgument(Number.class, arguments, 4).map(Number::intValue).orElse(1);
-        var color = getArgument(String.class, arguments, 5).orElse(null);
+        var cx = getArgument(Number.class, arguments, "cx").map(Number::intValue).orElseThrow();
+        var cy = getArgument(Number.class, arguments, "cy").map(Number::intValue).orElseThrow();
+        var radius = getArgument(Number.class, arguments, "radius").map(Number::intValue).orElseThrow();
+        var thickness = getArgument(Number.class, arguments, "thickness").map(Number::intValue).orElse(1);
+        var color = getArgument(String.class, arguments, "color").orElse(null);
         if (arg instanceof ImageWrapper img) {
             return drawCircle(img, cx, cy, radius, thickness, color);
         } else {
@@ -287,18 +288,18 @@ public class ImageDraw extends AbstractFunctionImpl {
         }
     }
 
-    public Object drawRectangle(List<Object> arguments) {
-        assertExpectedArgCount(arguments, "draw_rect takes 5 to 7 arguments (image(s), x1, y1, width, height, [thickness], [color])", 5, 7);
-        var arg = arguments.get(0);
+    public Object drawRectangle(Map<String ,Object> arguments) {
+        BuiltinFunction.DRAW_RECT.validateArgs(arguments);
+        var arg = arguments.get("img");
         if (arg instanceof List<?>) {
-            return expandToImageList("draw_rect", arguments, this::drawRectangle);
+            return expandToImageList("draw_rect", "img", arguments, this::drawRectangle);
         }
-        var x1 = getArgument(Number.class, arguments, 1).map(Number::intValue).orElseThrow();
-        var y1 = getArgument(Number.class, arguments, 2).map(Number::intValue).orElseThrow();
-        var width = getArgument(Number.class, arguments, 3).map(Number::intValue).orElseThrow();
-        var height = getArgument(Number.class, arguments, 4).map(Number::intValue).orElseThrow();
-        var thickness = getArgument(Number.class, arguments, 5).map(Number::intValue).orElse(1);
-        var color = getArgument(String.class, arguments, 6).orElse(null);
+        var x1 = getArgument(Number.class, arguments, "x").map(Number::intValue).orElseThrow();
+        var y1 = getArgument(Number.class, arguments, "y").map(Number::intValue).orElseThrow();
+        var width = getArgument(Number.class, arguments, "width").map(Number::intValue).orElseThrow();
+        var height = getArgument(Number.class, arguments, "height").map(Number::intValue).orElseThrow();
+        var thickness = getArgument(Number.class, arguments, "thickness").map(Number::intValue).orElse(1);
+        var color = getArgument(String.class, arguments, "color").orElse(null);
         if (arg instanceof ImageWrapper img) {
             return drawRectangle(img, x1, y1, width, height, color, thickness);
         } else {
@@ -323,19 +324,19 @@ public class ImageDraw extends AbstractFunctionImpl {
     }
 
 
-    public Object drawSolarParameters(List<Object> arguments) {
-        assertExpectedArgCount(arguments, "draw_solar_params takes 1, 2, or 3 (image(s), [x], [y])", 1, 3);
-        var arg = arguments.get(0);
+    public Object drawSolarParameters(Map<String ,Object> arguments) {
+        BuiltinFunction.DRAW_SOLAR_PARAMS.validateArgs(arguments);
+        var arg = arguments.get("img");
         if (arg instanceof List<?>) {
-            return expandToImageList("draw_solar_params", arguments, this::drawSolarParameters);
+            return expandToImageList("draw_solar_params", "img", arguments, this::drawSolarParameters);
         }
         if (arg instanceof ImageWrapper img) {
-            var x = getArgument(Number.class, arguments, 1).map(Number::intValue).orElse(-1);
-            var y = getArgument(Number.class, arguments, 2).map(Number::intValue).orElse(50);
+            var x = getArgument(Number.class, arguments, "x").map(Number::intValue).orElse(-1);
+            var y = getArgument(Number.class, arguments, "y").map(Number::intValue).orElse(50);
             var processParams = findProcessParams(img);
             if (processParams.isPresent()) {
                 return drawOnImage(img, (g, image) -> {
-                    getEllipse(arguments, 3).ifPresent(ellipse -> {
+                    getEllipse(arguments, "ellipse").ifPresent(ellipse -> {
                         var semiAxis = ellipse.semiAxis();
                         var radius = (semiAxis.a() + semiAxis.b()) / 2;
                         autoScaleFont(g, 1.2d, radius);
@@ -379,17 +380,17 @@ public class ImageDraw extends AbstractFunctionImpl {
     }
 
 
-    public Object drawGlobe(List<Object> arguments) {
-        assertExpectedArgCount(arguments, "draw_globe takes 1, 2, 3 or 4 arguments (image(s), [angleP], [b0], [ellipse])", 1, 4);
-        var arg = arguments.get(0);
+    public Object drawGlobe(Map<String ,Object> arguments) {
+        BuiltinFunction.DRAW_GLOBE.validateArgs(arguments);
+        var arg = arguments.get("img");
         if (arg instanceof List<?>) {
-            return expandToImageList("draw_globe", arguments, this::drawGlobe);
+            return expandToImageList("draw_globe", "img", arguments, this::drawGlobe);
         }
-        var img = arguments.get(0);
+        var img = arguments.get("img");
         if (img instanceof ImageWrapper image) {
-            var angleP = getArgument(Number.class, arguments, 1).map(Number::doubleValue).or(() -> findSolarParams(image).map(SolarParameters::p)).orElse(0d);
-            var b0 = getArgument(Number.class, arguments, 2).map(Number::doubleValue).or(() -> findSolarParams(image).map(SolarParameters::b0)).orElse(0d);
-            var ellipse = getEllipse(arguments, 3).orElseThrow(() -> new IllegalArgumentException("Ellipse not defined"));
+            var angleP = getArgument(Number.class, arguments, "angleP").map(Number::doubleValue).or(() -> findSolarParams(image).map(SolarParameters::p)).orElse(0d);
+            var b0 = getArgument(Number.class, arguments, "b0").map(Number::doubleValue).or(() -> findSolarParams(image).map(SolarParameters::b0)).orElse(0d);
+            var ellipse = getEllipse(arguments, "ellipse").orElseThrow(() -> new IllegalArgumentException("Ellipse not defined"));
             return doDrawGlobe(image, ellipse, angleP, b0);
         }
         throw new IllegalArgumentException("Unexpected image type: " + img);
@@ -621,14 +622,14 @@ public class ImageDraw extends AbstractFunctionImpl {
         return new double[]{cos(angle) * a - sin(angle) * b, sin(angle) * a + cos(angle) * b};
     }
 
-    public Object drawEarth(List<Object> arguments) {
-        assertExpectedArgCount(arguments, "draw_earth takes 3 arguments (image(s), x, y)", 3, 3);
-        var arg = arguments.get(0);
+    public Object drawEarth(Map<String ,Object> arguments) {
+        BuiltinFunction.DRAW_EARTH.validateArgs(arguments);
+        var arg = arguments.get("img");
         if (arg instanceof List<?>) {
-            return expandToImageList("draw_earth", arguments, this::drawEarth);
+            return expandToImageList("draw_earth", "img", arguments, this::drawEarth);
         }
-        int x = intArg(arguments, 1);
-        int y = intArg(arguments, 2);
+        int x = intArg(arguments, "x", 0);
+        int y = intArg(arguments, "y", 0);
         if (arg instanceof ImageWrapper wrapper) {
             return drawOnImage(wrapper, (g, image) -> {
                 var ellipse = image.findMetadata(Ellipse.class);
@@ -651,16 +652,16 @@ public class ImageDraw extends AbstractFunctionImpl {
         return arg;
     }
 
-    public Object activeRegionsOverlay(List<Object> arguments) {
-        assertExpectedArgCount(arguments, "ar_overlay takes 2 arguments (image(s), [show labels])", 1, 2);
-        var arg = arguments.get(0);
+    public Object activeRegionsOverlay(Map<String ,Object> arguments) {
+        BuiltinFunction.AR_OVERLAY.validateArgs(arguments);
+        var arg = arguments.get("img");
         if (arg instanceof List<?>) {
-            return expandToImageList("ar_overlay", arguments, this::activeRegionsOverlay);
+            return expandToImageList("ar_overlay", "img", arguments, this::activeRegionsOverlay);
         }
         if (arg instanceof ImageWrapper wrapper) {
             var metadata = wrapper.findMetadata(ActiveRegions.class);
             if (metadata.isPresent()) {
-                int displayParams = arguments.size() > 1 ? intArg(arguments, 1) : 1;
+                int displayParams = intArg(arguments, "labels", 1);
                 boolean showLabels = displayParams > 0;
                 boolean fillRegions = displayParams == 0 || displayParams == 1;
                 var activeRegions = metadata.get();

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Inverse.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Inverse.java
@@ -15,10 +15,10 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.stretching.NegativeImageStrategy;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 
-import java.util.List;
 import java.util.Map;
 
 public class Inverse extends AbstractFunctionImpl {
@@ -27,7 +27,8 @@ public class Inverse extends AbstractFunctionImpl {
         super(context, broadcaster);
     }
 
-    public Object invert(List<Object> arguments) {
-        return monoToMonoImageTransformer("invert", 1, arguments, NegativeImageStrategy.DEFAULT::stretch);
+    public Object invert(Map<String ,Object> arguments) {
+        BuiltinFunction.INVERT.validateArgs(arguments);
+        return monoToMonoImageTransformer("invert", "img", arguments, NegativeImageStrategy.DEFAULT::stretch);
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Loader.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Loader.java
@@ -15,6 +15,7 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.workflow.MetadataTable;
 import me.champeau.a4j.jsolex.processing.util.FitsUtils;
@@ -58,13 +59,11 @@ public class Loader extends AbstractFunctionImpl {
 
     private Path workingDirectory = new File(".").getAbsoluteFile().toPath();
 
-    public Object load(List<Object> arguments) {
-        if (arguments.size() != 1) {
-            throw new IllegalArgumentException("load takes 1 arguments (image file(s))");
-        }
-        var arg = arguments.get(0);
+    public Object load(Map<String ,Object> arguments) {
+        BuiltinFunction.LOAD.validateArgs(arguments);
+        var arg = arguments.get("file");
         if (arg instanceof List<?>) {
-            return expandToImageList("load", arguments, this::load);
+            return expandToImageList("load", "file", arguments, this::load);
         }
         if (arg instanceof String path) {
             var file = workingDirectory.resolve(path).toFile();
@@ -142,12 +141,10 @@ public class Loader extends AbstractFunctionImpl {
         }
     }
 
-    public List<ImageWrapper> loadMany(List<Object> arguments) {
-        if (arguments.size() > 2) {
-            throw new IllegalArgumentException("loadMany takes 1 or 2 arguments (directory, [pattern])");
-        }
-        var directory = (String) arguments.get(0);
-        var pattern = Pattern.compile(arguments.size() == 2 ? (String) arguments.get(1) : ".*");
+    public List<ImageWrapper> loadMany(Map<String ,Object> arguments) {
+        BuiltinFunction.LOAD_MANY.validateArgs(arguments);
+        var directory = (String) arguments.get("dir");
+        var pattern = Pattern.compile(stringArg(arguments, "pattern", ".*"));
         var lookupDir = workingDirectory.resolve(directory);
         if (Files.isDirectory(lookupDir)) {
             try (var stream = Files.list(lookupDir)) {
@@ -182,12 +179,10 @@ public class Loader extends AbstractFunctionImpl {
         this.workingDirectory = workingDirectory;
     }
 
-    public Object chooseFile(List<Object> arguments) {
-        if (arguments.size() != 2) {
-            throw new IllegalArgumentException("choose_file takes 1 arguments (id, message)");
-        }
-        var id = stringArg(arguments, 0);
-        var message = stringArg(arguments, 1);
+    public Object chooseFile(Map<String ,Object> arguments) {
+        BuiltinFunction.CHOOSE_FILES.validateArgs(arguments);
+        var id = stringArg(arguments, "id", null);
+        var message = stringArg(arguments, "message", null);
         var chooser = (FileSelector) context.get(FileSelector.class);
         if (chooser == null) {
             chooser = new FileSelector() {
@@ -206,12 +201,10 @@ public class Loader extends AbstractFunctionImpl {
         return file.map(Loader::loadImage).orElse(ImageWrapper32.createEmpty());
     }
 
-    public Object chooseFiles(List<Object> arguments) {
-        if (arguments.size() != 2) {
-            throw new IllegalArgumentException("choose_files takes 1 arguments (id, message)");
-        }
-        var id = stringArg(arguments, 0);
-        var message = stringArg(arguments, 1);
+    public Object chooseFiles(Map<String ,Object> arguments) {
+        BuiltinFunction.CHOOSE_FILES.validateArgs(arguments);
+        var id = stringArg(arguments, "id", null);
+        var message = stringArg(arguments, "message", null);
         var chooser = (FileSelector) context.get(FileSelector.class);
         if (chooser == null) {
             throw new IllegalStateException("No file selector registered");

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/MathFunctions.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/MathFunctions.java
@@ -15,9 +15,9 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 
-import java.util.List;
 import java.util.Map;
 
 public class MathFunctions extends AbstractFunctionImpl {
@@ -25,16 +25,19 @@ public class MathFunctions extends AbstractFunctionImpl {
         super(context, broadcaster);
     }
     
-    public Object pow(List<Object> arguments) {
-        return applyBinary(arguments, "pow", "exponent", Math::pow);
+    public Object pow(Map<String ,Object> arguments) {
+        BuiltinFunction.POW.validateArgs(arguments);
+        return applyBinary(arguments, "v", "exp", "pow", Math::pow);
     }
 
-    public Object log(List<Object> arguments) {
-        return applyBinary(arguments, "log", "base", (a, b) -> Math.log(a) / Math.log(b));
+    public Object log(Map<String ,Object> arguments) {
+        BuiltinFunction.LOG.validateArgs(arguments);
+        return applyBinary(arguments, "v", "exp", "log", (a, b) -> Math.log(a) / Math.log(b));
     }
 
-    public Object exp(List<Object> arguments) {
-        return applyUnary(arguments, "exp", Math::exp);
+    public Object exp(Map<String ,Object> arguments) {
+        BuiltinFunction.EXP.validateArgs(arguments);
+        return applyUnary(arguments, "v", "exp", Math::exp);
     }
 
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/RGBCombination.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/RGBCombination.java
@@ -15,24 +15,26 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.util.FileBackedImage;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
 
-import java.util.List;
+import java.util.Map;
 
 public class RGBCombination {
     private RGBCombination() {
 
     }
 
-    public static Object combine(List<Object> arguments) {
+    public static Object combine(Map<String ,Object> arguments) {
+        BuiltinFunction.RGB.validateArgs(arguments);
         if (arguments.size() != 3) {
             throw new IllegalArgumentException("rgb takes 3 arguments (red image, green image, blue image)");
         }
-        var ra = arguments.get(0);
-        var ga = arguments.get(1);
-        var ba = arguments.get(2);
+        var ra = arguments.get("r");
+        var ga = arguments.get("g");
+        var ba = arguments.get("b");
         if (ra instanceof FileBackedImage fileBackedImage) {
             ra = fileBackedImage.unwrapToMemory();
         }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/RemoteScriptGen.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/RemoteScriptGen.java
@@ -26,7 +26,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.HashMap;
-import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,11 +39,8 @@ public class RemoteScriptGen extends AbstractFunctionImpl {
         this.evaluator = evaluator;
     }
 
-    public Object callRemoteScriptGen(List<Object> arguments) {
-        if (arguments.size() != 1) {
-            throw new IllegalArgumentException("remote_scriptgen() accept a single argument (remote url)");
-        }
-        var scriptUrl = arguments.getFirst().toString();
+    public Object callRemoteScriptGen(Map<String ,Object> arguments) {
+        var scriptUrl = stringArg(arguments, "url", null);
         try (var client = HttpClient.newHttpClient()) {
             var request = HttpRequest.newBuilder()
                     .uri(java.net.URI.create(scriptUrl))
@@ -83,7 +80,7 @@ public class RemoteScriptGen extends AbstractFunctionImpl {
                                 .entrySet()
                                 .stream()
                                 .filter(e -> keys.contains(e.getKey()))
-                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
                         return new ExpressionEvaluator.NestedInvocationResult(collectedVariables);
                     }
                 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Saturation.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Saturation.java
@@ -15,6 +15,7 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.ImageUtils;
 import me.champeau.a4j.jsolex.processing.util.FileBackedImage;
@@ -29,15 +30,13 @@ public class Saturation extends AbstractFunctionImpl {
         super(context, broadcaster);
     }
 
-    public Object saturate(List<Object> arguments) {
-        if (arguments.size() != 2) {
-            throw new IllegalArgumentException("saturate takes 2 argument (image(s), saturation)");
-        }
-        var arg = arguments.get(0);
+    public Object saturate(Map<String ,Object> arguments) {
+        BuiltinFunction.SATURATE.validateArgs(arguments);
+        var arg = arguments.get("img");
         if (arg instanceof List) {
-            return expandToImageList("saturate", arguments, this::saturate);
+            return expandToImageList("saturate", "img", arguments, this::saturate);
         }
-        var saturation = doubleArg(arguments, 1);
+        var saturation = doubleArg(arguments, "saturation", 1);
         var exponent = Math.pow(2, -saturation);
         if (arg instanceof FileBackedImage fileBackedImage) {
             arg = fileBackedImage.unwrapToMemory();

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Stretching.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Stretching.java
@@ -15,12 +15,12 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.stretching.ArcsinhStretchingStrategy;
 import me.champeau.a4j.jsolex.processing.stretching.LinearStrechingStrategy;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.util.Constants;
 
-import java.util.List;
 import java.util.Map;
 
 public class Stretching extends AbstractFunctionImpl {
@@ -29,28 +29,17 @@ public class Stretching extends AbstractFunctionImpl {
         super(context, broadcaster);
     }
 
-    public Object asinhStretch(List<Object> arguments) {
-        if (arguments.size() < 3) {
-            throw new IllegalArgumentException("asinh_stretch takes 3 arguments (image(s), blackpoint, stretch)");
-        }
-        float blackpoint = floatArg(arguments, 1);
-        float stretch = floatArg(arguments, 2);
-        return monoToMonoImageTransformer( "asinh_stretch", 3, arguments, image -> new ArcsinhStretchingStrategy(blackpoint, stretch, stretch).stretch(image));
+    public Object asinhStretch(Map<String, Object> arguments) {
+        BuiltinFunction.ASINH_STRETCH.validateArgs(arguments);
+        float blackpoint = floatArg(arguments, "bp", 0);
+        float stretch = floatArg(arguments, "strech", 1);
+        return monoToMonoImageTransformer("asinh_stretch", "img", arguments, image -> new ArcsinhStretchingStrategy(blackpoint, stretch, stretch).stretch(image));
     }
 
-    public Object linearStretch(List<Object> arguments) {
-        if (arguments.size() != 1 && arguments.size() != 3) {
-            throw new IllegalArgumentException("linear_stretch takes 3 arguments (image(s), lo, hi)");
-        }
-        float lo;
-        float hi;
-        if (arguments.size() == 3) {
-            lo = Math.min(Constants.MAX_PIXEL_VALUE, Math.max(0, floatArg(arguments, 1)));
-            hi = Math.min(Constants.MAX_PIXEL_VALUE, Math.max(0, floatArg(arguments, 2)));
-        } else {
-            hi = Constants.MAX_PIXEL_VALUE;
-            lo = 0;
-        }
-        return monoToMonoImageTransformer("linear_stretch", 3, arguments, image -> new LinearStrechingStrategy(lo, hi).stretch(image));
+    public Object linearStretch(Map<String, Object> arguments) {
+        BuiltinFunction.LINEAR_STRETCH.validateArgs(arguments);
+        float lo = Math.clamp(floatArg(arguments, "lo", 0), 0, Constants.MAX_PIXEL_VALUE);
+        float hi = Math.clamp(floatArg(arguments, "hi", Constants.MAX_PIXEL_VALUE), 0, Constants.MAX_PIXEL_VALUE);
+        return monoToMonoImageTransformer("linear_stretch", "img", arguments, image -> new LinearStrechingStrategy(lo, hi).stretch(image));
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/DistorsionDebugImageCreator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/DistorsionDebugImageCreator.java
@@ -25,12 +25,11 @@ import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.MutableMap;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
 
-import java.awt.Color;
-import java.awt.GradientPaint;
+import java.awt.*;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static me.champeau.a4j.jsolex.processing.util.Constants.MAX_PIXEL_VALUE;
 
@@ -158,7 +157,7 @@ public class DistorsionDebugImageCreator {
                 }
             }
             double finalMaxAmplitude = maxAmplitude;
-            RGBImage image = (RGBImage) scaling.relativeRescale(List.of(imageDraw.drawOnImage(new RGBImage(heatmap[0][0].length, heatmap[0].length, heatmap[0], heatmap[1], heatmap[2], MutableMap.of()), (g, img) -> {
+            RGBImage image = (RGBImage) scaling.relativeRescale(Map.of("img", imageDraw.drawOnImage(new RGBImage(heatmap[0][0].length, heatmap[0].length, heatmap[0], heatmap[1], heatmap[2], MutableMap.of()), (g, img) -> {
                 g.setColor(Color.BLACK);
                 g.setFont(g.getFont().deriveFont(16f * (height / 384f)));
                 g.drawString("Displacement X", 2 * separator + width + width / 6, height + 1.5f * separator);
@@ -198,7 +197,7 @@ public class DistorsionDebugImageCreator {
                     g.drawString(String.format(Locale.US, "%.2fpx", pixels), (int) (2 * width + 2.5 * separator) + 15, y);
                 }
 
-            }), scale, scale));
+            }), "sx", scale, "sy", scale));
 
             return new float[][][]{image.r(), image.g(), image.b()};
         });

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/FileNamingPatternsIO.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/FileNamingPatternsIO.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static me.champeau.a4j.jsolex.processing.util.Constants.message;
+import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectoriesIfNeeded;
 
 public abstract class FileNamingPatternsIO {
     private static final Logger LOGGER = LoggerFactory.getLogger(FileNamingPatternsIO.class);
@@ -41,7 +42,7 @@ public abstract class FileNamingPatternsIO {
     private static Path resolveDefaultsFile() {
         var jsolexDir = VersionUtil.getJsolexDir();
         try {
-            Files.createDirectories(jsolexDir);
+            createDirectoriesIfNeeded(jsolexDir);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -103,7 +104,7 @@ public abstract class FileNamingPatternsIO {
 
     public static void saveTo(List<NamedPattern> patterns, File destination) {
         try {
-            Files.createDirectories(destination.getParentFile().toPath());
+            createDirectoriesIfNeeded(destination.getParentFile().toPath());
             try (var writer = FilesUtils.newTextWriter(destination.toPath())) {
                 var gson = newGson();
                 writer.write(gson.toJson(patterns));

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ProcessParamsIO.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ProcessParamsIO.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import static me.champeau.a4j.jsolex.processing.sun.BandingReduction.DEFAULT_BAND_SIZE;
 import static me.champeau.a4j.jsolex.processing.sun.BandingReduction.DEFAULT_PASS_COUNT;
 import static me.champeau.a4j.jsolex.processing.util.Constants.message;
+import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectoriesIfNeeded;
 
 public abstract class ProcessParamsIO {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProcessParamsIO.class);
@@ -54,7 +55,7 @@ public abstract class ProcessParamsIO {
     private static Path resolveDefaultsFile() {
         var jsolexDir = VersionUtil.getJsolexDir();
         try {
-            Files.createDirectories(jsolexDir);
+            createDirectoriesIfNeeded(jsolexDir);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -84,31 +85,31 @@ public abstract class ProcessParamsIO {
 
     public static ProcessParams createNewDefaults() {
         return new ProcessParams(
-            new SpectrumParams(SpectralRay.AUTO, 0, 3, Constants.DEFAULT_CONTINUUM_SHIFT, false),
-            new ObservationDetails(
-                null,
-                null,
-                SpectroHeliograph.SOLEX,
-                null,
-                null,
-                null,
-                null,
-                LocalDateTime.now().atZone(ZoneId.of("UTC")),
-                "",
-                1,
-                2.4,
-                false,
-                false,
-                false),
-            new ExtraParams(false, true, EnumSet.of(ImageFormat.PNG), FileNamingStrategy.DEFAULT_TEMPLATE, FileNamingStrategy.DEFAULT_DATETIME_FORMAT, FileNamingStrategy.DEFAULT_DATE_FORMAT, false),
-            new VideoParams(ColorMode.MONO),
-            new GeometryParams(null, null, false, false, false, false, true, RotationKind.NONE, AutocropMode.RADIUS_1_2, DeconvolutionMode.NONE, null, false, null, false),
-            new BandingCorrectionParams(DEFAULT_BAND_SIZE, DEFAULT_PASS_COUNT),
-            new RequestedImages(RequestedImages.FULL_MODE, List.of(0d), Set.of(), Set.of(), ImageMathParams.NONE, false),
-            createDefaultClaheParams(),
-            createDefaultAutoStretchParams(),
-            ContrastEnhancement.AUTOSTRETCH,
-            new EnhancementParams(false, FlatCorrection.DEFAULT_LO_PERCENTILE, FlatCorrection.DEFAULT_HI_PERCENTILE, FlatCorrection.DEFAULT_ORDER)
+                new SpectrumParams(SpectralRay.AUTO, 0, 3, Constants.DEFAULT_CONTINUUM_SHIFT, false),
+                new ObservationDetails(
+                        null,
+                        null,
+                        SpectroHeliograph.SOLEX,
+                        null,
+                        null,
+                        null,
+                        null,
+                        LocalDateTime.now().atZone(ZoneId.of("UTC")),
+                        "",
+                        1,
+                        2.4,
+                        false,
+                        false,
+                        false),
+                new ExtraParams(false, true, EnumSet.of(ImageFormat.PNG), FileNamingStrategy.DEFAULT_TEMPLATE, FileNamingStrategy.DEFAULT_DATETIME_FORMAT, FileNamingStrategy.DEFAULT_DATE_FORMAT, false),
+                new VideoParams(ColorMode.MONO),
+                new GeometryParams(null, null, false, false, false, false, true, RotationKind.NONE, AutocropMode.RADIUS_1_2, DeconvolutionMode.NONE, null, false, null, false),
+                new BandingCorrectionParams(DEFAULT_BAND_SIZE, DEFAULT_PASS_COUNT),
+                new RequestedImages(RequestedImages.FULL_MODE, List.of(0d), Set.of(), Set.of(), ImageMathParams.NONE, false),
+                createDefaultClaheParams(),
+                createDefaultAutoStretchParams(),
+                ContrastEnhancement.AUTOSTRETCH,
+                new EnhancementParams(false, FlatCorrection.DEFAULT_LO_PERCENTILE, FlatCorrection.DEFAULT_HI_PERCENTILE, FlatCorrection.DEFAULT_ORDER)
         );
     }
 
@@ -133,90 +134,90 @@ public abstract class ProcessParamsIO {
             if (params.videoParams() == null) {
                 // happens if loading an old config file
                 params = new ProcessParams(
-                    params.spectrumParams(),
-                    params.observationDetails(),
-                    params.extraParams(),
-                    new VideoParams(ColorMode.MONO),
-                    params.geometryParams(),
-                    params.bandingCorrectionParams(),
-                    params.requestedImages(),
-                    params.claheParams(),
-                    params.autoStretchParams(),
-                    params.contrastEnhancement(),
-                    params.enhancementParams()
+                        params.spectrumParams(),
+                        params.observationDetails(),
+                        params.extraParams(),
+                        new VideoParams(ColorMode.MONO),
+                        params.geometryParams(),
+                        params.bandingCorrectionParams(),
+                        params.requestedImages(),
+                        params.claheParams(),
+                        params.autoStretchParams(),
+                        params.contrastEnhancement(),
+                        params.enhancementParams()
                 );
             }
             if (params.geometryParams() == null) {
                 params = new ProcessParams(
-                    params.spectrumParams(),
-                    params.observationDetails(),
-                    params.extraParams(),
-                    params.videoParams(),
-                    new GeometryParams(
-                        null,
-                        null,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        RotationKind.NONE,
-                        AutocropMode.OFF,
-                        DeconvolutionMode.NONE,
-                        null,
-                        false,
-                        null,
-                        false),
-                    params.bandingCorrectionParams(),
-                    params.requestedImages(),
-                    params.claheParams(),
-                    params.autoStretchParams(),
-                    params.contrastEnhancement(),
-                    params.enhancementParams()
+                        params.spectrumParams(),
+                        params.observationDetails(),
+                        params.extraParams(),
+                        params.videoParams(),
+                        new GeometryParams(
+                                null,
+                                null,
+                                false,
+                                false,
+                                false,
+                                false,
+                                true,
+                                RotationKind.NONE,
+                                AutocropMode.OFF,
+                                DeconvolutionMode.NONE,
+                                null,
+                                false,
+                                null,
+                                false),
+                        params.bandingCorrectionParams(),
+                        params.requestedImages(),
+                        params.claheParams(),
+                        params.autoStretchParams(),
+                        params.contrastEnhancement(),
+                        params.enhancementParams()
                 );
             }
             if (params.bandingCorrectionParams() == null) {
                 params = new ProcessParams(
-                    params.spectrumParams(),
-                    params.observationDetails(),
-                    params.extraParams(),
-                    params.videoParams(),
-                    params.geometryParams(),
-                    new BandingCorrectionParams(
-                        DEFAULT_BAND_SIZE,
-                        DEFAULT_PASS_COUNT
-                    ),
-                    params.requestedImages(),
-                    params.claheParams(),
-                    params.autoStretchParams(),
-                    params.contrastEnhancement(),
-                    params.enhancementParams()
+                        params.spectrumParams(),
+                        params.observationDetails(),
+                        params.extraParams(),
+                        params.videoParams(),
+                        params.geometryParams(),
+                        new BandingCorrectionParams(
+                                DEFAULT_BAND_SIZE,
+                                DEFAULT_PASS_COUNT
+                        ),
+                        params.requestedImages(),
+                        params.claheParams(),
+                        params.autoStretchParams(),
+                        params.contrastEnhancement(),
+                        params.enhancementParams()
                 );
             }
             if (params.requestedImages() == null) {
                 params = new ProcessParams(
-                    params.spectrumParams(),
-                    params.observationDetails(),
-                    params.extraParams(),
-                    params.videoParams(),
-                    params.geometryParams(),
-                    params.bandingCorrectionParams(),
-                    new RequestedImages(RequestedImages.FULL_MODE, List.of(0d), Set.of(), Set.of(), ImageMathParams.NONE, false),
-                    params.claheParams(),
-                    params.autoStretchParams(),
-                    params.contrastEnhancement(),
-                    params.enhancementParams()
+                        params.spectrumParams(),
+                        params.observationDetails(),
+                        params.extraParams(),
+                        params.videoParams(),
+                        params.geometryParams(),
+                        params.bandingCorrectionParams(),
+                        new RequestedImages(RequestedImages.FULL_MODE, List.of(0d), Set.of(), Set.of(), ImageMathParams.NONE, false),
+                        params.claheParams(),
+                        params.autoStretchParams(),
+                        params.contrastEnhancement(),
+                        params.enhancementParams()
                 );
             }
             if (params.extraParams() == null) {
                 params = params.withExtraParams(new ExtraParams(
-                    false,
-                    true,
-                    EnumSet.of(ImageFormat.PNG),
-                    FileNamingStrategy.DEFAULT_TEMPLATE,
-                    FileNamingStrategy.DEFAULT_DATETIME_FORMAT,
-                    FileNamingStrategy.DEFAULT_DATE_FORMAT,
-                    false
+                        false,
+                        true,
+                        EnumSet.of(ImageFormat.PNG),
+                        FileNamingStrategy.DEFAULT_TEMPLATE,
+                        FileNamingStrategy.DEFAULT_DATETIME_FORMAT,
+                        FileNamingStrategy.DEFAULT_DATE_FORMAT,
+                        false
                 ));
             }
             if (params.extraParams().datetimeFormat() == null) {
@@ -257,7 +258,8 @@ public abstract class ProcessParamsIO {
 
     public static void saveTo(ProcessParams params, File destination) {
         try {
-            Files.createDirectories(destination.getParentFile().toPath());
+            var parent = destination.getParentFile().toPath();
+            createDirectoriesIfNeeded(parent);
             try (var writer = FilesUtils.newTextWriter(destination.toPath())) {
                 var gson = newGson();
                 writer.write(gson.toJson(params));

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/SetupsIO.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/SetupsIO.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.stream.Stream;
 
+import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectoriesIfNeeded;
+
 public abstract class SetupsIO {
     private static final Setup SUNSCAN = new Setup("Sunscan by Staros", "Sunscan", 200, 25, "IMX477", 3.1, null, null, false, false, true);
 
@@ -38,7 +40,7 @@ public abstract class SetupsIO {
     private static Path resolveDefaultsFile() {
         var jsolexDir = VersionUtil.getJsolexDir();
         try {
-            Files.createDirectories(jsolexDir);
+            createDirectoriesIfNeeded(jsolexDir);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -78,7 +80,7 @@ public abstract class SetupsIO {
 
     public static void saveTo(List<Setup> patterns, File destination) {
         try {
-            Files.createDirectories(destination.getParentFile().toPath());
+            createDirectoriesIfNeeded(destination.getParentFile().toPath());
             try (var writer = FilesUtils.newTextWriter(destination.toPath())) {
                 var gson = newGson();
                 writer.write(gson.toJson(patterns));

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/SpectralRayIO.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/SpectralRayIO.java
@@ -30,6 +30,8 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
+import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectoriesIfNeeded;
+
 public abstract class SpectralRayIO {
     private static final Logger LOGGER = LoggerFactory.getLogger(SpectralRayIO.class);
     private static final String SCHEMA_KEY = "spectral-ray";
@@ -42,7 +44,7 @@ public abstract class SpectralRayIO {
     private static Path resolveDefaultsFile() {
         var jsolexDir = VersionUtil.getJsolexDir();
         try {
-            Files.createDirectories(jsolexDir);
+            createDirectoriesIfNeeded(jsolexDir);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -114,7 +116,7 @@ public abstract class SpectralRayIO {
 
     public static void saveTo(List<SpectralRay> rays, File destination) {
         try {
-            Files.createDirectories(destination.getParentFile().toPath());
+            createDirectoriesIfNeeded(destination.getParentFile().toPath());
             try (var writer = FilesUtils.newTextWriter(destination.toPath())) {
                 var gson = newGson();
                 writer.write(gson.toJson(rays));

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/SpectroHeliographsIO.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/SpectroHeliographsIO.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static me.champeau.a4j.jsolex.processing.util.Constants.message;
+import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectoriesIfNeeded;
 
 public class SpectroHeliographsIO {
     private static final Logger LOGGER = LoggerFactory.getLogger(SpectroHeliographsIO.class);
@@ -40,7 +41,7 @@ public class SpectroHeliographsIO {
     private static Path resolveDefaultsFile() {
         var jsolexDir = VersionUtil.getJsolexDir();
         try {
-            Files.createDirectories(jsolexDir);
+            createDirectoriesIfNeeded(jsolexDir);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -100,7 +101,7 @@ public class SpectroHeliographsIO {
 
     public static void saveTo(List<SpectroHeliograph> shgs, File destination) {
         try {
-            Files.createDirectories(destination.getParentFile().toPath());
+            createDirectoriesIfNeeded(destination.getParentFile().toPath());
             try (var writer = FilesUtils.newTextWriter(destination.toPath())) {
                 var gson = newGson();
                 writer.write(gson.toJson(shgs));

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/StackingParamsIO.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/StackingParamsIO.java
@@ -38,6 +38,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static me.champeau.a4j.jsolex.processing.util.Constants.message;
+import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectoriesIfNeeded;
 
 public class StackingParamsIO {
     private static final Logger LOGGER = LoggerFactory.getLogger(StackingParamsIO.class);
@@ -49,7 +50,7 @@ public class StackingParamsIO {
     private static Path resolveDefaultsFile() {
         var jsolexDir = VersionUtil.getJsolexDir();
         try {
-            Files.createDirectories(jsolexDir);
+            createDirectoriesIfNeeded(jsolexDir);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -107,7 +108,7 @@ public class StackingParamsIO {
 
     public static void saveTo(StackingWorkflow.Parameters params, File destination) {
         try {
-            Files.createDirectories(destination.getParentFile().toPath());
+            createDirectoriesIfNeeded(destination.getParentFile().toPath());
             try (var writer = FilesUtils.newTextWriter(destination.toPath())) {
                 var gson = newGson();
                 writer.write(gson.toJson(params));

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -106,6 +106,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -358,7 +359,7 @@ public class SolexVideoProcessor implements Broadcaster {
                 }
                 var map = candidates
                         .stream()
-                        .collect(Collectors.toMap(d -> d, details -> SpectrumAnalyzer.computeDataPoints(details, polynomial, 0, width, width, height, averageImage)));
+                        .collect(Collectors.toMap(d -> d, details -> SpectrumAnalyzer.computeDataPoints(details, polynomial, 0, width, width, height, averageImage), (e1, e2) -> e1, LinkedHashMap::new));
                 var bestMatch = SpectrumAnalyzer.findBestMatch(map);
                 LOGGER.info(String.format(Locale.US, message("auto.detected.spectral.line"), bestMatch.line(), bestMatch.binning(), bestMatch.pixelSize()));
                 var spectrumParams = processParams.spectrumParams();

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/ImageAnalysis.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/ImageAnalysis.java
@@ -16,6 +16,7 @@
 package me.champeau.a4j.jsolex.processing.sun.tasks;
 
 import me.champeau.a4j.jsolex.processing.util.Histogram;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.math.regression.Ellipse;
 
 /**
@@ -27,6 +28,15 @@ import me.champeau.a4j.math.regression.Ellipse;
  * @param max the maximum value
  */
 public record ImageAnalysis(float avg, float stddev, float min, float max, Histogram histogram) {
+
+    public static ImageAnalysis of(ImageWrapper32 image, boolean useEllipse) {
+        var ellipse = useEllipse ? image.findMetadata(Ellipse.class).orElse(null) : null;
+        if (ellipse != null) {
+            return masked(image.data(), image.width(), image.height(), ellipse);
+        } else {
+            return of(image.data());
+        }
+    }
 
     public static ImageAnalysis of(float[][] array) {
         float min = Float.MAX_VALUE;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DefaultImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DefaultImageEmitter.java
@@ -40,6 +40,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectoriesIfNeeded;
+
 /**
  * An image emitter is a utility tool to generate
  * mono or color images with transformations.
@@ -85,9 +87,7 @@ public class DefaultImageEmitter implements ImageEmitter {
         var file = outputDir.toPath().resolve(name);
         try {
             Path parent = file.getParent();
-            if (!Files.isDirectory(parent)) {
-                Files.createDirectories(parent);
-            }
+            createDirectoriesIfNeeded(parent);
         } catch (IOException e) {
             throw new ProcessingException(e);
         }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
@@ -39,14 +39,18 @@ import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.ImageUtils;
 import me.champeau.a4j.jsolex.processing.sun.SolexVideoProcessor;
 import me.champeau.a4j.jsolex.processing.sun.WorkflowState;
+import me.champeau.a4j.jsolex.processing.sun.detection.ActiveRegions;
 import me.champeau.a4j.jsolex.processing.sun.detection.RedshiftArea;
 import me.champeau.a4j.jsolex.processing.sun.detection.Redshifts;
-import me.champeau.a4j.jsolex.processing.sun.detection.ActiveRegions;
 import me.champeau.a4j.jsolex.processing.sun.tasks.CoronagraphTask;
 import me.champeau.a4j.jsolex.processing.sun.tasks.EllipseFittingTask;
 import me.champeau.a4j.jsolex.processing.sun.tasks.GeometryCorrector;
 import me.champeau.a4j.jsolex.processing.sun.tasks.ImageBandingCorrector;
-import me.champeau.a4j.jsolex.processing.util.*;
+import me.champeau.a4j.jsolex.processing.util.Constants;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
+import me.champeau.a4j.jsolex.processing.util.MutableMap;
+import me.champeau.a4j.jsolex.processing.util.RGBImage;
 import me.champeau.a4j.math.Point2D;
 import me.champeau.a4j.math.image.Deconvolution;
 import me.champeau.a4j.math.image.ImageMath;
@@ -56,14 +60,14 @@ import me.champeau.a4j.ser.Header;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
+import java.awt.*;
 import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import static me.champeau.a4j.jsolex.processing.sun.ImageUtils.bilinearSmoothing;
@@ -406,15 +410,15 @@ public class ProcessingWorkflow {
         var rotation = processParams.geometryParams().rotation();
         if (rotation.angle() != 0) {
             details = switch (rotation) {
-                case LEFT -> (ImageWrapper32) rotate.rotateRadians(List.of(details, -Math.PI / 2d, -1, 1));
-                case RIGHT -> (ImageWrapper32) rotate.rotateRadians(List.of(details, Math.PI / 2d, -1, 1));
+                case LEFT -> (ImageWrapper32) rotate.rotateRadians(Map.of("img", details, "angle", -Math.PI / 2d, "bp", -1, "resize", 1));
+                case RIGHT -> (ImageWrapper32) rotate.rotateRadians(Map.of("img", details, "angle", Math.PI / 2d, "bp", -1, "resize", 1));
                 case NONE -> details;
             };
         }
-        var cropped = crop.autocrop2(List.of(details, 1.2d));
-        var decorated = (ImageWrapper32) draw.drawSolarParameters(List.of(
-                draw.drawObservationDetails(List.of(
-                        draw.drawGlobe(List.of(cropped))
+        var cropped = crop.autocrop2(Map.of("img", details, "factor", 1.2d));
+        var decorated = (ImageWrapper32) draw.drawSolarParameters(Map.of(
+                "img", draw.drawObservationDetails(Map.of(
+                        "img", draw.drawGlobe(Map.of("img", cropped))
                 ))
         ));
         decorated.metadata().put(RotationKind.class, RotationKind.NONE);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/StackingWorkflow.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/StackingWorkflow.java
@@ -130,7 +130,7 @@ public class StackingWorkflow {
     }
 
     private ImageWrapper32 performStitching(Parameters parameters, File outputDirectory, List<ImageWrapper32> stackedImages) {
-        var cropped = crop.autocrop2(List.of(stackedImages));
+        var cropped = crop.autocrop2(Map.of("img", stackedImages));
         if (cropped instanceof List<?> list) {
             var croppedImages = list.stream()
                 .filter(ImageWrapper.class::isInstance)

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FilesUtils.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FilesUtils.java
@@ -39,6 +39,17 @@ public class FilesUtils {
             StandardCharsets.UTF_16
     );
 
+    /**
+     * Creates the directories in the given path if they do not exist.
+     * This is not strictly needed to perform a check, but it avoids
+     * an internal exception which is annoying when debugging.
+     */
+    public static void createDirectoriesIfNeeded(Path dir) throws IOException {
+        if (!Files.exists(dir)) {
+            Files.createDirectories(dir);
+        }
+    }
+
     private static <T> T withCharsetDetection(Producer<Charset, T> producer) {
         for (Charset charset : STANDARD_CHARSETS) {
             try {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/NOAARegions.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/NOAARegions.java
@@ -39,6 +39,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.zip.GZIPInputStream;
 
 import static me.champeau.a4j.jsolex.processing.util.Constants.message;
+import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectoriesIfNeeded;
 
 public class NOAARegions {
 
@@ -120,7 +121,7 @@ public class NOAARegions {
         var srsFile = srsDir.resolve(year + String.format("%02d", month) + String.format("%02d", day) + "SRS.txt");
         if (!Files.exists(srsFile)) {
             try {
-                Files.createDirectories(srsDir);
+                createDirectoriesIfNeeded(srsDir);
                 downloadSRSData(targetFolder, utcDate, year, month, day);
             } catch (Exception ex) {
                 LOGGER.warn(String.format(message("download.srs.failed"), year, month, day), ex);
@@ -165,9 +166,9 @@ public class NOAARegions {
             while ((entry = tarArchiveInputStream.getNextEntry()) != null) {
                 var entryPath = targetFolder.resolve(entry.getName());
                 if (entry.isDirectory()) {
-                    Files.createDirectories(entryPath);
+                    createDirectoriesIfNeeded(entryPath);
                 } else {
-                    Files.createDirectories(entryPath.getParent());
+                    createDirectoriesIfNeeded(entryPath.getParent());
                     Files.copy(tarArchiveInputStream, entryPath);
                 }
             }
@@ -179,7 +180,7 @@ public class NOAARegions {
         var conn = new URI(url).toURL().openConnection();
         conn.connect();
         var yearFolder = targetFolder.resolve(String.valueOf(year) + "_SRS");
-        Files.createDirectories(yearFolder);
+        createDirectoriesIfNeeded(yearFolder);
         try (var in = conn.getInputStream()) {
             var target = yearFolder.resolve(String.format("%02d%02d%02dSRS.txt", year, month, day));
             Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
@@ -191,7 +192,7 @@ public class NOAARegions {
         var conn = new URI(url).toURL().openConnection();
         conn.connect();
         var yearFolder = targetFolder.resolve(year + "_SRS");
-        Files.createDirectories(yearFolder);
+        createDirectoriesIfNeeded(yearFolder);
         try (var in = conn.getInputStream()) {
             var target = yearFolder.resolve(String.format("%02d%02d%02dSRS.txt", year, month, day));
             Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/TemporaryFolder.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/TemporaryFolder.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectoriesIfNeeded;
+
 public class TemporaryFolder {
     private static final Path TEMP_DIR = tempDir(ProcessHandle.current().pid());
     private static final String JSOLEX_PREFIX = "jsolex";
@@ -68,9 +70,7 @@ public class TemporaryFolder {
     }
 
     public static Path newTempFile(String prefix, String suffix) throws IOException {
-        if (!Files.isDirectory(TEMP_DIR)) {
-            Files.createDirectories(TEMP_DIR);
-        }
+        createDirectoriesIfNeeded(TEMP_DIR);
         var tempFile = Files.createTempFile(TEMP_DIR, prefix, suffix);
         tempFile.toFile().deleteOnExit();
         return tempFile;
@@ -95,7 +95,7 @@ public class TemporaryFolder {
     public static Path newTempDir(String dirName) throws IOException {
         var tempDir = TEMP_DIR.resolve(dirName);
         tempDir.toFile().deleteOnExit();
-        Files.createDirectories(tempDir);
+        createDirectoriesIfNeeded(tempDir);
         return tempDir;
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/VersionUtil.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/VersionUtil.java
@@ -21,6 +21,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 
+import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectoriesIfNeeded;
+
 public class VersionUtil {
     private static Path TEMPORARY_HOME;
 
@@ -46,13 +48,13 @@ public class VersionUtil {
             if (Files.exists(origFile)) {
                 // copy the original directory to the new one
                 try {
-                    Files.createDirectories(path);
+                    createDirectoriesIfNeeded(path);
                     try (var walker = Files.walk(origFile)) {
                         walker.forEach(source -> {
                             try {
                                 var target = path.resolve(origFile.relativize(source));
                                 if (Files.isRegularFile(source)) {
-                                    Files.createDirectories(target.getParent());
+                                    createDirectoriesIfNeeded(target.getParent());
                                     Files.copy(source, target);
                                 }
                             } catch (IOException e) {

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/expr/ExpressionEvaluatorTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/expr/ExpressionEvaluatorTest.groovy
@@ -115,17 +115,17 @@ class ExpressionEvaluatorTest extends Specification {
         }
 
         @Override
-        protected Object functionCall(BuiltinFunction fun, List<Object> arguments) {
+        protected Object functionCall(BuiltinFunction fun, Map<String, Object> arguments) {
             return switch (fun) {
-                case BuiltinFunction.MIN -> arguments.min()
-                case BuiltinFunction.MAX -> arguments.max()
-                case BuiltinFunction.AVG -> arguments.average()
+                case BuiltinFunction.MIN -> arguments["list"].min()
+                case BuiltinFunction.MAX -> arguments["list"].max()
+                case BuiltinFunction.AVG -> arguments["list"].average()
             }
         }
     }
 
     private Object eval(String expr) {
         var parser = new ImageMathParser(expr)
-        evaluator.evaluate(parser.parseAndInlineIncludes().findSections(ImageMathScriptExecutor.SectionKind.ALL).getFirst().children().getFirst())
+        evaluator.evaluate(parser.parseAndInlineIncludes().findSections(ImageMathScriptExecutor.SectionKind.SINGLE).getFirst().children().getFirst())
     }
 }

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/ImageExpressionEvaluatorTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/ImageExpressionEvaluatorTest.groovy
@@ -116,7 +116,6 @@ class ImageExpressionEvaluatorTest extends Specification {
         "fix_banding"     | "range(0,1), 10, 1"         | List
         "linear_stretch"  | "range(0,1)"                | List
         "ASINH_STRETCH"   | "range(0,1), 0, 10"         | List
-        "CLAHE"           | "range(0,1), 1.2"           | List
         "CLAHE"           | "range(0,1), 128, 512, 1.2" | List
         "ADJUST_CONTRAST" | "range(0,1), 0, 255"        | List
         "autocrop"        | "range(0,1)"                | List
@@ -124,6 +123,6 @@ class ImageExpressionEvaluatorTest extends Specification {
 
     private Object eval(String expr) {
         var parser = new ImageMathParser(expr)
-        evaluator.evaluate(parser.parseAndInlineIncludes().findSections(ImageMathScriptExecutor.SectionKind.ALL).getFirst().children().getFirst())
+        evaluator.evaluate(parser.parseAndInlineIncludes().findSections(ImageMathScriptExecutor.SectionKind.SINGLE).getFirst().children().getFirst())
     }
 }

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/sun/SpectrumFrameAnalyzerTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/sun/SpectrumFrameAnalyzerTest.groovy
@@ -101,7 +101,7 @@ class SpectrumFrameAnalyzerTest extends Specification {
         }
         var map = candidates
                 .stream()
-                .collect(Collectors.toMap(d -> d, details -> SpectrumAnalyzer.computeDataPoints(details, polynomial, leftBorder, rightBorder, width, height, data)));
+                .collect(Collectors.toMap(d -> d, details -> SpectrumAnalyzer.computeDataPoints(details, polynomial, leftBorder, rightBorder, width, height, data), (e1, e2) -> e1, LinkedHashMap::new));
 
         when:
         var bestMatch = SpectrumAnalyzer.findBestMatch(map)

--- a/jsolex-server/src/main/java/me/champeau/a4j/jsolex/server/ImagesStore.java
+++ b/jsolex-server/src/main/java/me/champeau/a4j/jsolex/server/ImagesStore.java
@@ -31,6 +31,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -120,7 +121,7 @@ public class ImagesStore implements ProcessingEventListener {
         return getDisplayCategories().stream()
             .collect(Collectors.toMap(
                 dc -> dc,
-                images::get
+                images::get, (e1, e2) -> e1, LinkedHashMap::new
             ));
     }
 }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageInspectorController.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageInspectorController.java
@@ -68,6 +68,7 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static me.champeau.a4j.jsolex.processing.sun.CaptureSoftwareMetadataHelper.findMetadataFile;
+import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectoriesIfNeeded;
 
 public class ImageInspectorController {
     private static final Logger LOGGER = LoggerFactory.getLogger(ImageInspectorController.class);
@@ -245,7 +246,7 @@ public class ImageInspectorController {
             findMainImage(generatedImages).ifPresent(c -> {
                 var path = findImageFile(c);
                 if (path != null) {
-                    var loaded = (ImageWrapper) loader.load(List.of(path.toAbsolutePath().toString()));
+                    var loaded = (ImageWrapper) loader.load(Map.of("file", path.toAbsolutePath().toString()));
                     if (loaded instanceof RGBImage rgb) {
                         loaded = rgb.toMono();
                     }
@@ -470,7 +471,7 @@ public class ImageInspectorController {
                             try {
                                 var relativePath = outputDirectory.toPath().relativize(file.toPath());
                                 var destination = discardedDir.resolve(relativePath);
-                                Files.createDirectories(destination.getParent());
+                                createDirectoriesIfNeeded(destination.getParent());
                                 Files.move(file.toPath(), destination);
                                 deleteParentDirectories(file);
                                 movedFiles.put(file, destination.toFile());
@@ -495,7 +496,7 @@ public class ImageInspectorController {
                         } else if (options.serAction == DiscardAction.MOVE) {
                             try {
                                 var destination = discardedDir.resolve(metadataFile.getName());
-                                Files.createDirectories(destination.getParent());
+                                createDirectoriesIfNeeded(destination.getParent());
                                 Files.move(metadataFile.toPath(), destination);
                                 movedFiles.put(metadataFile, destination.toFile());
                             } catch (IOException e) {
@@ -508,7 +509,7 @@ public class ImageInspectorController {
                         deletedFiles.add(serFile);
                     } else if (options.serAction == DiscardAction.MOVE) {
                         var destination = discardedDir.resolve(serFile.getName());
-                        Files.createDirectories(destination.getParent());
+                        createDirectoriesIfNeeded(destination.getParent());
                         Files.move(serFile.toPath(), destination);
                         movedFiles.put(serFile, destination.toFile());
                     }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/SpectralLineDebugger.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/SpectralLineDebugger.java
@@ -74,6 +74,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -386,7 +387,7 @@ public class SpectralLineDebugger {
                 int rightBorder = analysis.rightBorder().orElse(width);
                 var map = candidates
                     .stream()
-                    .collect(Collectors.toMap(d -> d, details -> SpectrumAnalyzer.computeDataPoints(details, polynomial, leftBorder, rightBorder, width, height, buffer)));
+                    .collect(Collectors.toMap(d -> d, details -> SpectrumAnalyzer.computeDataPoints(details, polynomial, leftBorder, rightBorder, width, height, buffer), (e1, e2) -> e1, LinkedHashMap::new));
                 spectralRayDetectionResult = SpectrumAnalyzer.findBestMatch(map);
             }
         });

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/JSolExInterface.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/JSolExInterface.java
@@ -17,6 +17,7 @@ package me.champeau.a4j.jsolex.app.listeners;
 
 import javafx.application.HostServices;
 import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
 import javafx.stage.Stage;
 import me.champeau.a4j.jsolex.app.jfx.ApplyUserRotation;
 import me.champeau.a4j.jsolex.app.jfx.MultipleImagesViewer;
@@ -38,13 +39,17 @@ public interface JSolExInterface {
 
     Tab getRedshiftTab();
 
+    Tab getImagesViewerTab();
+
+    TabPane getTabs();
+
     void showProgress();
 
     void hideProgress();
 
     void updateProgress(double progress, String text);
 
-    void prepareForScriptExecution(ImageMathScriptExecutor executor, ProcessParams params, ProgressOperation rootOperation);
+    void prepareForScriptExecution(ImageMathScriptExecutor executor, ProcessParams params, ProgressOperation rootOperation, ImageMathScriptExecutor.SectionKind sectionKind);
 
     HostServices getHostServices();
 
@@ -59,4 +64,5 @@ public interface JSolExInterface {
     void showImages();
 
     void setTrimmingParameters(TrimmingParameters payload);
+
 }

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/syntax.css
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/syntax.css
@@ -10,6 +10,10 @@
     -fx-fill: green;
     -fx-font-weight: bold;
 }
+.named_arg {
+    -fx-fill: #6ab321;
+    -fx-font-weight: bold;
+}
 .sectionheader {
     -fx-fill: blue;
     -fx-font-weight: bold;


### PR DESCRIPTION
This commit reworks the script engine in order to support named arguments. It is now possible to use either a list of parameters, like before, when invoking a function (e.g `img(0)`) or to invoke the function using named arguments (e.g `img(ps: 0)`).

Named arguments are ordered, which makes it possible to map the list of parameters to their named couterparts.