### PR TITLE
Fix orientation of active regions

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/ImageBandingCorrector.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/ImageBandingCorrector.java
@@ -16,13 +16,17 @@
 package me.champeau.a4j.jsolex.processing.sun.tasks;
 
 import me.champeau.a4j.jsolex.processing.event.ProgressOperation;
+import me.champeau.a4j.jsolex.processing.expr.impl.Rotate;
 import me.champeau.a4j.jsolex.processing.params.BandingCorrectionParams;
+import me.champeau.a4j.jsolex.processing.params.RotationKind;
 import me.champeau.a4j.jsolex.processing.sun.BandingReduction;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.workflow.TransformationHistory;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
+import me.champeau.a4j.jsolex.processing.util.MutableMap;
 import me.champeau.a4j.math.regression.Ellipse;
 
+import java.util.Map;
 import java.util.function.Supplier;
 
 import static me.champeau.a4j.jsolex.processing.util.Constants.message;
@@ -31,31 +35,64 @@ public class ImageBandingCorrector extends AbstractTask<ImageWrapper32> {
 
     private final Ellipse ellipse;
     private final BandingCorrectionParams params;
+    private final RotationKind rotation;
 
     public ImageBandingCorrector(Broadcaster broadcaster,
                                  ProgressOperation operation,
                                  Supplier<ImageWrapper32> image,
                                  Ellipse ellipse,
-                                 BandingCorrectionParams params) {
+                                 BandingCorrectionParams params,
+                                 RotationKind rotation) {
         super(broadcaster, operation, image);
         this.ellipse = ellipse;
         this.params = params;
+        this.rotation = rotation;
     }
 
     @Override
     protected ImageWrapper32 doCall() throws Exception {
-//        if (true) {
-//            return workImage;
-//        }
         broadcaster.broadcast(operation.update(0, message("banding.correction")));
+        var rotator = new Rotate(Map.of(), Broadcaster.NO_OP);
         var passes = params.passes();
         var bandSize = params.width();
+        var width = this.width;
+        var height = this.height;
+        float[][] buffer = getBuffer();
+        var ellipse = this.ellipse;
+        if (rotation != RotationKind.NONE) {
+            var copy = workImage.copy();
+            copy.metadata().put(Ellipse.class, ellipse);
+            var rotated = (ImageWrapper32) switch (rotation) {
+                case LEFT -> rotator.rotateRight(Map.of("img", copy));
+                case RIGHT -> rotator.rotateLeft(Map.of("img", copy));
+                default -> workImage;
+            };
+            width = rotated.width();
+            height = rotated.height();
+            buffer = rotated.data();
+            ellipse = rotated.findMetadata(Ellipse.class).orElse(null);
+        }
         for (int i = 0; i < passes; i++) {
-            BandingReduction.reduceBanding(width, height, getBuffer(), bandSize, ellipse);
+            BandingReduction.reduceBanding(width, height, buffer, bandSize, ellipse);
             broadcaster.broadcast(operation.update((i + 1d / passes)));
         }
         broadcaster.broadcast(operation.complete());
         TransformationHistory.recordTransform(workImage, "Banding reduction (band size: " + bandSize + " passes: " + passes + ")");
+
+        // rotate back to original orientation
+        if (rotation != RotationKind.NONE) {
+            var rotated = (ImageWrapper32) switch (rotation) {
+                case LEFT ->
+                        rotator.rotateLeft(Map.of("img", new ImageWrapper32(width, height, buffer, MutableMap.of())));
+                case RIGHT ->
+                        rotator.rotateRight(Map.of("img", new ImageWrapper32(width, height, buffer, MutableMap.of())));
+                default -> workImage;
+            };
+            for (int y = 0; y < this.height; y++) {
+                System.arraycopy(rotated.data()[y], 0, getBuffer()[y], 0, this.width);
+            }
+        }
+
         return workImage;
     }
 }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
@@ -53,7 +53,6 @@ import me.champeau.a4j.jsolex.processing.event.ProgressOperation;
 import me.champeau.a4j.jsolex.processing.expr.impl.ImageDraw;
 import me.champeau.a4j.jsolex.processing.params.AutocropMode;
 import me.champeau.a4j.jsolex.processing.params.ProcessParams;
-import me.champeau.a4j.jsolex.processing.params.RotationKind;
 import me.champeau.a4j.jsolex.processing.stretching.ContrastAdjustmentStrategy;
 import me.champeau.a4j.jsolex.processing.stretching.CurveTransformStrategy;
 import me.champeau.a4j.jsolex.processing.stretching.CutoffStretchingStrategy;
@@ -619,7 +618,6 @@ public class ImageViewer implements WithRootNode {
         }
 
         if (!kind.cannotPerformManualRotation()) {
-            correction = image.findMetadata(RotationKind.class).orElseGet(() -> processParams.geometryParams().rotation()).angle();
             if (correctAngleP.isSelected()) {
                 correction += SolarParametersUtils.computeSolarParams(processParams.observationDetails().date().toLocalDateTime()).p();
             }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/BatchModeEventListener.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/BatchModeEventListener.java
@@ -46,7 +46,6 @@ import me.champeau.a4j.jsolex.processing.expr.ImageMathScriptResult;
 import me.champeau.a4j.jsolex.processing.file.FileNamingStrategy;
 import me.champeau.a4j.jsolex.processing.params.AutocropMode;
 import me.champeau.a4j.jsolex.processing.params.ProcessParams;
-import me.champeau.a4j.jsolex.processing.params.RotationKind;
 import me.champeau.a4j.jsolex.processing.stretching.RangeExpansionStrategy;
 import me.champeau.a4j.jsolex.processing.sun.detection.RedshiftArea;
 import me.champeau.a4j.jsolex.processing.sun.workflow.DefaultImageEmitter;
@@ -157,7 +156,6 @@ public class BatchModeEventListener implements ProcessingEventListener, ImageMat
         var img = image;
         double correction = 0;
         if (!kind.cannotPerformManualRotation()) {
-            correction = image.findMetadata(RotationKind.class).orElseGet(() -> params.geometryParams().rotation()).angle();
             if (params.geometryParams().isAutocorrectAngleP()) {
                 correction += SolarParametersUtils.computeSolarParams(params.observationDetails().date().toLocalDateTime()).p();
             }

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -14,6 +14,7 @@
 ### 3.0.4
 
 - Fixed a performance issue when redshift measurement was enabled
+- Fixed position of active areas when rotation is applied
 
 ### 3.0.3
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -14,6 +14,7 @@
 ### 3.0.4
 
 - Correction d'un problème de performance lorsque la mesure des décalages vers le rouge était activée
+- Correction de la position des zones actives lorsqu'une rotation est appliquée
 
 ### 3.0.3
 


### PR DESCRIPTION
This commit fixes the position of active regions when a rotation is applied. To fix this, the rotations are now applied before the process is started, which required some adjustment in processing and displaying images:

- rotations are applied to the reconstructed image
- the only rotations applied in the image view are these that the user applied manually _after_ processing
- the `img(xxx)` image will now have the rotations applied
- the initial banding correction needs to account for the rotations which have been applied