### PR TITLE
Fix sunscan images wrongly oriented

### DIFF
--- a/docs/src/docs/asciidoc/en/jsolex.adoc
+++ b/docs/src/docs/asciidoc/en/jsolex.adoc
@@ -141,7 +141,7 @@ Here are the fields available in JSol'Ex:
 - Binning : the binning of pixels when the video was recorded
 - Pixel size : the size of the camera pixels in microns
 - Vertical flip of the spectrum : normally, the spectrum should have the blue wing at the top and the red wing at the bottom. If it's the opposite, you can check this box. This is typically the case if you are using a Sunscan.
-- Alt-Az mode : check this box if you are not using an equatorial mount but an alt-az mount.
+- Alt-Az mode : check this box if you are not using an equatorial mount but an alt-az mount and that you are seeing an incorrect orientation of the image.
 
 [IMPORTANT]
 .Alt-Az mode and image orientation correctness

--- a/docs/src/docs/asciidoc/fr/jsolex.adoc
+++ b/docs/src/docs/asciidoc/fr/jsolex.adoc
@@ -142,7 +142,7 @@ Voici les champs disponibles dans JSol'Ex:
 - Binning : le binning appliqué à la caméra lors de l'acquisition
 - Taille des pixels : la taille des pixels de la caméra, en microns
 - Inversement haut/bas du spectre : normalement, le spectre doit avoir l'aile bleue en haut et l'aile rouge en bas. Si c'est l'inverse, vous pouvez cocher cette case. C'est typiquement le cas si vous utilisez un Sunscan.
-- Mode altazimutal : cochez cette case si vous n'utilisez pas une monture équatoriale mais une monture altazimutale (typiquement le cas avec Sunscan).
+- Mode altazimutal : cochez cette case si vous n'utilisez pas une monture équatoriale mais une monture altazimutale et que vous constatez que l'orientation du disque est incorrecte.
 
 [IMPORTANT]
 .Mode altazimutal et correction de l'orientation des images

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/SetupsIO.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/SetupsIO.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
 import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectoriesIfNeeded;
 
 public abstract class SetupsIO {
-    private static final Setup SUNSCAN = new Setup("Sunscan by Staros", "Sunscan", 200, 25, "IMX477", 3.1, null, null, false, false, true);
+    private static final Setup SUNSCAN = new Setup("Sunscan by Staros", "Sunscan", 200, 25, "IMX477", 3.1, null, null, false, false, false);
 
     private SetupsIO() {
 

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/process-params.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/process-params.properties
@@ -1,4 +1,4 @@
-altaz.mode=Altazimuth mode (e.g sunscan mode)
+altaz.mode=Altazimuth mode
 aperture=Aperture (mm)
 assume.mono.images=Assume mono images
 assume.mono.images.tooltip=If set to true, assume that the images are mono images. This is useful for mono-bin images as it avoids debayering and significantly speeds up processing.
@@ -95,7 +95,7 @@ flat.percentile.order.tooltip=Order of the polynomial used to fit the flat model
 spectrum.vflip=Vertical flip of the spectrum (e.g. Sunscan)
 spectrum.vflip.tooltip=Check this box if the spectrum is vertically flipped, for example when using a Sunscan: red should be at the bottom, violet at the top.
 altazmode.warning.header=Warning: Altazimuth mode
-altazmode.warning.content=You have selected an altazimuth mount (aka "sunscan mode") but you did not specify the latitude and longitude. If you don't, JSol'Ex will not be able to perform parallactic angle correction and some images will be incorrect (e.g the orientation grid or the active regions labels positions). Do you still want to proceed?
+altazmode.warning.content=You have selected an altazimuth mount but you did not specify the latitude and longitude. If you don't, JSol'Ex will not be able to perform parallactic angle correction and some images will be incorrect (e.g the orientation grid or the active regions labels positions). Do you still want to proceed?
 auto.trim.ser.file=Automatically trim SER file (generates new SER file)
 auto.trim.ser.file.tooltip=If checked, the processed SER file will be automatically trimmed to reduce disk space usage, using automatic parameters.
 review.images.after.batch=Review images after batch processing

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/process-params_fr.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/process-params_fr.properties
@@ -1,4 +1,4 @@
-altaz.mode=Mode altazimutal (ex: mode Sunscan)
+altaz.mode=Mode altazimutal
 aperture=Ouverture (mm)
 assume.mono.images=Supposer vidéo mono
 assume.mono.images.tooltip=Si cochée, on supposera que les images sont monochromes. C'est intéressant pour les images en mono-bin pour éviter de faire un dématriçage et gagner du temps de traitement.
@@ -95,7 +95,7 @@ flat.percentile.order.tooltip=Ordre du polynôme à utiliser pour la correction fl
 spectrum.vflip=Inversion haut/bas du spectre (ex: Sunscan)
 spectrum.vflip.tooltip=Cochez cette case si le spectre est invers\u00E9 verticalement, par exemple en utilisant un Sunscan : le rouge doit être en bas, le violet en haut.
 altazmode.warning.header=Attention : Mode altazimutal
-altazmode.warning.content=Vous avez sélectionné un mode altazimutal (ex: mode Sunscan) mais vous n'avez pas spécifié la latitude et la longitude. Si vous ne le faites pas, JSol'Ex ne pourra pas effectuer la correction de l'angle parallactique et certaines images seront incorrectes (par exemple, la grille d'orientation ou les positions des labels des régions actives). Voulez-vous continuer ?
+altazmode.warning.content=Vous avez sélectionné un mode altazimutal mais vous n'avez pas spécifié la latitude et la longitude. Si vous ne le faites pas, JSol'Ex ne pourra pas effectuer la correction de l'angle parallactique et certaines images seront incorrectes (par exemple, la grille d'orientation ou les positions des labels des régions actives). Voulez-vous continuer ?
 auto.trim.ser.file=Réduire la taille du fichier SER (génère un nouveau fichier SER)
 auto.trim.ser.file.tooltip=Si cochée, un nouveau fichier SER sera créé avec les paramètres de réduction automatiques.
 review.images.after.batch=Passer en revue les images après traitement en lot

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -20,6 +20,7 @@
 - Optimize UI responsiveness
 - Enhanced profile view: clicking on reconstruction now displays both frame average and spectral line intensity profiles, with wavelength information when available
 - Add ability to export the profile view as a CSV file
+- By default, Sunscan instrument shouldn't use altaz mode
 
 ### 3.2.1
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -20,6 +20,7 @@
 - Optimisation de la réactivité de l'interface utilisateur
 - Amélioration de la vue de profil : cliquer sur la reconstruction affiche maintenant les profils d'intensité moyenne de la trame et de la raie spectrale, avec l'information de longueur d'onde quand disponible
 - Ajout d'un export CSV du profil spectral
+- Par défaut, le Sunscan ne devrait pas utiliser le mode AltAz
 
 ### 3.2.1
 


### PR DESCRIPTION
For some reason it seems that the alt-az mode is causing more troubles than it fixes with sunscan: the parallactic angle correction is not required!