### PR TITLE
Fix array index out of bounds

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/AutohistogramStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/AutohistogramStrategy.java
@@ -98,6 +98,7 @@ public final class AutohistogramStrategy implements StretchingStrategy {
         clamping(output, 0, .9998).stretch(image);
         maybeAdjustBrightness(image, height, width, output);
         RangeExpansionStrategy.DEFAULT.stretch(image);
+        CutoffStretchingStrategy.DEFAULT.stretch(image);
     }
 
     private static float[][] blend(float[][] img1, float[][] img2, int width, int height, double alpha) {
@@ -159,11 +160,13 @@ public final class AutohistogramStrategy implements StretchingStrategy {
                 foundPedestral = true;
             }
         }
-        // Background neutralization can result in the image being clamped to 0, which is unnatural,
-        // so we're adding a pedestal to the image.
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                denoised.data()[y][x] += pedestral / 2;
+        if (pedestral>0) {
+            // Background neutralization can result in the image being clamped to 0, which is unnatural,
+            // so we're adding a pedestal to the image.
+            for (int y = 0; y < height; y++) {
+                for (int x = 0; x < width; x++) {
+                    denoised.data()[y][x] += pedestral / 2;
+                }
             }
         }
         return denoised;

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -12,6 +12,10 @@
 
 ## Changes since 3.0.0
 
+### 3.2.3
+
+- Correction d'un bug dans le mode auto contrast qui pouvait provoquer une exception
+
 ### 3.2.2
 
 - Added an `unsharp_mask` function, which applies an unsharp mask to the image, enhancing details

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -12,6 +12,10 @@
 
 ## Changements depuis la 3.0.0
 
+### 3.2.3
+
+- Fix bug in auto contrast which could cause an array index out of bounds exception
+
 ### 3.2.2
 
 - Ajout de la fonction `unsharp_mask` pour appliquer un masque flou (amélioration de la netteté)


### PR DESCRIPTION
When auto constrast is applied on a binary image (e.g a masked image) then the pedestral could be negative.

Fixes #612