### PR TITLE
Add Midtone Transfer Function autostretch

### DIFF
--- a/jsolex-core/src/main/functions/mtf.yml
+++ b/jsolex-core/src/main/functions/mtf.yml
@@ -1,0 +1,32 @@
+name: MTF
+category: ENHANCEMENT
+description:
+  fr: "Applique une fonction de transfert des tons moyens (MTF) avec des paramètres configurables pour les ombres, tons moyens et hautes lumières. Permet un contrôle précis de la transformation tonale."
+  en: "Applies a Midtone Transfer Function (MTF) with configurable parameters for shadows, midtones and highlights. Allows precise control over tonal transformation."
+arguments:
+  - name: img
+    description: Image(s)
+    required: true
+  - name: shadows
+    optional: true
+    default: 0
+    description:
+      fr: "Point d'écrêtage des ombres (valeur 8-bit: 0-255)"
+      en: "Shadow clipping point (8-bit value: 0-255)"
+  - name: midtones
+    optional: true
+    default: 1.0
+    description:
+      fr: "Paramètre des tons moyens (valeur > 0)"
+      en: "Midtones parameter (value > 0)"
+  - name: highlights
+    optional: true
+    default: 255
+    description:
+      fr: "Point d'écrêtage des hautes lumières (valeur 8-bit: 0-255)"
+      en: "Highlight clipping point (8-bit value: 0-255)"
+examples:
+  - "mtf(img: img(0))"
+  - "mtf(img(0))"
+  - "mtf(img: img(0), shadows: 10, midtones: 1.5, highlights: 240)"
+  - "mtf(img(0), 20, 0.8, 220)"

--- a/jsolex-core/src/main/functions/mtf_autostretch.yml
+++ b/jsolex-core/src/main/functions/mtf_autostretch.yml
@@ -1,0 +1,26 @@
+name: MTF_AUTOSTRETCH
+category: ENHANCEMENT
+description:
+  fr: "Applique un algorithme d'auto-étirement utilisant une fonction de transfert des tons moyens (MTF) qui ajuste automatiquement le contraste basé sur l'analyse de l'histogramme. Utilise un écrêtage des ombres basé sur sigma et un niveau de fond cible."
+  en: "Applies an autostretch algorithm using Midtone Transfer Function (MTF) that automatically adjusts contrast based on histogram analysis. Uses sigma-based shadow clipping and target background level."
+arguments:
+  - name: img
+    description: Image(s)
+    required: true
+  - name: shadows_clip
+    optional: true
+    default: -2.8
+    description:
+      fr: "Point d'écrêtage des ombres mesuré en unités sigma depuis le pic de l'histogramme"
+      en: "Shadow clipping point measured in sigma units from histogram peak"
+  - name: target_bg
+    optional: true
+    default: 0.25
+    description:
+      fr: "Niveau de luminosité cible du fond (plage [0, 1])"
+      en: "Target background brightness level (range [0, 1])"
+examples:
+  - "mtf_autostretch(img: img(0))"
+  - "mtf_autostretch(img(0))"
+  - "mtf_autostretch(img: img(0), shadows_clip: -3.0, target_bg: 0.3)"
+  - "mtf_autostretch(img(0), -2.5, 0.2)"

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/UserFunction.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/expr/UserFunction.java
@@ -18,6 +18,7 @@ package me.champeau.a4j.jsolex.expr;
 import me.champeau.a4j.jsolex.expr.ast.Expression;
 import me.champeau.a4j.jsolex.processing.expr.DefaultImageScriptExecutor;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
+import me.champeau.a4j.jsolex.processing.sun.workflow.PixelShift;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 
 import java.util.Collections;
@@ -32,7 +33,7 @@ public class UserFunction {
     private final int arity;
     private final List<String> arguments;
     private final List<Expression> body;
-    private final Function<Double, ImageWrapper> imageSupplier;
+    private final Function<PixelShift, ImageWrapper> imageSupplier;
     private final Map<Class, Object> context;
     private final Consumer<? super Double> shiftCollector;
     private final Broadcaster broadcaster;
@@ -41,7 +42,7 @@ public class UserFunction {
     public UserFunction(String name,
                         List<String> arguments,
                         List<Expression> body,
-                        Function<Double, ImageWrapper> imageSupplier,
+                        Function<PixelShift, ImageWrapper> imageSupplier,
                         Map<Class, Object> context,
                         Consumer<? super Double> shiftCollector,
                         Broadcaster broadcaster,
@@ -67,7 +68,7 @@ public class UserFunction {
     }
 
     public UserFunction prepare(
-        Function<Double, ImageWrapper> imageSupplier,
+        Function<PixelShift, ImageWrapper> imageSupplier,
         Map<Class, Object> context,
         Consumer<? super Double> shiftCollector,
         Broadcaster broadcaster

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/event/ProcessingDoneEvent.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/event/ProcessingDoneEvent.java
@@ -19,6 +19,7 @@ import me.champeau.a4j.jsolex.processing.params.ProcessParams;
 import me.champeau.a4j.jsolex.processing.sun.detection.RedshiftArea;
 import me.champeau.a4j.jsolex.processing.sun.workflow.ImageEmitter;
 import me.champeau.a4j.jsolex.processing.sun.workflow.ImageStats;
+import me.champeau.a4j.jsolex.processing.sun.workflow.PixelShift;
 import me.champeau.a4j.jsolex.processing.sun.workflow.PixelShiftRange;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.math.regression.Ellipse;
@@ -35,7 +36,7 @@ public final class ProcessingDoneEvent extends ProcessingEvent<ProcessingDoneEve
 
     public record Outcome(
         long timestamp,
-        Map<Double, ImageWrapper> shiftImages,
+        Map<PixelShift, ImageWrapper> shiftImages,
         ImageEmitter customImageEmitter,
         Ellipse mainEllipse,
         Ellipse ellipse,
@@ -52,7 +53,7 @@ public final class ProcessingDoneEvent extends ProcessingEvent<ProcessingDoneEve
     }
 
     public static ProcessingDoneEvent of(long timestamp,
-                                         Map<Double, ImageWrapper> images,
+                                         Map<PixelShift, ImageWrapper> images,
                                          ImageEmitter customImageEmitter,
                                          Ellipse mainEllipse,
                                          Ellipse ellipse,

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
@@ -344,6 +344,8 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
             case RGB -> RGBCombination.combine(arguments);
             case SATURATE -> saturation.saturate(arguments);
             case SHARPEN -> convolution.sharpen(arguments);
+            case MTF -> stretching.mtf(arguments);
+            case MTF_AUTOSTRETCH -> stretching.mtfAutostretch(arguments);
             case FIND_SHIFT -> pixelShiftFor(arguments);
             case STACK -> stacking.stack(arguments);
             case STACK_REF -> stacking.chooseReference(arguments);
@@ -557,14 +559,14 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
         return path;
     }
 
-    public abstract ImageWrapper findImage(double shift);
+    public abstract ImageWrapper findImage(PixelShift shift);
 
     private ImageWrapper image(Map<String, Object> arguments) {
         BuiltinFunction.IMG.validateArgs(arguments);
         var arg = arguments.get("ps");
         if (arg instanceof Number shift) {
             double pixelShift = shift.doubleValue();
-            var image = findImage(pixelShift);
+            var image = findImage(new PixelShift(pixelShift));
 //            if (image.findMetadata(TruncatedImage.class).isPresent() && image.findMetadata(TruncatedImage.class).get().truncated()) {
 //                if (warnings.add(pixelShift)) {
 //                    LOGGER.warn(String.format(message("warn.truncated.image"), pixelShift));
@@ -712,7 +714,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
                 toDouble = tmp;
             }
             for (double i = fromDouble; i <= toDouble; i += stepDouble) {
-                images.add(findImage(i));
+                images.add(findImage(new PixelShift(i)));
             }
         }
         return Collections.unmodifiableList(images);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/DefaultImageScriptExecutor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/DefaultImageScriptExecutor.java
@@ -15,17 +15,39 @@
  */
 package me.champeau.a4j.jsolex.processing.expr;
 
-import me.champeau.a4j.jsolex.expr.*;
-import me.champeau.a4j.jsolex.expr.ast.*;
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
+import me.champeau.a4j.jsolex.expr.ExpressionEvaluator;
+import me.champeau.a4j.jsolex.expr.ImageMathParser;
+import me.champeau.a4j.jsolex.expr.Node;
+import me.champeau.a4j.jsolex.expr.ParseException;
+import me.champeau.a4j.jsolex.expr.UserFunction;
+import me.champeau.a4j.jsolex.expr.ast.Assignment;
+import me.champeau.a4j.jsolex.expr.ast.Expression;
+import me.champeau.a4j.jsolex.expr.ast.FunctionCall;
+import me.champeau.a4j.jsolex.expr.ast.FunctionDef;
+import me.champeau.a4j.jsolex.expr.ast.ImageMathScript;
 import me.champeau.a4j.jsolex.processing.event.ProgressOperation;
 import me.champeau.a4j.jsolex.processing.params.ProcessParams;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.workflow.ImageStats;
+import me.champeau.a4j.jsolex.processing.sun.workflow.PixelShift;
 import me.champeau.a4j.jsolex.processing.sun.workflow.TransformationHistory;
-import me.champeau.a4j.jsolex.processing.util.*;
+import me.champeau.a4j.jsolex.processing.util.FileBackedImage;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
+import me.champeau.a4j.jsolex.processing.util.ProcessingException;
+import me.champeau.a4j.jsolex.processing.util.SolarParameters;
 
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -46,7 +68,7 @@ public class DefaultImageScriptExecutor implements ImageMathScriptExecutor {
 
     public static final String OUTPUTS_SECTION_NAME = "outputs";
 
-    private final Function<Double, ImageWrapper> imagesByShift;
+    private final Function<PixelShift, ImageWrapper> imagesByShift;
     private final Map<Class, Object> context;
     private final AtomicInteger executionCount = new AtomicInteger(0);
     private final Broadcaster broadcaster;
@@ -56,7 +78,7 @@ public class DefaultImageScriptExecutor implements ImageMathScriptExecutor {
     private Path includesDir;
     private boolean outputLogging = true;
 
-    public DefaultImageScriptExecutor(Function<Double, ImageWrapper> imageSupplier,
+    public DefaultImageScriptExecutor(Function<PixelShift, ImageWrapper> imageSupplier,
                                       Map<Class, Object> context,
                                       Broadcaster broadcaster) {
         this.imagesByShift = imageSupplier;
@@ -78,7 +100,7 @@ public class DefaultImageScriptExecutor implements ImageMathScriptExecutor {
         return progressOperation;
     }
 
-    public DefaultImageScriptExecutor(Function<Double, ImageWrapper> imagesByShift,
+    public DefaultImageScriptExecutor(Function<PixelShift, ImageWrapper> imagesByShift,
                                       Map<Class, Object> context) {
         this(imagesByShift, context, Broadcaster.NO_OP);
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/ImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/ImageExpressionEvaluator.java
@@ -16,6 +16,7 @@
 package me.champeau.a4j.jsolex.processing.expr;
 
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
+import me.champeau.a4j.jsolex.processing.sun.workflow.PixelShift;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 
 import java.util.function.Function;
@@ -23,14 +24,14 @@ import java.util.function.Function;
 import static me.champeau.a4j.jsolex.processing.util.Constants.message;
 
 public class ImageExpressionEvaluator extends AbstractImageExpressionEvaluator {
-    protected final Function<Double, ImageWrapper> images;
+    protected final Function<PixelShift, ImageWrapper> images;
 
-    public ImageExpressionEvaluator(Broadcaster broadcaster, Function<Double, ImageWrapper> images) {
+    public ImageExpressionEvaluator(Broadcaster broadcaster, Function<PixelShift, ImageWrapper> images) {
         super(broadcaster);
         this.images = images;
     }
 
-    public ImageWrapper findImage(double shift) {
+    public ImageWrapper findImage(PixelShift shift) {
         var image = images.apply(shift);
         if (image == null) {
             throw new IllegalArgumentException(String.format(message("missing.shift"), shift));

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Stretching.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Stretching.java
@@ -19,6 +19,8 @@ import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.stretching.ArcsinhStretchingStrategy;
 import me.champeau.a4j.jsolex.processing.stretching.CurveTransformStrategy;
 import me.champeau.a4j.jsolex.processing.stretching.LinearStrechingStrategy;
+import me.champeau.a4j.jsolex.processing.stretching.MidtoneTransferFunctionStrategy;
+import me.champeau.a4j.jsolex.processing.stretching.MidtoneTransferFunctionAutostretchStrategy;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.util.Constants;
 
@@ -57,5 +59,26 @@ public class Stretching extends AbstractFunctionImpl {
         int protectLo = intArg(arguments, "protectLo", 0);
         int protectHi = intArg(arguments, "protectHi", 255);
         return monoToMonoImageTransformer("curve_transform", "img", arguments, image -> new CurveTransformStrategy(in << 8, out << 8, protectLo << 8, protectHi << 8).stretch(image));
+    }
+
+    public Object mtf(Map<String, Object> arguments) {
+        BuiltinFunction.MTF.validateArgs(arguments);
+        double shadows = doubleArg(arguments, "shadows", 0);
+        double midtones = doubleArg(arguments, "midtones", 1.0);
+        double highlights = doubleArg(arguments, "highlights", 255);
+        if (shadows < 0 || shadows > 255) {
+            throw new IllegalArgumentException("mtf shadows must be between 0 and 255");
+        }
+        if (highlights < 0 || highlights > 255) {
+            throw new IllegalArgumentException("mtf highlights must be between 0 and 255");
+        }
+        return monoToMonoImageTransformer("mtf", "img", arguments, image -> new MidtoneTransferFunctionStrategy(shadows, midtones, highlights).stretch(image));
+    }
+
+    public Object mtfAutostretch(Map<String, Object> arguments) {
+        BuiltinFunction.MTF_AUTOSTRETCH.validateArgs(arguments);
+        double shadowsClip = doubleArg(arguments, "shadows_clip", MidtoneTransferFunctionAutostretchStrategy.DEFAULT_SHADOWS_CLIP);
+        double targetBg = doubleArg(arguments, "target_bg", MidtoneTransferFunctionAutostretchStrategy.DEFAULT_TARGET_BG);
+        return monoToMonoImageTransformer("mtf_autostretch", "img", arguments, image -> new MidtoneTransferFunctionAutostretchStrategy(shadowsClip, targetBg).stretch(image));
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/MidtoneTransferFunctionAutostretchStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/MidtoneTransferFunctionAutostretchStrategy.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.stretching;
+
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
+
+import static java.util.Arrays.*;
+import static me.champeau.a4j.jsolex.processing.util.Constants.MAX_PIXEL_VALUE;
+
+/**
+ * This strategy implements the midtone transfer function (MTF) autostretching algorithm.
+ * It calculates the shadows, midtones, and highlights parameters based on the image data,
+ * and applies the MTF transformation to stretch the image. This is inspired by the SIRIL
+ * autostretching algorithm.
+ * See <a href="https://siril.readthedocs.io/en/stable/Commands.html#autostretch">AUTOSTRETCH</a>
+ */
+public final class MidtoneTransferFunctionAutostretchStrategy implements StretchingStrategy {
+
+    public static final double DEFAULT_SHADOWS_CLIP = -2.8;
+    public static final double DEFAULT_TARGET_BG = 0.25;
+    private static final double EPSILON = 0.00001;
+
+    private final double shadowsClip;
+    private final double targetBg;
+
+    public MidtoneTransferFunctionAutostretchStrategy() {
+        this(DEFAULT_SHADOWS_CLIP, DEFAULT_TARGET_BG);
+    }
+
+    public MidtoneTransferFunctionAutostretchStrategy(double shadowsClip, double targetBg) {
+        if (targetBg < 0 || targetBg > 1) {
+            throw new IllegalArgumentException("Target background must be in range [0, 1]");
+        }
+        this.shadowsClip = shadowsClip;
+        this.targetBg = targetBg;
+    }
+
+    @Override
+    public void stretch(ImageWrapper32 image) {
+        var data = image.data();
+        var width = image.width();
+        var height = image.height();
+
+        if (width == 0 || height == 0) {
+            return;
+        }
+
+        var params = calculateMTFParams(data, width, height);
+
+        var mtfStrategy = new MidtoneTransferFunctionStrategy(clampTo8Bit(params.shadows), params.midtones, clampTo8Bit(params.highlights));
+        mtfStrategy.stretch(image);
+    }
+
+    private static double clampTo8Bit(double value) {
+        return Math.clamp(value / 256, 0, 255);
+    }
+
+    private MTFParams calculateMTFParams(float[][] data, int width, int height) {
+        var totalPixels = width * height;
+        var pixels = new float[totalPixels];
+        var index = 0;
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                pixels[index++] = data[y][x];
+            }
+        }
+
+        sort(pixels);
+
+        // Calculate median
+        var median = 0.0;
+        if (totalPixels % 2 == 0) {
+            median = (pixels[totalPixels / 2 - 1] + pixels[totalPixels / 2]) / 2.0;
+        } else {
+            median = pixels[totalPixels / 2];
+        }
+
+        // Calculate MAD (Median Absolute Deviation)
+        var deviations = new float[totalPixels];
+        for (var i = 0; i < totalPixels; i++) {
+            deviations[i] = Math.abs(pixels[i] - (float) median);
+        }
+        sort(deviations);
+
+        var mad = 0.0;
+        if (totalPixels % 2 == 0) {
+            mad = (deviations[totalPixels / 2 - 1] + deviations[totalPixels / 2]) / 2.0;
+        } else {
+            mad = deviations[totalPixels / 2];
+        }
+
+        var normalizedMedian = median / MAX_PIXEL_VALUE;
+        var normalizedMad = mad / MAX_PIXEL_VALUE * 1.4826; // MAD normalization constant
+
+        if (normalizedMad == 0.0) {
+            normalizedMad = EPSILON;
+        }
+
+        // Calculate shadow clipping point using sigma-based approach
+        var c0 = normalizedMedian + shadowsClip * normalizedMad;
+        if (c0 < 0.0) {
+            c0 = 0.0;
+        }
+
+        var m2 = normalizedMedian - c0;
+
+        // Calculate midtones parameter using MTF function
+        var midtones = calculateMTF(m2, targetBg, 0.0, 1.0);
+
+        // Convert back to pixel values
+        return new MTFParams(
+                c0 * MAX_PIXEL_VALUE,     // shadows
+                midtones,                         // midtones (unitless)
+                MAX_PIXEL_VALUE                   // highlights (full range)
+        );
+    }
+
+    // MTF function: MTF(x, m, lo, hi)
+    private static double calculateMTF(double x, double m, double lo, double hi) {
+        if (x <= lo) {
+            return 0.0;
+        }
+        if (x >= hi) {
+            return 1.0;
+        }
+
+        var xp = (x - lo) / (hi - lo);
+        return ((m - 1.0) * xp) / (((2.0 * m - 1.0) * xp) - m);
+    }
+
+    private record MTFParams(double shadows, double midtones, double highlights) {
+
+    }
+
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/MidtoneTransferFunctionStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/MidtoneTransferFunctionStrategy.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.stretching;
+
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
+
+import static me.champeau.a4j.jsolex.processing.util.Constants.MAX_PIXEL_VALUE;
+
+/**
+ * This strategy implements the midtone transfer function (MTF) stretching algorithm.
+ * It applies a transformation based on shadows, midtones, and highlights to stretch the image.
+ * The shadows and highlights are specified in 8-bit values (0-255), while midtones is a floating-point value.
+ * Inspired from the SIRIL MTF algorithm, see <a href="https://siril.readthedocs.io/en/stable/processing/stretching.html#midtone-transfer-function-transformation-mtf">MTF</a>
+ */
+public final class MidtoneTransferFunctionStrategy implements StretchingStrategy {
+    
+    private final double shadows;
+    private final double midtones;
+    private final double highlights;
+    
+    public MidtoneTransferFunctionStrategy(double shadows8bit, double midtones, double highlights8bit) {
+        if (shadows8bit < 0 || shadows8bit > 255) {
+            throw new IllegalArgumentException("Shadows must be in range [0, 255], found: " + shadows8bit);
+        }
+        if (highlights8bit < 0 || highlights8bit > 255) {
+            throw new IllegalArgumentException("Highlights must be in range [0, 255], found: " + highlights8bit);
+        }
+        if (shadows8bit >= highlights8bit) {
+            throw new IllegalArgumentException("Shadows must be less than highlights. Found: shadows=" + shadows8bit + ", highlights=" + highlights8bit);
+        }
+        if (midtones <= 0) {
+            throw new IllegalArgumentException("Midtones must be greater than 0. Found: " + midtones);
+        }
+        
+        this.shadows = shadows8bit * 256;
+        this.midtones = midtones;
+        this.highlights = highlights8bit * 256;
+    }
+    
+    @Override
+    public void stretch(ImageWrapper32 image) {
+        var data = image.data();
+        var width = image.width();
+        var height = image.height();
+        
+        if (width == 0 || height == 0) {
+            return;
+        }
+        
+        // Apply MTF transformation to all pixels
+        for (var y = 0; y < height; y++) {
+            for (var x = 0; x < width; x++) {
+                var originalValue = data[y][x];
+                var transformedValue = mtfTransform(originalValue, midtones, shadows, highlights);
+                data[y][x] = (float) Math.clamp(transformedValue, 0, MAX_PIXEL_VALUE);
+            }
+        }
+    }
+    
+    // MTF transformation: MTF(x, m, lo, hi)
+    private double mtfTransform(double x, double m, double lo, double hi) {
+        if (x <= lo) {
+            return lo;
+        }
+        if (x >= hi) {
+            return hi;
+        }
+        
+        var xp = (x - lo) / (hi - lo);
+        var result = ((m - 1.0) * xp) / (((2.0 * m - 1.0) * xp) - m);
+        
+        return lo + result * (hi - lo);
+    }
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/StretchingStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/StretchingStrategy.java
@@ -32,6 +32,8 @@ public sealed interface StretchingStrategy permits
     AutohistogramStrategy,
     ContrastAdjustmentStrategy,
     DynamicStretchStrategy,
+    MidtoneTransferFunctionStrategy,
+    MidtoneTransferFunctionAutostretchStrategy,
     StretchingChain {
 
     default void stretch(ImageWrapper image) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/HeliumLineProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/HeliumLineProcessor.java
@@ -51,7 +51,7 @@ public class HeliumLineProcessor {
     private final ProcessParams processParams;
     private final ProgressOperation progressOperation;
     private final PixelShiftRange pixelShiftRange;
-    private final Map<Double, WorkflowState> imageByPixelShift;
+    private final Map<PixelShift, WorkflowState> imageByPixelShift;
     private final double heliumLineShift;
     private final ImageEmitter imageEmitter;
     private final Broadcaster broadcaster;
@@ -66,14 +66,14 @@ public class HeliumLineProcessor {
         this.processParams = processParams;
         this.progressOperation = progressOperation;
         this.pixelShiftRange = pixelShiftRange;
-        this.imageByPixelShift = imageList.stream().collect(Collectors.toMap(WorkflowState::pixelShift, s -> s, (e1, e2) -> e1, LinkedHashMap::new));
+        this.imageByPixelShift = imageList.stream().collect(Collectors.toMap(s -> new PixelShift(s.pixelShift()), s -> s, (e1, e2) -> e1, LinkedHashMap::new));
         this.heliumLineShift = heliumLineShift;
         this.imageEmitter = imageEmitter;
         this.broadcaster = broadcaster;
     }
 
     public void process() {
-        var source = findEnhancedImage(heliumLineShift);
+        var source = findEnhancedImage(new PixelShift(heliumLineShift));
         if (source == null) {
             return;
         }
@@ -130,7 +130,7 @@ public class HeliumLineProcessor {
         }
     }
 
-    private ImageWrapper findEnhancedImage(double shift) {
+    private ImageWrapper findEnhancedImage(PixelShift shift) {
         var workflowState = imageByPixelShift.get(shift);
         if (workflowState == null) {
             return null;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/PixelShift.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/PixelShift.java
@@ -18,4 +18,7 @@ package me.champeau.a4j.jsolex.processing.sun.workflow;
 public record PixelShift(
     double pixelShift
 ) {
+    public PixelShift(double pixelShift) {
+        this.pixelShift = Math.round(pixelShift * 100.0) / 100.0;
+    }
 }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageSelector.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageSelector.java
@@ -30,6 +30,7 @@ import me.champeau.a4j.jsolex.processing.expr.ImageMathScriptExecutor;
 import me.champeau.a4j.jsolex.processing.params.ImageMathParams;
 import me.champeau.a4j.jsolex.processing.params.RequestedImages;
 import me.champeau.a4j.jsolex.processing.sun.workflow.GeneratedImageKind;
+import me.champeau.a4j.jsolex.processing.sun.workflow.PixelShift;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.MutableMap;
 import me.champeau.a4j.jsolex.processing.util.ProcessingException;
@@ -387,7 +388,7 @@ public class ImageSelector {
     }
 
     private DefaultImageScriptExecutor createScriptExecutor() {
-        var images = new HashMap<Double, ImageWrapper32>();
+        var images = new HashMap<PixelShift, ImageWrapper32>();
         return new JSolExScriptExecutor(
             i -> images.computeIfAbsent(i, unused -> ImageWrapper32.createEmpty()),
             MutableMap.of(),

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/RedshiftImagesProcessor.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/RedshiftImagesProcessor.java
@@ -78,7 +78,7 @@ public class RedshiftImagesProcessor {
     private static final int TMP_IMAGES_COUNT = 4;
     private static final int MAX_PANEL_SIZE = 7680;
 
-    private final Map<Double, ImageWrapper> shiftImages;
+    private final Map<PixelShift, ImageWrapper> shiftImages;
     private final ProcessParams params;
     private final File serFile;
     private final Path outputDirectory;
@@ -92,7 +92,7 @@ public class RedshiftImagesProcessor {
     private final int imageWidth;
     private final int imageHeight;
 
-    public RedshiftImagesProcessor(Map<Double, ImageWrapper> shiftImages,
+    public RedshiftImagesProcessor(Map<PixelShift, ImageWrapper> shiftImages,
                                    ProcessParams params,
                                    File serFile,
                                    Path outputDirectory,
@@ -158,8 +158,8 @@ public class RedshiftImagesProcessor {
                            .mapToDouble(RedshiftArea::pixelShift)
                            .max()
                            .orElse(0d) + margin;
-        var min = Math.max(-maxShift, computedShifts.first());
-        var max = Math.min(maxShift, computedShifts.last());
+        var min = Math.max(-maxShift, computedShifts.first().pixelShift());
+        var max = Math.min(maxShift, computedShifts.last().pixelShift());
         var range = createMinMaxRange(min, max, .25).stream().sorted().toList();
         var contrast = new AdjustContrast(Map.of(), broadcaster);
         var initialImages = range.stream().map(shiftImages::get).toList();

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/script/JSolExScriptExecutor.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/script/JSolExScriptExecutor.java
@@ -25,6 +25,7 @@ import me.champeau.a4j.jsolex.processing.expr.DefaultImageScriptExecutor;
 import me.champeau.a4j.jsolex.processing.expr.impl.FileSelector;
 import me.champeau.a4j.jsolex.processing.expr.impl.Loader;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
+import me.champeau.a4j.jsolex.processing.sun.workflow.PixelShift;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 
 import java.io.File;
@@ -37,7 +38,7 @@ import java.util.function.Function;
  * A script executor which exposes a JavaFX file chooser to the {@link Loader}.
  */
 public class JSolExScriptExecutor extends DefaultImageScriptExecutor {
-    public JSolExScriptExecutor(Function<Double, ImageWrapper> imageSupplier,
+    public JSolExScriptExecutor(Function<PixelShift, ImageWrapper> imageSupplier,
                                 Map<Class, Object> context,
                                 Broadcaster broadcaster,
                                 Stage stage) {
@@ -45,7 +46,7 @@ public class JSolExScriptExecutor extends DefaultImageScriptExecutor {
         prepareContext(context, stage);
     }
 
-    public JSolExScriptExecutor(Function<Double, ImageWrapper> imagesByShift,
+    public JSolExScriptExecutor(Function<PixelShift, ImageWrapper> imagesByShift,
                                 Map<Class, Object> context,
                                 Stage stage) {
         super(imagesByShift, context);

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -14,7 +14,9 @@
 
 ### 3.2.3
 
-- Correction d'un bug dans le mode auto contrast qui pouvait provoquer une exception
+- Fix bug in auto contrast which could cause an array index out of bounds exception
+- Added `mtf` function inspired by SIRIL, which applies a Midtone Transfer Function (MTF) with configurable shadows, midtones and highlights parameters (8-bit values 0-255)
+- Added `mtf_autostretch` function inspired by SIRIL, which applies automatic MTF stretching based on histogram analysis using sigma-based shadow clipping and target background level
 
 ### 3.2.2
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -14,7 +14,9 @@
 
 ### 3.2.3
 
-- Fix bug in auto contrast which could cause an array index out of bounds exception
+- Correction d'un bug dans le mode auto contrast qui pouvait provoquer une exception
+- Ajout de la fonction `mtf` inspirée de SIRIL qui applique une fonction de transfert des tons moyens (MTF) avec des paramètres configurables pour les ombres, tons moyens et hautes lumières (valeurs 8-bit 0-255)
+- Ajout de la fonction `mtf_autostretch` inspirée de SIRIL qui applique un étirement MTF automatique basé sur l'analyse de l'histogramme utilisant un écrêtage des ombres basé sur sigma et un niveau de fond cible
 
 ### 3.2.2
 


### PR DESCRIPTION
This will be very useful for corona imaging. This commit introduces 2 new functions directly inspired from SIRIL: an MTF stretching strategy ("midtone transfer function") and an autostretch strategy which automatically computes the MTF parameters from image stats.