### PR TITLE
Read frame fully when detecting pixel depth

### DIFF
--- a/jserfile/src/main/java/me/champeau/a4j/ser/SerFileReader.java
+++ b/jserfile/src/main/java/me/champeau/a4j/ser/SerFileReader.java
@@ -197,7 +197,7 @@ public class SerFileReader implements AutoCloseable {
                 var data = tmpReader.currentFrame().data();
                 var dataLen = width * height * numPlanes;
 
-                for (int j = 0; j < dataLen; j += 16) {
+                for (int j = 0; j < dataLen; j++) {
                     int pixelValue = readColor(data, bytesPerPixel, bitsToDiscard);
                     maxPixel = Math.max(maxPixel, pixelValue);
                     minPixel = Math.min(minPixel, pixelValue);

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -12,6 +12,10 @@
 
 ## Changes since 3.0.0
 
+### 3.3.2
+
+- Fixed detection of bit depth in SER files
+
 ### 3.3.1
 
 - Fixed bug in cropping or SER frames extraction

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -12,6 +12,10 @@
 
 ## Changements depuis la 3.0.0
 
+### 3.3.2
+
+- Correction de la détection de profondeur de pixels des fichiers SER
+
 ### 3.3.1
 
 - Correction d'une erreur lors de l'opération de rognage ou d'extraction de trames du fichier SER


### PR DESCRIPTION
Before this change, only the first bytes of a frame were read, which was a mistake and premature optimization.

Should fix #585