### PR TITLE
No longer stretch image math images by default

### DIFF
--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
@@ -154,6 +154,9 @@ public class ImageViewer implements WithRootNode {
         this.title = title;
         this.description = description;
         this.siblings = siblings;
+        if (kind == GeneratedImageKind.IMAGE_MATH) {
+            this.stretchingMode = StretchingMode.NO_STRETCH;
+        }
         this.descriptionArea.textProperty().addListener((obs, old, newValue) -> {
             var textElement = this.descriptionArea.lookup(".text");
             if (textElement != null) {

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/BatchModeEventListener.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/BatchModeEventListener.java
@@ -47,6 +47,7 @@ import me.champeau.a4j.jsolex.processing.expr.ImageMathScriptResult;
 import me.champeau.a4j.jsolex.processing.file.FileNamingStrategy;
 import me.champeau.a4j.jsolex.processing.params.AutocropMode;
 import me.champeau.a4j.jsolex.processing.params.ProcessParams;
+import me.champeau.a4j.jsolex.processing.stretching.CutoffStretchingStrategy;
 import me.champeau.a4j.jsolex.processing.stretching.RangeExpansionStrategy;
 import me.champeau.a4j.jsolex.processing.sun.detection.RedshiftArea;
 import me.champeau.a4j.jsolex.processing.sun.workflow.DefaultImageEmitter;
@@ -228,7 +229,8 @@ public class BatchModeEventListener implements ProcessingEventListener, ImageMat
         if (correction != 0) {
             img = Corrector.rotate(img, correction, params.geometryParams().autocropMode() == AutocropMode.OFF);
         }
-        var saved = new ImageSaver(RangeExpansionStrategy.DEFAULT, params).save(img, target);
+        var strategy = kind == GeneratedImageKind.IMAGE_MATH ? CutoffStretchingStrategy.DEFAULT : RangeExpansionStrategy.DEFAULT;
+        var saved = new ImageSaver(strategy, params).save(img, target);
         for (var file : saved) {
             item.generatedFiles().add(file);
             dataLock.writeLock().lock();

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -18,6 +18,7 @@
 - Added mount, ERF and stop in observation details
 - Add an "assisted ellipse fitting" mode, which allows you to draw an ellipse around the disk, when detection fails
 - Moved advanced process parameters to their own section in the process settings
+- Images generated using scripts are no longer stretched by default (fixes issue 660)
 
 ### 3.3.2
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -18,6 +18,7 @@
 - Ajout de la monture et du filtre de rejet d'énergie et du diaphragme dans les paramètres d'observation
 - Ajout d'un mode de détection d'ellipse assistée par l'utilisateur, qui permet de dessiner une ellipse sur l'image et ainsi corriger les cas où la détection automatique échoue
 - Déplacement des paramètres de traitement avancés dans leur propre section
+- Les images générées par script ne sont plus automatiquement étirées (corrige issue 660)
 
 ### 3.3.2
 


### PR DESCRIPTION
This is a small breaking change but this is the right thing to do.

Fixes #660 