### PR TITLE
Add support for script parameters in UI

### DIFF
--- a/docs/src/docs/asciidoc/en/jsolex.adoc
+++ b/docs/src/docs/asciidoc/en/jsolex.adoc
@@ -5,7 +5,7 @@ Cédric Champeau
 
 JSol'Ex is a solar images processing software for http://www.astrosurf.com/solex/sol-ex-presentation-en.html[Christian Buil's Sol'Ex].
 It is capable of processing SER files captured with this instrument in order to produce images of the solar disk, in a similar way to what http://valerie.desnoux.free.fr/inti/[INTI from Valérie Desnoux] is doing.
-It is primarily designed to process images for Sol'Ex, but it might work properly for other kinds of spectroheliographs.
+It is primarily designed to process images for Sol'Ex, but it will work properly for other kinds of spectroheliographs.
 
 JSol'Ex is free software published under the Apache 2 software license.
 It is written in en Java and provided for free without any warranty.
@@ -516,6 +516,104 @@ Last but not least, the `[outputs]` section declares the images we want to gener
 - `helium_color` is the `helium_mono` image to which we have applied a colorization.
 
 NOTE: Comments can be added either with the `#` or `//` prefix.
+
+[[script-parameters]]
+=== Script Parameters
+
+Scripts can optionally declare configurable parameters using the `meta` block.
+While not required, adding parameters is highly recommended if you plan to share your script with others, as users unfamiliar with scripting will prefer tweaking parameters rather than modifying code directly.
+
+When a script declares parameters, JSol'Ex automatically creates user interface controls that allow users to adjust values without editing the script.
+
+==== Declaring Parameters
+
+Parameters are declared in a `meta` block at the beginning of your script:
+
+[source]
+----
+meta {
+    title = "Enhanced Stacking Script"
+    requires = "4.1.0"
+
+    params {
+        tileSize {
+            type = "number"
+            default = 64
+            min = 16
+            max = 512
+            name {
+                en = "Tile Size"
+                fr = "Taille de tuile"
+            }
+            description {
+                en = "Size of tiles for processing"
+                fr = "Taille des tuiles pour le traitement"
+            }
+        }
+
+        pixelShift {
+            type = "number"
+            default = 0
+            min = -10
+            max = 10
+            name = "Pixel Shift"
+            description = "Shift in pixels from reference wavelength"
+        }
+
+        cropRatio {
+            type = "choice"
+            choices = "1.0,1.1,1.2,1.5,2.0"
+            default = "1.1"
+            name = "Autocrop Ratio"
+            description = "Solar radius multiplication factor for cropping"
+        }
+    }
+}
+
+[outputs]
+result = autocrop(img(pixelShift), cropRatio)
+----
+
+==== Parameter Types
+
+JSol'Ex supports three parameter types:
+
+* **number**: Numeric values with optional min/max constraints
+* **string**: Text values
+* **choice**: Selection from predefined options
+
+==== Meta Block Properties
+
+* **title**: Display name for the script (supports multiple languages)
+* **requires**: Minimum JSol'Ex version needed (displays warning if not met)
+* **params**: Container for parameter definitions
+
+==== Localization
+
+Parameter names and descriptions can be localized using language objects or simple strings:
+
+[source]
+----
+name {
+    en = "English Name"
+    fr = "Nom français"
+}
+// Or simply:
+name = "Default Name"
+----
+
+If no localization is provided for the user's language, JSol'Ex falls back to English, then to the first available language.
+
+==== Version Compatibility
+
+The `requires` field ensures users are warned if their JSol'Ex version might not support all script features:
+
+[source]
+----
+meta {
+    requires = "4.1.0"  // Warns users with older versions
+}
+----
 
 [[special-variables]]
 === Special variables

--- a/docs/src/docs/asciidoc/fr/jsolex.adoc
+++ b/docs/src/docs/asciidoc/fr/jsolex.adoc
@@ -707,6 +707,104 @@ Au final, la section `[outputs]` déclare les images qui nous intéressent :
 
 NOTE: Vous pouvez mettre des commentaires sur une ligne commençant par `#` ou `//`
 
+[[script-parameters]]
+=== Paramètres de scripts
+
+Les scripts peuvent optionnellement déclarer des paramètres configurables en utilisant le bloc `meta`.
+Bien que ce ne soit pas obligatoire, ajouter des paramètres est fortement recommandé si vous prévoyez de partager votre script avec d'autres, car les utilisateurs peu familiers avec les scripts préfèreront ajuster des paramètres plutôt que de modifier directement le code.
+
+Lorsqu'un script déclare des paramètres, JSol'Ex crée automatiquement des contrôles d'interface utilisateur qui permettent aux utilisateurs d'ajuster les valeurs sans éditer le script.
+
+==== Déclaration des paramètres
+
+Les paramètres sont déclarés dans un bloc `meta` au début de votre script :
+
+[source]
+----
+meta {
+    title = "Script d'empilement amélioré"
+    requires = "4.1.0"
+
+    params {
+        tileSize{
+            type = "number"
+            default = 64
+            min = 16
+            max = 512
+            name {
+                en = "Tile Size"
+                fr = "Taille de tuile"
+            }
+            description {
+                en = "Size of tiles for processing"
+                fr = "Taille des tuiles pour le traitement"
+            }
+        }
+
+        pixelShift {
+            type = "number"
+            default = 0
+            min = -10
+            max = 10
+            name = "Décalage pixel"
+            description = "Décalage en pixels par rapport à la longueur d'onde de référence"
+        }
+
+        cropRatio {
+            type = "choice"
+            choices = "1.0,1.1,1.2,1.5,2.0"
+            default = "1.1"
+            name = "Ratio de rognage"
+            description = "Facteur de multiplication du rayon solaire pour le rognage"
+        }
+    }
+}
+
+[outputs]
+result = autocrop(img(pixelShift), cropRatio)
+----
+
+==== Types de paramètres
+
+JSol'Ex supporte trois types de paramètres :
+
+* **number** : Valeurs numériques avec contraintes min/max optionnelles
+* **string** : Valeurs textuelles
+* **choice** : Sélection parmi des options prédéfinies
+
+==== Propriétés du bloc Meta
+
+* **title** : Nom d'affichage pour le script (supporte plusieurs langues)
+* **requires** : Version minimale de JSol'Ex requise (affiche un avertissement si non satisfaite)
+* **params** : Conteneur pour les définitions de paramètres
+
+==== Localisation
+
+Les noms et descriptions des paramètres peuvent être localisés en utilisant des objets de langue ou des chaînes simples :
+
+[source]
+----
+name {
+    en = "English Name"
+    fr = "Nom français"
+}
+// Ou simplement :
+name = "Nom par défaut"
+----
+
+Si aucune localisation n'est fournie pour la langue de l'utilisateur, JSol'Ex utilise l'anglais par défaut, puis la première langue disponible.
+
+==== Compatibilité de version
+
+Le champ `requires` assure que les utilisateurs sont avertis si leur version de JSol'Ex peut ne pas supporter toutes les fonctionnalités du script :
+
+[source]
+----
+meta {
+    requires = "4.1.0"  // Avertit les utilisateurs avec des versions plus anciennes
+}
+----
+
 [[trimming-ser-files]]
 == Réduire la taille des fichiers SER
 

--- a/jsolex-core/src/main/congocc/ImageMath.ccc
+++ b/jsolex-core/src/main/congocc/ImageMath.ccc
@@ -32,7 +32,7 @@ INJECT PARSER_CLASS:
 
 INCLUDE "ImageMathLexer.ccc"
 
-Root#ImageMathScript : (IncludeDef! | FunctionDef!)* (IncludeDef! | FirstSection!) ( IncludeDef! | SubsequentSection! )* <EOF>;
+Root#ImageMathScript : (IncludeDef! | FunctionDef! | MetaBlock!)* (IncludeDef! | FirstSection!) ( IncludeDef! | SubsequentSection! )* <EOF>;
 
 INJECT ImageMathScript:
 import java.nio.file.Path;
@@ -106,6 +106,12 @@ import me.champeau.a4j.jsolex.processing.expr.ImageMathScriptExecutor;
                     if (first.isMajor() && "batch".equals(first.id())) {
                         isInBatch = true;
                         batchSections.add(section);
+                    } else if (first.isMajor() && "params".equals(first.id())) {
+                        // Skip params sections in both single and batch modes
+                        continue;
+                    } else if (first.isMajor() && "single".equals(first.id())) {
+                        // [[single]] sections are treated as standard sections
+                        standardSections.add(section);
                     } else {
                         standardSections.add(section);
                     }
@@ -116,11 +122,39 @@ import me.champeau.a4j.jsolex.processing.expr.ImageMathScriptExecutor;
         }
         return Collections.unmodifiableList(kind == ImageMathScriptExecutor.SectionKind.SINGLE ? standardSections : batchSections);
     }
+
+    public Optional<Section> findParamsSection() {
+        // Look for top-level meta blocks containing params
+        var metaBlocks = childrenOfType(MetaBlock.class);
+        if (!metaBlocks.isEmpty()) {
+            // Return the first section we can find for compatibility,
+            // the actual parameters will be extracted via getTopLevelParameterDefs()
+            return childrenOfType(Section.class).stream().findFirst();
+        }
+        return Optional.empty();
+    }
+
+    public List<ParameterDef> getTopLevelParameterDefs() {
+        var metaBlocks = childrenOfType(MetaBlock.class);
+        for (var metaBlock : metaBlocks) {
+            var content = metaBlock.getContent();
+            var paramsBlocks = content.childrenOfType(ParametersBlock.class);
+            for (var paramsBlock : paramsBlocks) {
+                if (paramsBlock.isParams()) {
+                    return paramsBlock.getParameterDefs();
+                }
+            }
+        }
+        return Collections.emptyList();
+    }
 }
 
-FirstSection#Section : [SectionHeader] (Assignment!)*;
+FirstSection#Section : [SectionHeader] SectionContent;
 
-SubsequentSection#Section : SectionHeader (Assignment!)* ;
+SubsequentSection#Section : SectionHeader SectionContent;
+
+SectionContent#void:
+    (Assignment | MetaBlock)*;
 
 INJECT Section:
 
@@ -132,13 +166,38 @@ import me.champeau.a4j.jsolex.processing.expr.ImageMathScriptExecutor;
                    .map(header -> header.firstChildOfType(Identifier.class).toString());
     }
 
+    public List<ParameterDef> getParameterDefs() {
+        // Look for meta blocks with params in this section
+        var metaBlocks = childrenOfType(MetaBlock.class);
+        for (var metaBlock : metaBlocks) {
+            var content = metaBlock.getContent();
+            var paramsBlocks = content.childrenOfType(ParametersBlock.class);
+            for (var paramsBlock : paramsBlocks) {
+                if (paramsBlock.isParams()) {
+                    return paramsBlock.getParameterDefs();
+                }
+            }
+        }
+
+        // If no meta blocks in this section, check the script level
+        var parent = getParent();
+        while (parent != null && !(parent instanceof ImageMathScript)) {
+            parent = parent.getParent();
+        }
+        if (parent instanceof ImageMathScript script) {
+            return script.getTopLevelParameterDefs();
+        }
+
+        return Collections.emptyList();
+    }
+
 }
 
 SectionHeader :
 (
     <LBRACKET> (
         (<LBRACKET> <IDENTIFIER> <RBRACKET> <RBRACKET>) { thisProduction.setMajor(true); }# |
-        <IDENTIFIER> <RBRACKET>
+        (<IDENTIFIER> | "params") <RBRACKET>
     )
 );
 
@@ -306,7 +365,16 @@ INJECT NumericalLiteral: extends Expression;
 NamedArgument :
     <IDENTIFIER> <COLON> Expression =>||;
 
-INJECT NamedArgument : extends Argument;
+INJECT NamedArgument : extends Argument
+{
+    public String getName() {
+        return firstChildOfType(Identifier.class).toString();
+    }
+
+    public Expression getValue() {
+        return firstChildOfType(Expression.class);
+    }
+}
 
 Argument:
     NamedArgument | Expression;
@@ -388,5 +456,200 @@ INJECT IncludeDef:
 
     public boolean isUnresolved() {
         return includedNodes == null;
+    }
+}
+
+ParameterDef:
+    <IDENTIFIER> ParameterObject;
+
+INJECT ParameterDef:
+{
+    public String getName() {
+        return firstChildOfType(Identifier.class).toString();
+    }
+
+    public ParameterObject getObjectValue() {
+        return firstChildOfType(ParameterObject.class);
+    }
+
+    public StringLiteral getStringValue() {
+        return firstChildOfType(StringLiteral.class);
+    }
+
+    public NumericalLiteral getNumberValue() {
+        return firstChildOfType(NumericalLiteral.class);
+    }
+
+    public ParameterArray getArrayValue() {
+        return firstChildOfType(ParameterArray.class);
+    }
+
+    public Object getValue() {
+        var obj = getObjectValue();
+        if (obj != null) return obj;
+        var str = getStringValue();
+        if (str != null) return str;
+        var num = getNumberValue();
+        if (num != null) return num;
+        var arr = getArrayValue();
+        if (arr != null) return arr;
+        return null;
+    }
+}
+
+ParameterValue:
+    ParameterObject |
+    StringLiteral |
+    NumericalLiteral;
+
+ParameterObject:
+    <LBRACE> (ParameterProperty)* <RBRACE>;
+
+INJECT ParameterObject:
+{
+    public List<ParameterProperty> getProperties() {
+        return childrenOfType(ParameterProperty.class);
+    }
+
+    public Optional<String> getProperty(String name) {
+        return getProperties().stream()
+            .filter(prop -> name.equals(prop.getName()))
+            .map(ParameterProperty::getStringValue)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .findFirst();
+    }
+
+    public Optional<Number> getNumberProperty(String name) {
+        return getProperties().stream()
+            .filter(prop -> name.equals(prop.getName()))
+            .map(ParameterProperty::getNumberValue)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .findFirst();
+    }
+}
+
+ParameterProperty:
+    <IDENTIFIER> (<ASSIGNMENT> ParameterPropertyValue | ParameterObject);
+
+INJECT ParameterProperty:
+{
+    public String getName() {
+        return firstChildOfType(Identifier.class).toString();
+    }
+
+    public ParameterPropertyValue getValue() {
+        var value = firstChildOfType(ParameterPropertyValue.class);
+        if (value != null) {
+            return value;
+        }
+        // Fallback: if ParameterPropertyValue is optimized away, create a virtual one
+        var virtualValue = new ParameterPropertyValue();
+        virtualValue.addAll(childrenOfType(StringLiteral.class));
+        virtualValue.addAll(childrenOfType(NumericalLiteral.class));
+        virtualValue.addAll(childrenOfType(ParameterObject.class));
+        virtualValue.addAll(childrenOfType(ParameterArray.class));
+        return virtualValue;
+    }
+
+    public Optional<String> getStringValue() {
+        var value = getValue();
+        if (value.firstChildOfType(StringLiteral.class) != null) {
+            return Optional.of(value.firstChildOfType(StringLiteral.class).toString());
+        }
+        return Optional.empty();
+    }
+
+    public Optional<Number> getNumberValue() {
+        var value = getValue();
+        var numLiteral = value.firstChildOfType(NumericalLiteral.class);
+        if (numLiteral != null) {
+            try {
+                var str = numLiteral.toString();
+                if (str.contains(".")) {
+                    return Optional.of(Double.parseDouble(str));
+                } else {
+                    return Optional.of(Long.parseLong(str));
+                }
+            } catch (NumberFormatException e) {
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+}
+
+ParameterPropertyValue:
+    StringLiteral |
+    NumericalLiteral |
+    ParameterObject |
+    ParameterArray;
+
+ParameterArray:
+    <LBRACKET> [StringLiteral ((<COMMA>|<SEMICOLON>) StringLiteral)*] <RBRACKET>;
+
+INJECT ParameterArray:
+{
+    public List<StringLiteral> getElements() {
+        return childrenOfType(StringLiteral.class);
+    }
+}
+
+MetaBlock:
+    <META> <LBRACE> MetaContent <RBRACE>;
+
+INJECT MetaBlock:
+{
+    public String getName() {
+        return "meta";
+    }
+
+    public MetaContent getContent() {
+        var content = firstChildOfType(MetaContent.class);
+        if (content != null) {
+            return content;
+        }
+        // Fallback: if MetaContent is optimized away, create a virtual one
+        var virtualContent = new MetaContent();
+        virtualContent.addAll(childrenOfType(ParametersBlock.class));
+        virtualContent.addAll(childrenOfType(MetaProperty.class));
+        return virtualContent;
+    }
+
+}
+
+MetaContent:
+    (ParametersBlock | MetaProperty)*;
+
+INJECT MetaContent:
+{
+    public List<ParametersBlock> getParametersBlocks() {
+        return childrenOfType(ParametersBlock.class);
+    }
+
+    public List<MetaProperty> getMetaProperties() {
+        return childrenOfType(MetaProperty.class);
+    }
+}
+
+MetaProperty:
+    <IDENTIFIER> (<ASSIGNMENT> (StringLiteral | NumericalLiteral) | ParameterObject);
+
+ParametersBlock:
+    <PARAMS> <LBRACE> (ParameterDef)* <RBRACE>;
+
+INJECT ParametersBlock:
+{
+    public String getName() {
+        return "params";
+    }
+
+    public boolean isParams() {
+        return true;
+    }
+
+    public List<ParameterDef> getParameterDefs() {
+        return childrenOfType(ParameterDef.class);
     }
 }

--- a/jsolex-core/src/main/congocc/ImageMathLexer.ccc
+++ b/jsolex-core/src/main/congocc/ImageMathLexer.ccc
@@ -84,4 +84,8 @@ TOKEN #Keyword:
     <FUNCTION: "fun">
     |
     <INCLUDE: "include">
+    |
+    <META: "meta">
+    |
+    <PARAMS: "params">
 ;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ChoiceParameter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ChoiceParameter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.params;
+
+import java.util.List;
+import java.util.Map;
+
+public class ChoiceParameter extends ScriptParameter {
+    private final List<String> choices;
+
+    public ChoiceParameter(String name, String defaultValue, Map<String, String> displayName, Map<String, String> description,
+                          List<String> choices) {
+        super(name, ParameterType.CHOICE, defaultValue, displayName, description);
+        this.choices = List.copyOf(choices);
+    }
+
+    public List<String> getChoices() {
+        return choices;
+    }
+
+    @Override
+    public ValidationResult validate(Object value) {
+        if (value == null) {
+            return ValidationResult.invalid("Value cannot be null");
+        }
+
+        String strValue = value.toString();
+        if (!choices.contains(strValue)) {
+            return ValidationResult.invalid("Value must be one of: " + choices);
+        }
+
+        return ValidationResult.valid();
+    }
+
+    @Override
+    public String formatValue(Object value) {
+        return value.toString();
+    }
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ImageMathParameterExtractor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ImageMathParameterExtractor.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.params;
+
+import me.champeau.a4j.jsolex.expr.ImageMathParser;
+import me.champeau.a4j.jsolex.expr.ast.Identifier;
+import me.champeau.a4j.jsolex.expr.ast.ImageMathScript;
+import me.champeau.a4j.jsolex.expr.ast.MetaBlock;
+import me.champeau.a4j.jsolex.expr.ast.MetaProperty;
+import me.champeau.a4j.jsolex.expr.ast.ParameterDef;
+import me.champeau.a4j.jsolex.expr.ast.ParameterObject;
+import me.champeau.a4j.jsolex.expr.ast.ParameterProperty;
+import me.champeau.a4j.jsolex.expr.ast.StringLiteral;
+import me.champeau.a4j.jsolex.processing.util.VersionUtil;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class ImageMathParameterExtractor {
+
+    public static class ParameterExtractionResult {
+        private final List<ScriptParameter> parameters;
+        private final boolean hasParametersSection;
+        private final Map<String, String> title;
+        private final String scriptFileName;
+        private final String requiredVersion;
+
+        public ParameterExtractionResult(List<ScriptParameter> parameters,
+                                         boolean hasParametersSection,
+                                         Map<String, String> title,
+                                         String scriptFileName,
+                                         String requiredVersion) {
+            this.parameters = List.copyOf(parameters);
+            this.hasParametersSection = hasParametersSection;
+            this.title = Map.copyOf(title != null ? title : Map.of());
+            this.scriptFileName = scriptFileName;
+            this.requiredVersion = requiredVersion;
+        }
+
+        public List<ScriptParameter> getParameters() {
+            return parameters;
+        }
+
+        public boolean hasParametersSection() {
+            return hasParametersSection;
+        }
+
+        public Map<String, String> getTitle() {
+            return title;
+        }
+
+        public String getScriptFileName() {
+            return scriptFileName;
+        }
+
+        public String getRequiredVersion() {
+            return requiredVersion;
+        }
+
+        public boolean isVersionSupported() {
+            return VersionUtil.isVersionSupported(requiredVersion);
+        }
+
+        public String getDisplayTitle(String language) {
+            if (title.isEmpty()) {
+                return scriptFileName;
+            }
+
+            String titleText = title.get(language);
+            if (titleText != null) {
+                return titleText;
+            }
+
+            titleText = title.get("default");
+            if (titleText != null) {
+                return titleText;
+            }
+
+            titleText = title.get("en");
+            if (titleText != null) {
+                return titleText;
+            }
+
+            if (!title.isEmpty()) {
+                return title.values().iterator().next();
+            }
+
+            return scriptFileName;
+        }
+    }
+
+    public ParameterExtractionResult extractParameters(Path scriptFile) throws Exception {
+        String content = Files.readString(scriptFile);
+        String fileName = scriptFile.getFileName().toString();
+        return extractParameters(content, fileName);
+    }
+
+    public ParameterExtractionResult extractParameters(String scriptContent) throws Exception {
+        return extractParameters(scriptContent, "unknown");
+    }
+
+    public ParameterExtractionResult extractParameters(String scriptContent, String fileName) throws Exception {
+        try {
+            var parser = new ImageMathParser(scriptContent);
+            ImageMathScript script = parser.parseAndInlineIncludes();
+
+            return extractParametersFromAST(script, fileName);
+        } catch (Exception e) {
+            throw new Exception("Failed to parse script for parameter extraction", e);
+        }
+    }
+
+    public ParameterExtractionResult extractParametersFromAST(ImageMathScript script, String fileName) {
+        List<ScriptParameter> parameters = new ArrayList<>();
+        boolean hasParametersSection = false;
+        Map<String, String> title = new HashMap<>();
+        String requiredVersion = null;
+
+        var metaBlocks = script.childrenOfType(MetaBlock.class);
+        for (var metaBlock : metaBlocks) {
+            var metaContent = metaBlock.getContent();
+            var metaProperties = metaContent.getMetaProperties();
+
+            for (var property : metaProperties) {
+                var identifier = property.firstChildOfType(Identifier.class);
+                if (identifier != null) {
+                    if ("title".equals(identifier.toString()) || "name".equals(identifier.toString())) {
+                        title.putAll(extractLocalizedValuesFromProperty(property));
+                    } else if ("requires".equals(identifier.toString())) {
+                        var stringLiteral = property.firstChildOfType(StringLiteral.class);
+                        if (stringLiteral != null) {
+                            requiredVersion = stringLiteral.toString();
+                        }
+                    }
+                }
+            }
+        }
+
+        List<ParameterDef> topLevelParams = script.getTopLevelParameterDefs();
+        if (!topLevelParams.isEmpty()) {
+            hasParametersSection = true;
+            for (ParameterDef paramDef : topLevelParams) {
+                ScriptParameter parameter = extractParameterFromDef(paramDef);
+                if (parameter != null) {
+                    parameters.add(parameter);
+                }
+            }
+        }
+
+        return new ParameterExtractionResult(parameters, hasParametersSection, title, fileName, requiredVersion);
+    }
+
+
+    private ScriptParameter extractParameterFromDef(ParameterDef paramDef) {
+        String parameterName = paramDef.getName();
+        ParameterObject paramObj = paramDef.getObjectValue();
+
+        if (paramObj == null) {
+            return null;
+        }
+
+        Optional<String> typeOpt = paramObj.getProperty("type");
+        if (typeOpt.isEmpty()) {
+            return null;
+        }
+
+        ParameterType parameterType;
+        try {
+            parameterType = ParameterType.valueOf(typeOpt.get().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+
+        Object defaultValue = null;
+        var defaultNumberOpt = paramObj.getNumberProperty("default");
+        if (defaultNumberOpt.isPresent()) {
+            defaultValue = defaultNumberOpt.get();
+        } else {
+            var defaultStringOpt = paramObj.getProperty("default");
+            if (defaultStringOpt.isPresent()) {
+                defaultValue = defaultStringOpt.get();
+            }
+        }
+
+        Map<String, String> displayNames = extractLocalizedValues(paramObj, "name");
+        Map<String, String> descriptions = extractLocalizedValues(paramObj, "description");
+
+        return switch (parameterType) {
+            case NUMBER -> {
+                Double min = paramObj.getNumberProperty("min").map(Number::doubleValue).orElse(null);
+                Double max = paramObj.getNumberProperty("max").map(Number::doubleValue).orElse(null);
+                Number numDefault = defaultValue instanceof Number ? (Number) defaultValue : 0.0;
+                yield new NumberParameter(parameterName, numDefault, displayNames, descriptions, min, max);
+            }
+            case STRING -> {
+                String strDefault = defaultValue != null ? defaultValue.toString() : "";
+                yield new StringParameter(parameterName, strDefault, displayNames, descriptions, null, null);
+            }
+            case CHOICE -> {
+                String choices = paramObj.getProperty("choices").orElse("");
+                List<String> choiceList = choices.isEmpty() ? List.of() : List.of(choices.split(","));
+                String strDefault = defaultValue != null ? defaultValue.toString() : (choiceList.isEmpty() ? "" : choiceList.get(0));
+                yield new ChoiceParameter(parameterName, strDefault, displayNames, descriptions, choiceList);
+            }
+        };
+    }
+
+    private Map<String, String> extractLocalizedValues(ParameterObject paramObj, String baseName) {
+        Map<String, String> result = new HashMap<>();
+
+        for (ParameterProperty prop : paramObj.getProperties()) {
+            String propName = prop.getName();
+            if (propName.equals(baseName)) {
+                var nestedObj = prop.getValue().firstChildOfType(ParameterObject.class);
+                if (nestedObj != null) {
+                    for (ParameterProperty langProp : nestedObj.getProperties()) {
+                        String language = langProp.getName();
+                        Optional<String> value = langProp.getStringValue();
+                        if (value.isPresent()) {
+                            result.put(language, value.get());
+                        }
+                    }
+                } else {
+                    Optional<String> directValue = prop.getStringValue();
+                    if (directValue.isPresent()) {
+                        result.put("default", directValue.get());
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private Map<String, String> extractLocalizedValuesFromProperty(MetaProperty property) {
+        Map<String, String> result = new HashMap<>();
+
+        var nestedObj = property.firstChildOfType(ParameterObject.class);
+        if (nestedObj != null) {
+            for (ParameterProperty langProp : nestedObj.getProperties()) {
+                String language = langProp.getName();
+                Optional<String> value = langProp.getStringValue();
+                if (value.isPresent()) {
+                    result.put(language, value.get());
+                }
+            }
+        } else {
+            var stringLiteral = property.firstChildOfType(StringLiteral.class);
+            if (stringLiteral != null) {
+                result.put("default", stringLiteral.toString());
+            }
+        }
+
+        return result;
+    }
+
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ImageMathParams.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ImageMathParams.java
@@ -20,16 +20,19 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 
 import static me.champeau.a4j.jsolex.processing.util.Constants.message;
 
 public record ImageMathParams(
-        List<File> scriptFiles
+        List<File> scriptFiles,
+        Map<File, Map<String, Object>> parameterValues
 ) {
     public static final Logger LOGGER = LoggerFactory.getLogger(ImageMathParams.class);
 
     public static final ImageMathParams NONE = new ImageMathParams(
-            List.of()
+            List.of(),
+            Map.of()
     );
 
     @Override

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/NumberParameter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/NumberParameter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.params;
+
+import java.util.Map;
+
+public class NumberParameter extends ScriptParameter {
+    private final Double min;
+    private final Double max;
+
+    public NumberParameter(String name,
+                           Number defaultValue,
+                           Map<String, String> displayName,
+                           Map<String, String> description,
+                           Double min,
+                           Double max) {
+        super(name, ParameterType.NUMBER, defaultValue, displayName, description);
+        this.min = min;
+        this.max = max;
+    }
+
+    public Double getMin() {
+        return min;
+    }
+
+    public Double getMax() {
+        return max;
+    }
+
+    @Override
+    public ValidationResult validate(Object value) {
+        if (value == null) {
+            return ValidationResult.invalid("Value cannot be null");
+        }
+
+        double numValue;
+        try {
+            if (value instanceof Number) {
+                numValue = ((Number) value).doubleValue();
+            } else {
+                numValue = Double.parseDouble(value.toString());
+            }
+        } catch (NumberFormatException e) {
+            return ValidationResult.invalid("Value must be a number");
+        }
+
+        if (min != null && numValue < min) {
+            return ValidationResult.invalid("Value must be >= " + min);
+        }
+
+        if (max != null && numValue > max) {
+            return ValidationResult.invalid("Value must be <= " + max);
+        }
+
+        return ValidationResult.valid();
+    }
+
+    @Override
+    public String formatValue(Object value) {
+        if (value instanceof Number) {
+            return value.toString();
+        }
+        return String.valueOf(value);
+    }
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ParameterType.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ParameterType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.params;
+
+public enum ParameterType {
+    NUMBER,
+    STRING,
+    CHOICE
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ProcessParams.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ProcessParams.java
@@ -270,6 +270,6 @@ public record ProcessParams(
             combinedScripts.add(scriptPath.toFile());
         }
 
-        return new ImageMathParams(combinedScripts);
+        return new ImageMathParams(combinedScripts, requestedImages.mathImages().parameterValues());
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ScriptParameter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ScriptParameter.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.params;
+
+import java.util.Map;
+
+public abstract class ScriptParameter {
+    private final String name;
+    private final ParameterType type;
+    private final Object defaultValue;
+    private final Map<String, String> displayName;
+    private final Map<String, String> description;
+
+    protected ScriptParameter(String name,
+                              ParameterType type,
+                              Object defaultValue,
+                              Map<String, String> displayName,
+                              Map<String, String> description) {
+        this.name = name;
+        this.type = type;
+        this.defaultValue = defaultValue;
+        this.displayName = displayName != null ? Map.copyOf(displayName) : Map.of();
+        this.description = description != null ? Map.copyOf(description) : Map.of();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ParameterType getType() {
+        return type;
+    }
+
+    public Object getDefaultValue() {
+        return defaultValue;
+    }
+
+    public Map<String, String> getDisplayName() {
+        return displayName;
+    }
+
+    public String getDisplayName(String language) {
+        String name = displayName.get(language);
+        if (name != null) {
+            return name;
+        }
+
+        // If shorthand notation was used, it's stored as "default" - use it
+        name = displayName.get("default");
+        if (name != null) {
+            return name;
+        }
+
+        // If no shorthand, use English as default
+        name = displayName.get("en");
+        if (name != null) {
+            return name;
+        }
+
+        // If no English, use first available translation
+        if (!displayName.isEmpty()) {
+            return displayName.values().iterator().next();
+        }
+
+        // Last resort: use parameter variable name
+        return this.name;
+    }
+
+    public Map<String, String> getDescription() {
+        return description;
+    }
+
+    public String getDescription(String language) {
+        String desc = description.get(language);
+        if (desc != null) {
+            return desc;
+        }
+
+        // If shorthand notation was used, it's stored as "default" - use it
+        desc = description.get("default");
+        if (desc != null) {
+            return desc;
+        }
+
+        // If no shorthand, use English as default
+        desc = description.get("en");
+        if (desc != null) {
+            return desc;
+        }
+
+        // If no English, use first available translation
+        if (!description.isEmpty()) {
+            return description.values().iterator().next();
+        }
+
+        // No description available
+        return null;
+    }
+
+    public abstract ValidationResult validate(Object value);
+
+    public abstract String formatValue(Object value);
+
+    public static class ValidationResult {
+        private final boolean valid;
+        private final String errorMessage;
+
+        private ValidationResult(boolean valid, String errorMessage) {
+            this.valid = valid;
+            this.errorMessage = errorMessage;
+        }
+
+        public static ValidationResult valid() {
+            return new ValidationResult(true, null);
+        }
+
+        public static ValidationResult invalid(String message) {
+            return new ValidationResult(false, message);
+        }
+
+        public boolean isValid() {
+            return valid;
+        }
+
+        public String getErrorMessage() {
+            return errorMessage;
+        }
+    }
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/StringParameter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/StringParameter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.params;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class StringParameter extends ScriptParameter {
+    private final String pattern;
+    private final List<String> choices;
+    private final Pattern compiledPattern;
+
+    public StringParameter(String name, String defaultValue, Map<String, String> displayName, Map<String, String> description,
+                          String pattern, List<String> choices) {
+        super(name, ParameterType.STRING, defaultValue, displayName, description);
+        this.pattern = pattern;
+        this.choices = choices != null ? List.copyOf(choices) : null;
+        this.compiledPattern = pattern != null ? Pattern.compile(pattern) : null;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public List<String> getChoices() {
+        return choices;
+    }
+
+    @Override
+    public ValidationResult validate(Object value) {
+        if (value == null) {
+            return ValidationResult.invalid("Value cannot be null");
+        }
+
+        String strValue = value.toString();
+
+        if (choices != null && !choices.contains(strValue)) {
+            return ValidationResult.invalid("Value must be one of: " + choices);
+        }
+
+        if (compiledPattern != null && !compiledPattern.matcher(strValue).matches()) {
+            return ValidationResult.invalid("Value must match pattern: " + pattern);
+        }
+
+        return ValidationResult.valid();
+    }
+
+    @Override
+    public String formatValue(Object value) {
+        return value.toString();
+    }
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -1081,6 +1081,12 @@ public class SolexVideoProcessor implements Broadcaster {
                     }
                     return img;
                 }, Collections.unmodifiableMap(context), this);
+                var fileParams = mathImages.parameterValues().get(scriptFile);
+                if (fileParams != null) {
+                    for (Map.Entry<String, Object> entry : fileParams.entrySet()) {
+                        scriptRunner.putVariable(entry.getKey(), entry.getValue());
+                    }
+                }
                 try {
                     var result = scriptRunner.execute(scriptFile.toPath(), ImageMathScriptExecutor.SectionKind.SINGLE);
                     ImageMathScriptExecutor.render(result, emitter);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/Bass2000ConfigService.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/Bass2000ConfigService.java
@@ -127,45 +127,6 @@ public class Bass2000ConfigService {
     }
 
     private boolean isVersionSupported(String requiredVersion) {
-        if (requiredVersion == null || requiredVersion.trim().isEmpty()) {
-            return true;
-        }
-        
-        try {
-            var currentVersion = VersionUtil.getVersion();
-            return compareVersions(currentVersion, requiredVersion) >= 0;
-        } catch (Exception e) {
-            LOGGER.warn("Failed to compare versions", e);
-            return true;
-        }
-    }
-
-    private int compareVersions(String version1, String version2) {
-        var parts1 = version1.split("\\.");
-        var parts2 = version2.split("\\.");
-        
-        int maxLength = Math.max(parts1.length, parts2.length);
-        
-        for (int i = 0; i < maxLength; i++) {
-            int v1 = i < parts1.length ? parseVersionPart(parts1[i]) : 0;
-            int v2 = i < parts2.length ? parseVersionPart(parts2[i]) : 0;
-            
-            if (v1 != v2) {
-                return Integer.compare(v1, v2);
-            }
-        }
-        
-        return 0;
-    }
-
-    private int parseVersionPart(String part) {
-        try {
-            if (part.contains("-")) {
-                part = part.substring(0, part.indexOf("-"));
-            }
-            return Integer.parseInt(part);
-        } catch (NumberFormatException e) {
-            return 0;
-        }
+        return VersionUtil.isVersionSupported(requiredVersion);
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/VersionUtil.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/VersionUtil.java
@@ -134,4 +134,46 @@ public class VersionUtil {
             return version;
         }
     }
+
+    public static boolean isVersionSupported(String requiredVersion) {
+        if (requiredVersion == null || requiredVersion.trim().isEmpty()) {
+            return true;
+        }
+
+        try {
+            var currentVersion = getVersion();
+            return compareVersions(currentVersion, requiredVersion) >= 0;
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
+    public static int compareVersions(String version1, String version2) {
+        var parts1 = version1.split("\\.");
+        var parts2 = version2.split("\\.");
+
+        int maxLength = Math.max(parts1.length, parts2.length);
+
+        for (int i = 0; i < maxLength; i++) {
+            int v1 = i < parts1.length ? parseVersionPart(parts1[i]) : 0;
+            int v2 = i < parts2.length ? parseVersionPart(parts2[i]) : 0;
+
+            if (v1 != v2) {
+                return Integer.compare(v1, v2);
+            }
+        }
+
+        return 0;
+    }
+
+    private static int parseVersionPart(String part) {
+        try {
+            if (part.contains("-")) {
+                part = part.substring(0, part.indexOf("-"));
+            }
+            return Integer.parseInt(part);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
 }

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/expr/EnhancedScriptWithFunctionsTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/expr/EnhancedScriptWithFunctionsTest.groovy
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.expr
+
+import me.champeau.a4j.jsolex.processing.params.ImageMathParameterExtractor
+import spock.lang.Specification
+
+class EnhancedScriptWithFunctionsTest extends Specification {
+
+    def "can have both a meta block and functions"() {
+        given:
+        var scriptContent = '''meta {
+    title="Test"
+    requires="5.0.0"
+    params {
+        gamma {
+            type = "number"
+            name = "Gamma Correction"
+            description {
+                en = "Gamma correction value for contrast adjustment"
+                fr = "Valeur de correction gamma pour l'ajustement du contraste"
+            }
+            default = 1.5
+            min = 0.5
+            max = 100
+        }
+        tileSize {
+            type = "choice"
+            name {
+                en = "Tile Size"
+                fr = "Taille de tuile"
+            }
+            description {
+                en = "Tile size for processing (smaller = more detail, larger = faster)"
+                fr = "Taille de tuile pour le traitement (plus petit = plus de détails, plus grand = plus rapide)"
+            }
+            default = "32"
+            choices = "16,32,64,128"
+        }
+
+        sampling {
+            type = "number"
+            name {
+                en = "Sampling Rate"
+                fr = "Taux d'échantillonnage"
+            }
+            description {
+                en = "Sampling rate for processing (lower = faster but less accurate)"
+                fr = "Taux d'échantillonnage pour le traitement (plus bas = plus rapide mais moins précis)"
+            }
+            default = 0.25
+            min = 0.1
+            max = 1.0
+        }
+    }
+}
+
+[fun:foo i]
+   result=img(i)
+
+[tmp]
+v=foo(2)
+denoised=avg(range(-1;1))
+
+[outputs]
+processed=draw_text(denoised;100;100; "" + gamma)
+
+[[batch]]
+[outputs]
+stacked=draw_text(auto_contrast(stack(processed;tileSize;sampling);gamma);100;100; "" + gamma)
+'''
+        var extractor = new ImageMathParameterExtractor()
+
+        when:
+        var result = extractor.extractParameters(scriptContent)
+
+        then:
+        println("=== PARAMETER EXTRACTION RESULT ===")
+        println("Parameters found: ${result.parameters.size()}")
+        result.parameters.each { param ->
+            println("  - ${param.name}: ${param.class.simpleName} (default: ${param.defaultValue})")
+        }
+        println("Has parameters section: ${result.hasParametersSection()}")
+        println("Required version: ${result.requiredVersion}")
+        println("Title: ${result.title}")
+
+        and:
+        result.hasParametersSection()
+        result.parameters.size() == 3
+        result.parameters.find { it.name == "gamma" }?.defaultValue == 1.5
+        result.parameters.find { it.name == "tileSize" }?.defaultValue == "32"
+        result.parameters.find { it.name == "sampling" }?.defaultValue == 0.25
+        result.requiredVersion == "5.0.0"
+    }
+
+    def "should inject parameter default values during script execution"() {
+        given:
+        var scriptContent = '''meta {
+    params {
+        gamma {
+            type = "number"
+            default = 1.5
+        }
+    }
+}
+
+[outputs]
+result = gamma
+'''
+
+        when:
+        var parser = new ImageMathParser(scriptContent)
+        var script = parser.parseAndInlineIncludes()
+        var topLevelParams = script.getTopLevelParameterDefs()
+
+        then:
+        println("Top level parameters found: ${topLevelParams.size()}")
+        topLevelParams.each { param ->
+            println("  - ${param.name}: ${param.objectValue?.getProperty('default')}")
+        }
+        topLevelParams.size() == 1
+        topLevelParams[0].name == "gamma"
+        topLevelParams[0].objectValue?.getNumberProperty("default")?.orElse(null) == 1.5
+    }
+}

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/expr/ParameterExecutionTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/expr/ParameterExecutionTest.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.expr
+
+import me.champeau.a4j.jsolex.processing.expr.DefaultImageScriptExecutor
+import me.champeau.a4j.jsolex.processing.expr.ImageMathScriptExecutor
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32
+import spock.lang.Specification
+
+class ParameterExecutionTest extends Specification {
+    def "extracts parameter default values as variables"() {
+        def script = """meta {
+    params {
+        brightness {
+            type = "number"
+            default = 1.5
+            min = 0.0
+            max = 2.0
+        }
+        contrast {
+            type = "number"
+            default = 2.0
+        }
+        filter_size {
+            type = "number"
+            default = 3
+        }
+    }
+}
+
+[[single]]
+result = brightness + contrast + filter_size"""
+
+        def imageSupplier = { ImageWrapper32.createEmpty() }
+        def executor = new DefaultImageScriptExecutor(imageSupplier, [:])
+
+        when:
+        def result = executor.execute(script, ImageMathScriptExecutor.SectionKind.SINGLE)
+
+        then:
+        // Check that parameters are available as variables in the executor
+        executor.getVariable("brightness").isPresent()
+        executor.getVariable("brightness").get() == 1.5
+        executor.getVariable("contrast").isPresent()
+        executor.getVariable("contrast").get() == 2.0
+        executor.getVariable("filter_size").isPresent()
+        executor.getVariable("filter_size").get() == 3L
+    }
+
+    def "handles string parameters"() {
+        def script = """meta {
+    params {
+        method {
+            type = "choice"
+            default = "median"
+            choices = "median,average,maximum"
+        }
+    }
+}
+
+[[single]]
+result = method"""
+
+        def imageSupplier = { ImageWrapper32.createEmpty() }
+        def executor = new DefaultImageScriptExecutor(imageSupplier, [:])
+
+        when:
+        def result = executor.execute(script, ImageMathScriptExecutor.SectionKind.SINGLE)
+
+        then:
+        executor.getVariable("method").isPresent()
+        executor.getVariable("method").get() == "median"
+    }
+}

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/expr/ParameterParsingTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/expr/ParameterParsingTest.groovy
@@ -1,0 +1,332 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.expr
+
+import me.champeau.a4j.jsolex.expr.ast.Identifier
+import me.champeau.a4j.jsolex.expr.ast.MetaBlock
+import me.champeau.a4j.jsolex.expr.ast.ParameterObject
+import me.champeau.a4j.jsolex.processing.params.ImageMathParameterExtractor
+import spock.lang.Specification
+
+class ParameterParsingTest extends Specification {
+    def "parses simple parameter definition"() {
+        def script = """meta {
+    params {
+        test {
+            type = "number"
+            default = 42
+        }
+    }
+}"""
+        def parser = new ImageMathParser(script)
+
+        when:
+        def root = parser.parseAndInlineIncludes()
+
+        then:
+        root != null
+        def paramsSection = root.findParamsSection()
+        paramsSection.isPresent()
+        def section = paramsSection.get()
+        def paramDefs = section.getParameterDefs()
+        paramDefs.size() == 1
+        paramDefs[0].getName() == "test"
+    }
+
+    def "parses parameter with object syntax"() {
+        def script = """meta {
+    params {
+        brightness {
+            type = "number"
+            default = 1.0
+            min = 0.0
+            max = 2.0
+        }
+    }
+}"""
+        def parser = new ImageMathParser(script)
+
+        when:
+        def root = parser.parseAndInlineIncludes()
+
+        then:
+        root != null
+        def paramsSection = root.findParamsSection()
+        paramsSection.isPresent()
+        def section = paramsSection.get()
+        def paramDefs = section.getParameterDefs()
+        paramDefs.size() == 1
+        paramDefs[0].getName() == "brightness"
+    }
+
+    def "parses mixed params and single sections"() {
+        def script = """meta {
+    params {
+        brightness {
+            type = "number"
+            default = 1.0
+            min = 0.0
+            max = 2.0
+        }
+    }
+}
+
+[[single]]
+result = adjust_gamma(img(0), brightness)"""
+        def parser = new ImageMathParser(script)
+
+        when:
+        def root = parser.parseAndInlineIncludes()
+
+        then:
+        root != null
+        def paramsSection = root.findParamsSection()
+        paramsSection.isPresent()
+        def singleSections = root.findSections(me.champeau.a4j.jsolex.processing.expr.ImageMathScriptExecutor.SectionKind.SINGLE)
+        singleSections.size() == 1
+    }
+
+    def "extracts parameters using ImageMathParameterExtractor"() {
+        def script = """meta {
+    params {
+        gamma {
+            type = "number"
+            default = 1.5
+            min = 0.5
+            max = 3.0
+            description = "Gamma correction factor"
+        }
+        method {
+            type = "choice"
+            default = "auto"
+            choices = "auto,manual,hybrid"
+            description = "Processing method"
+        }
+    }
+}
+
+[[single]]
+result = img(0)"""
+        def extractor = new me.champeau.a4j.jsolex.processing.params.ImageMathParameterExtractor()
+
+        when:
+        def result = extractor.extractParameters(script)
+
+        then:
+        result != null
+        result.hasParametersSection()
+        result.parameters.size() == 2
+        def gammaParam = result.parameters.find { it.name == "gamma" }
+        gammaParam != null
+        gammaParam.type.name() == "NUMBER"
+        gammaParam.defaultValue == 1.5
+        def methodParam = result.parameters.find { it.name == "method" }
+        methodParam != null
+        methodParam.type.name() == "CHOICE"
+        methodParam.defaultValue == "auto"
+    }
+
+    def "parses nested parameter objects"() {
+        def script = """meta {
+    params {
+        gamma {
+            type = "number"
+            name {
+                en = "Gamma Correction"
+            }
+            default = 1.5
+        }
+    }
+}"""
+        def parser = new ImageMathParser(script)
+
+        when:
+        def root = parser.parseAndInlineIncludes()
+
+        then:
+        root != null
+        def paramsSection = root.findParamsSection()
+        paramsSection.isPresent()
+        def paramDefs = paramsSection.get().getParameterDefs()
+        paramDefs.size() == 1
+        paramDefs[0].getName() == "gamma"
+    }
+
+    def "parses internationalized title in meta section"() {
+        def script = """meta {
+    author = "Test Author"
+    title {
+        en = "English Title"
+        fr = "Titre Français"
+    }
+    version = "1.0"
+    params {
+        gamma {
+            type = "number"
+            default = 1.5
+        }
+    }
+}
+
+image = gamma(image)
+"""
+
+        def parser = new ImageMathParser(script)
+
+        when:
+        def root = parser.parseAndInlineIncludes()
+
+        then:
+        root != null
+        def metaBlocks = root.childrenOfType(MetaBlock.class)
+        metaBlocks.size() == 1
+        def metaBlock = metaBlocks[0]
+
+        // Check that the meta content contains both regular properties and nested objects
+        def metaContent = metaBlock.getContent()
+        def metaProperties = metaContent.getMetaProperties()
+        metaProperties.size() == 3 // author, title, version
+
+        // Find the title property with nested language structure
+        def titleProperty = metaProperties.find { prop ->
+            def identifier = prop.firstChildOfType(Identifier.class)
+            identifier != null && identifier.toString() == "title"
+        }
+        titleProperty != null
+
+        // Verify it has a ParameterObject child (for the nested structure)
+        def titleObject = titleProperty.firstChildOfType(ParameterObject.class)
+        titleObject != null
+
+        // Check for parameters section
+        def paramsBlocks = metaContent.getParametersBlocks()
+        paramsBlocks.size() == 1
+    }
+
+    def "handles shorthand notation as default locale"() {
+        def script = """meta {
+    params {
+        gamma {
+            type = "number"
+            name = "Gamma Correction"
+            description = "Adjusts gamma correction"
+            default = 1.5
+        }
+        method {
+            type = "choice"
+            name {
+                en = "Processing Method"
+                fr = "Méthode de traitement"
+            }
+            description = "Choose processing method"
+            choices = "auto,manual"
+            default = "auto"
+        }
+    }
+}"""
+
+        def extractor = new ImageMathParameterExtractor()
+
+        when:
+        def result = extractor.extractParameters(script)
+
+        then:
+        result != null
+        result.hasParametersSection()
+        result.parameters.size() == 2
+
+        // Check gamma parameter with shorthand notation
+        def gammaParam = result.parameters.find { it.name == "gamma" }
+        gammaParam != null
+        gammaParam.displayName.size() == 1
+        gammaParam.displayName.containsKey("default")
+        gammaParam.displayName.get("default") == "Gamma Correction"
+        gammaParam.description.size() == 1
+        gammaParam.description.containsKey("default")
+        gammaParam.description.get("default") == "Adjusts gamma correction"
+
+        // Check method parameter with mixed notation
+        def methodParam = result.parameters.find { it.name == "method" }
+        methodParam != null
+        methodParam.displayName.size() == 2
+        methodParam.displayName.containsKey("en")
+        methodParam.displayName.get("en") == "Processing Method"
+        methodParam.displayName.containsKey("fr")
+        methodParam.displayName.get("fr") == "Méthode de traitement"
+        methodParam.description.size() == 1
+        methodParam.description.containsKey("default")
+        methodParam.description.get("default") == "Choose processing method"
+    }
+
+    def "fallback logic works correctly for display names"() {
+        def script = """meta {
+    params {
+        shorthandParam {
+            type = "number"
+            name = "Shorthand Name"
+            default = 1.0
+        }
+        englishParam {
+            type = "number"
+            name {
+                en = "English Name"
+                de = "German Name"
+            }
+            default = 2.0
+        }
+        multiLangParam {
+            type = "number"
+            name {
+                fr = "French Name"
+                de = "German Name"
+                es = "Spanish Name"
+            }
+            default = 3.0
+        }
+    }
+}"""
+
+        def extractor = new ImageMathParameterExtractor()
+
+        when:
+        def result = extractor.extractParameters(script)
+
+        then:
+        result != null
+        result.parameters.size() == 3
+
+        // Test shorthand parameter
+        def shorthandParam = result.parameters.find { it.name == "shorthandParam" }
+        shorthandParam != null
+        shorthandParam.getDisplayName("fr") == "Shorthand Name"  // Falls back to default
+        shorthandParam.getDisplayName("en") == "Shorthand Name"  // Falls back to default
+        shorthandParam.getDisplayName("default") == "Shorthand Name"  // Direct access
+
+        // Test English parameter (no shorthand, has English)
+        def englishParam = result.parameters.find { it.name == "englishParam" }
+        englishParam != null
+        englishParam.getDisplayName("fr") == "English Name"  // Falls back to English
+        englishParam.getDisplayName("en") == "English Name"  // Direct English
+        englishParam.getDisplayName("de") == "German Name"  // Direct German
+
+        // Test multi-language parameter (no shorthand, no English)
+        def multiLangParam = result.parameters.find { it.name == "multiLangParam" }
+        multiLangParam != null
+        multiLangParam.getDisplayName("en") != null  // Falls back to first available
+        multiLangParam.getDisplayName("it") != null  // Falls back to first available
+        multiLangParam.getDisplayName("fr") == "French Name"  // Direct French
+    }
+}

--- a/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script31.txt
+++ b/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script31.txt
@@ -1,0 +1,19 @@
+meta {
+    params {
+        brightness {
+            type = "number"
+            default = 1.0
+            min = 0.0
+            max = 2.0
+            description = "Image brightness"
+        }
+        contrast {
+            type = "number"
+            default = 1.0
+            description = "Image contrast"
+        }
+    }
+}
+
+[[single]]
+result = adjust_gamma(img(0), brightness, contrast)

--- a/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script32.txt
+++ b/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script32.txt
@@ -1,0 +1,25 @@
+meta {
+    author = "Cédric Champeau"
+    title = "Median Filter with Threshold"
+    version = "1.0"
+    requires = "4.1.0"
+    params {
+        threshold {
+            type = "number"
+            default = 0.5
+            min = 0.0
+            max = 1.0
+            description = "Detection threshold"
+        }
+        method {
+            type = "choice"
+            default = "auto"
+            choices = "auto,manual,hybrid"
+            description = "Processing method"
+        }
+    }
+}
+
+[[single]]
+filtered = median_filter(img(0), 3)
+result = apply_threshold(filtered, threshold, method)

--- a/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script33.txt
+++ b/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script33.txt
@@ -1,0 +1,15 @@
+meta {
+    params {
+        text_content {
+            type = "string"
+            default = "Sample text"
+            description = "Text to add"
+        }
+    }
+}
+
+x_position = 10
+y_position = 20
+
+[[single]]
+result = draw_text(img(0), x_position, y_position, text_content)

--- a/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script34.txt
+++ b/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script34.txt
@@ -1,0 +1,14 @@
+meta {
+    params {
+        scale {
+            type = "number"
+            default = 1.5
+            display_name = "Scale Factor"
+            description = "Scaling factor for image processing"
+        }
+    }
+}
+
+[[single]]
+scaled = resize(img(0), scale)
+result = scaled

--- a/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script35.txt
+++ b/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script35.txt
@@ -1,0 +1,17 @@
+meta {
+    params {
+        radius {
+            type = "number"
+            default = 5.0
+            min = 1.0
+            max = 50.0
+            display_name = "Blur Radius"
+            display_name_fr = "Rayon de flou"
+            description = "Gaussian blur radius in pixels"
+            description_fr = "Rayon du flou gaussien en pixels"
+        }
+    }
+}
+
+[[single]]
+result = gaussian_blur(img(0), radius)

--- a/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script36.txt
+++ b/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script36.txt
@@ -1,0 +1,3 @@
+brightness = 1.2
+contrast = 0.8
+result = adjust_gamma(img(0), brightness, contrast)

--- a/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script37.txt
+++ b/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script37.txt
@@ -1,0 +1,8 @@
+[section1]
+var1 = 123
+
+[section2]
+var2 = 456
+
+[[batch]]
+var3 = 789

--- a/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script38.txt
+++ b/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script38.txt
@@ -1,0 +1,27 @@
+[fun:enhance img radius]
+blurred = gaussian_blur(img, radius)
+contrast = auto_contrast(blurred, 1.2)
+result = sharpen(contrast, 2)
+
+meta {
+    params {
+        blur_radius {
+            type = "number"
+            default = 3.0
+            min = 1.0
+            max = 10.0
+            description = "Blur radius for preprocessing"
+        }
+        threshold {
+            type = "number"
+            default = 0.8
+            min = 0.0
+            max = 1.0
+            description = "Detection threshold"
+        }
+    }
+}
+
+[[single]]
+preprocessed = enhance(img(0), blur_radius)
+result = threshold_detect(preprocessed, threshold)

--- a/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script39.txt
+++ b/jsolex-core/src/test/resources/me/champeau/a4j/jsolex/expr/script39.txt
@@ -1,0 +1,29 @@
+[fun:process_frame img method]
+enhanced = linear_stretch(img, 2.0)
+denoised = median_filter(enhanced, 3)
+result = apply_method(denoised, method)
+
+meta {
+    params {
+        stack_method {
+            type = "choice"
+            default = "median"
+            choices = "median,average,maximum"
+            description = "Stacking method"
+        }
+        iterations {
+            type = "number"
+            default = 5
+            min = 1
+            max = 20
+            description = "Processing iterations"
+        }
+    }
+}
+
+[[batch]]
+processed = process_frame(img(0), stack_method)
+stacked = stack(processed, stack_method)
+
+[[single]]
+final_result = iterate_process(stacked, iterations)

--- a/jsolex-scripting/src/main/java/me/champeau/a4j/jsolex/cli/ScriptingEntryPoint.java
+++ b/jsolex-scripting/src/main/java/me/champeau/a4j/jsolex/cli/ScriptingEntryPoint.java
@@ -230,7 +230,7 @@ public class ScriptingEntryPoint implements Runnable {
         }
         processParams = processParams.withRequestedImages(
                 processParams.requestedImages().withMathImages(
-                        new ImageMathParams(List.of(scriptPath)
+                        new ImageMathParams(List.of(scriptPath), Map.of()
                         )
                 )
         );

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
@@ -376,6 +376,7 @@ public class JSolEx implements JSolExInterface {
             var root = (Parent) fxmlLoader.load();
             configureIsolatedScriptExecution();
             imageMathScript.setPrefHeight(10000);
+            imageMathScript.setAutoFoldMetaBlocks(true);
             var preferredDimensions = config.getPreferredDimensions();
             Scene rootScene = new Scene(root, preferredDimensions.a(), preferredDimensions.b());
             rootScene.getStylesheets().add(JSolEx.class.getResource("syntax.css").toExternalForm());

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/I18N.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/I18N.java
@@ -18,6 +18,7 @@ package me.champeau.a4j.jsolex.app.jfx;
 import javafx.fxml.FXMLLoader;
 import me.champeau.a4j.jsolex.processing.util.LocaleUtils;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
@@ -32,7 +33,7 @@ public class I18N {
 
     public static FXMLLoader fxmlLoader(Class<?> clazz, String resourceName) {
         try {
-            var bundle = ResourceBundle.getBundle(clazz.getPackageName() + "." + resourceName, LocaleUtils.getConfiguredLocale());
+            var bundle = fetchBundle(clazz.getPackageName() + "." + resourceName);
             return new FXMLLoader(clazz.getResource(resourceName + ".fxml"), bundle);
         } catch (MissingResourceException ex) {
             return new FXMLLoader(clazz.getResource(resourceName + ".fxml"));
@@ -42,11 +43,20 @@ public class I18N {
     public static String string(Class<?> clazz, String resourceName, String label) {
         try {
             var baseName = clazz.getPackageName() + "." + resourceName;
-            var bundle = CACHED_BUNDLES.computeIfAbsent(baseName, _ -> ResourceBundle.getBundle(baseName, LocaleUtils.getConfiguredLocale()));
+            var bundle = fetchBundle(baseName);
             return bundle.getString(label);
         } catch (MissingResourceException ex) {
             return "";
         }
+    }
+
+    private static ResourceBundle fetchBundle(String baseName) {
+        return CACHED_BUNDLES.computeIfAbsent(baseName, _ -> {
+            if ("en".equals(LocaleUtils.getConfiguredLocale().toString())) {
+                return ResourceBundle.getBundle(baseName, Locale.ROOT);
+            }
+            return ResourceBundle.getBundle(baseName, LocaleUtils.getConfiguredLocale());
+        });
     }
 
 }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageMathEditor.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageMathEditor.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -167,7 +168,7 @@ public class ImageMathEditor {
         if (!items.isEmpty()) {
             scriptsToApply.getSelectionModel().selectFirst();
         }
-        scriptTextArea.minHeightProperty().bind(stage.heightProperty().subtract(200));
+        scriptTextArea.minHeightProperty().bind(stage.heightProperty().subtract(300));
     }
 
     private void loadPredefinedScripts() {
@@ -240,7 +241,8 @@ public class ImageMathEditor {
     private void ok() {
         if (doesNotHaveStaleChanges()) {
             params = new ImageMathParams(
-                    scriptsToApply.getItems().stream().map(ImageMathEntry::scriptFile).toList()
+                    scriptsToApply.getItems().stream().map(ImageMathEntry::scriptFile).toList(),
+                    Map.of()
             );
             requestClose();
         }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/stacking/StackingAndMosaicController.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/stacking/StackingAndMosaicController.java
@@ -370,7 +370,7 @@ public class StackingAndMosaicController {
     private void editStackingPostProcessingScript() {
         var files = stackPostProcessingScriptFile != null ? List.of(stackPostProcessingScriptFile) : List.<File>of();
         ImageMathEditor.create(stage,
-            new ImageMathParams(files),
+            new ImageMathParams(files, Map.of()),
             owner.getHostServices(),
             false,
             false,
@@ -390,7 +390,7 @@ public class StackingAndMosaicController {
     private void editMosaicPostProcessingScript() {
         var files = mosaicPostProcessingScriptFile != null ? List.of(mosaicPostProcessingScriptFile) : List.<File>of();
         ImageMathEditor.create(stage,
-            new ImageMathParams(files),
+            new ImageMathParams(files, Map.of()),
             owner.getHostServices(),
             false,
             false,

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/image-selection.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/image-selection.properties
@@ -27,3 +27,5 @@ redshift=Redshift measurements
 doppler.eclipse=Doppler eclipse
 activeregions=Active regions
 ellerman.bombs=Ellerman bombs detection (H-alpha only)
+script.parameters.header=Parameters for %s
+script.version.warning=Warning: This script requires JSol'Ex version %s or later (current version: %s). The script may not work correctly.

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/image-selection_fr.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/image-selection_fr.properties
@@ -27,3 +27,5 @@ redshift=Mesures de décalage vers le rouge
 doppler.eclipse=Eclipse mode Doppler
 activeregions=Régions actives
 ellerman.bombs=Détection des bombes d'Ellerman (H-alpha seulement)
+script.parameters.header=Paramètres pour %s
+script.version.warning=Attention : Ce script nécessite JSol'Ex version %s ou ultérieure (version actuelle : %s). Le script pourrait ne pas fonctionner correctement.

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/imagemath-editor.fxml
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/imagemath-editor.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import me.champeau.a4j.jsolex.app.jfx.ime.ImageMathTextArea?>
 
-<BorderPane prefHeight="600.0" prefWidth="1100.0" styleClass="params-dialog" xmlns="http://javafx.com/javafx/19"
+<BorderPane prefHeight="600.0" prefWidth="1100.0" minHeight="500.0" maxHeight="800.0" styleClass="params-dialog" xmlns="http://javafx.com/javafx/19"
             xmlns:fx="http://javafx.com/fxml/1" fx:controller="me.champeau.a4j.jsolex.app.jfx.ImageMathEditor">
     <center>
         <HBox spacing="0">
@@ -42,15 +42,15 @@
                 <padding>
                     <Insets top="8" right="12" bottom="8" left="12"/>
                 </padding>
-                
+
                 <!-- Script Editor Header -->
                 <HBox alignment="CENTER_LEFT" spacing="16">
                     <Label text="%script.text" style="-fx-font-weight: bold; -fx-font-size: 14px;"/>
                     <Hyperlink fx:id="docsLink" text="%open.documentation" onAction="#openDocs"/>
                 </HBox>
-                
+
                 <!-- Script Text Area - This should take most of the space -->
-                <ImageMathTextArea fx:id="scriptTextArea" prefHeight="350" VBox.vgrow="ALWAYS">
+                <ImageMathTextArea fx:id="scriptTextArea" prefHeight="250" minHeight="200" VBox.vgrow="ALWAYS">
                     <VBox.margin>
                         <Insets top="8" bottom="12"/>
                     </VBox.margin>

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/process-params.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/process-params.properties
@@ -199,3 +199,4 @@ preset.delete.confirm.header=Delete preset "{0}"?
 preset.delete.confirm.content=Are you sure you want to delete this preset? This action cannot be undone.
 load.preset.tooltip=Load this preset configuration
 delete.preset.tooltip=Delete this preset
+script.parameters=Script Parameters

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/process-params_fr.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/process-params_fr.properties
@@ -199,3 +199,4 @@ preset.delete.confirm.header=Supprimer le préréglage "{0}" ?
 preset.delete.confirm.content=Êtes-vous sûr de vouloir supprimer ce préréglage ? Cette action ne peut pas être annulée.
 load.preset.tooltip=Charger cette configuration de préréglage
 delete.preset.tooltip=Supprimer ce préréglage
+script.parameters=Paramètres des scripts

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/syntax.css
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/syntax.css
@@ -64,3 +64,25 @@
 .log_debug {
     -fx-fill: blue;
 }
+
+.parameter_property {
+    -fx-fill: #27ae60;
+    -fx-font-weight: bold;
+}
+
+.language_code {
+    -fx-fill: #f39c12;
+    -fx-font-style: italic;
+}
+
+.parameter_name {
+    -fx-fill: #dd5f00;
+    -fx-font-weight: bold;
+}
+
+.folded-hidden {
+    visibility: hidden;
+    -fx-max-height: 0;
+    -fx-pref-height: 0;
+    -fx-min-height: 0;
+}

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/templates/enhanced-invert.math
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/templates/enhanced-invert.math
@@ -3,10 +3,59 @@
 # with the prominences image
 ###
 
-[params]
-gamma1 = 1.5
-gamma2 = 1.05
-protus_stretch = 20
+meta {
+    name {
+        en = "Enhanced Invert"
+        fr = "Inversion Améliorée"
+    }
+    author = "Cédric Champeau"
+    params {
+        gamma1 {
+            type = "number"
+            default = 1.5
+            min = 0.1
+            max = 5.0
+            step = 0.05
+            name {
+                en = "Disk Contrast Gamma"
+                fr = "Gamma de Contraste du Disque"
+            }
+            description {
+                en = "Gamma correction value for the contrast adjustment of the solar disk"
+                fr = "Valeur de correction gamma pour l'ajustement du contraste du disque solaire"
+            }
+        }
+        gamma2 {
+            type = "number"
+            default = 1.05
+            min = 0.1
+            max = 5.0
+            name {
+                en = "Final Contrast Gamma"
+                fr = "Gamma de Contraste Final"
+            }
+            description {
+                en = "Gamma correction value for the final contrast adjustment"
+                fr = "Valeur de correction gamma pour l'ajustement final du contraste"
+            }
+        }
+        protus_stretch {
+            type = "number"
+            default = 20
+            min = 1
+            max = 100
+            step = 1
+            name {
+                en = "Prominences Stretch"
+                fr = "Étalement des Protubérances"
+            }
+            description {
+                en = "Stretch factor for the prominences enhancement"
+                fr = "Facteur d'étalement pour l'amélioration des protubérances"
+            }
+        }
+    }
+}
 
 [tmp]
 # The negative image

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -3,9 +3,11 @@
 ## What's New in Version 4.1.0
 
 - **User-Defined Presets**: Create, save, and manage your own custom image selection and script presets alongside the existing Quick and Full mode presets
+- Scripts can now declare their parameters which will automatically be configurable in the user interface
 - Added blend mode for BASS2000 image alignment with adjustable opacity
 - Added a warning when submitting to BASS2000 a file which was already submitted on the same day for the same wavelength
 - [bugfix] Fixed BASS2000 upload button being enabled before files are fully saved to disk
+- [improvement] Script parameters are now properly isolated per script file to prevent parameter name conflicts
 
 ## What's New in Version 4.0.1
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -3,6 +3,7 @@
 ## Nouveautés de la version 4.1.0
 
 - **Préréglages utilisateur** : Créez, sauvegardez et gérez vos propres préréglages personnalisés pour la sélection d'images et les scripts, en complément des modes Rapide et Complet
+- Les scripts peuvent maintenant déclarer leurs paramètres qui seront automatiquement configurables dans l'interface utilisateur
 - Ajout du mode fondu pour l'alignement d'images BASS2000 avec opacité réglable
 - Avertissement lors de la soumission à BASS2000 si un fichier a déjà été envoyé le même jour pour la même longueur d'onde
 - [bugfix] Correction du bouton d'upload BASS2000 activé avant la sauvegarde des fichiers sur disque


### PR DESCRIPTION
This commit introduces a new, optional section in scripts, which is called `meta`. This section contains description about the script, and more specifically, information about the parameters that the script accepts. These parameters are different from regular variables in the sense that they are exposed via the UI.

A script author can therefore write a "plugin" for JSol'Ex by exposing a script with parameter definition, in which case the users wouldn't have to understand where to modify the code: the UI will display both parameters and tooltips.