### PR TITLE
Introduce stack_dedis function

### DIFF
--- a/jsolex-core/src/main/functions/flat_correction.yml
+++ b/jsolex-core/src/main/functions/flat_correction.yml
@@ -28,12 +28,14 @@ examples:
   - "flat_correction(img(0))"
   - "flat_correction(img: img(0), order: 3)"
 extraDocs:
-  fr: "[NOTE]
+  fr: "
+[NOTE]
 .Expérimental
 ====
 La correction par flat artificiel permet de corriger un éventuel vignettage. Elle calcule un modèle à partir des pixels du disque. Les pixels considérés sont ceux dont la valeur est comprise entre un percentile bas et un percentile haut. Par exemple, si vous entrez 0.1 et 0.9, les pixels dont la valeur est comprise entre le 10ème et le 90ème percentile seront utilisés pour calculer le modèle. Enfin, un polynome d'ordre spécifié est ajusté sur les valeurs du modèle pour corriger l'image.
 ===="
-  en: "[NOTE]
+  en: "
+[NOTE]
 .Experimental
 ====
 The artificial flat correction allows to correct a possible vignetting. It computes a model from the disk pixels. The pixels considered are those whose value is between a low and a high percentile. For example, if you enter 0.1 and 0.9, the pixels whose value is between the 10th and 90th percentile will be used to compute the model. Finally, a polynomial of the specified order is adjusted on the model values to correct the image.

--- a/jsolex-core/src/main/functions/stack_dedis.yml
+++ b/jsolex-core/src/main/functions/stack_dedis.yml
@@ -1,0 +1,27 @@
+name: STACK_DEDIS
+category: STACKING
+description:
+  fr: "Empile des images dé-déformées en appliquant un poids sur chaque image. Le poids est calculé en fonction de l'erreur de dé-distortion : les images nécessitant une forte correction de distorsion auront un poids plus faible."
+  en: "Stacks de-distorted images by applying a weight to each image. The weight is calculated based on the de-distortion error: images requiring strong distortion correction will have a lower weight."
+arguments:
+  - name: images
+    description:
+      fr: "Images à empiler."
+      en: "Images to be stacked."
+  - name: best
+    optional: true
+    default: 1
+    description:
+      fr: "Fraction des meilleures images à empiler."
+      en: "Fraction of the best images to be stacked."
+  - name: local
+    optional: true
+    default: 0
+    description:
+      fr: "Active une analyse locale des distorsions (1=activé, 0=désactivé). Si activé, les images à prendre en compte et leur poids sont calculés pixel par pixel en fonction de l'erreur de distorsion locale. Cette méthode peut donner de meilleurs résultats, mais ils ne sont pas garantis. Il peut être judicieux de ne pas conserver 100% des images pour cette méthode."
+      en: "Enables local distortion analysis (1=enabled, 0=disabled). If enabled, the images to be considered and their weight are calculated pixel by pixel based on the local distortion error. This method can yield better results, but they are not guaranteed. It may be wise not to keep 100% of the images for this method."
+examples:
+  - "stack_dedis(some_images)"
+  - "stack_dedis(images: some_images)"
+  - "stack_dedis(images: some_images, local: 1)"
+

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
@@ -166,9 +166,9 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
         this.scaling = new Scaling(context, broadcaster, crop);
         this.simpleFunctionCall = new SimpleFunctionCall(context, broadcaster);
         this.stretching = new Stretching(context, broadcaster);
-        this.stacking = new Stacking(context, scaling, crop, simpleFunctionCall, imageDraw, broadcaster);
-        this.mosaicComposition = new MosaicComposition(context, broadcaster, stacking, ellipseFit, scaling);
         this.utilities = new Utilities(context, broadcaster);
+        this.stacking = new Stacking(context, scaling, crop, simpleFunctionCall, imageDraw, utilities, broadcaster);
+        this.mosaicComposition = new MosaicComposition(context, broadcaster, stacking, ellipseFit, scaling);
     }
 
     public <T> void putInContext(Class<T> key, T value) {
@@ -358,6 +358,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
             case FIND_SHIFT -> pixelShiftFor(arguments);
             case STACK -> stacking.stack(arguments);
             case STACK_REF -> stacking.chooseReference(arguments);
+            case STACK_DEDIS -> stacking.stackDedistorted(arguments);
             case SORT -> utilities.sort(arguments);
             case TRANSITION -> animate.transition(arguments);
             case UNSHARP_MASK -> convolution.unsharpMask(arguments);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Dedistort.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Dedistort.java
@@ -189,15 +189,6 @@ public class Dedistort extends AbstractFunctionImpl {
         return new FFTSupport.FloatFFT2DResult(shiftedReal, shiftedImag);
     }
 
-    // Parabola fitting for sub-pixel accuracy correction
-    public static double fitParabola1D(double v0, double v1, double v2) {
-        var denom = 2 * (2 * v1 - v0 - v2);
-        if (denom == 0) {
-            return 0;
-        }
-        return (v0 - v2) / denom;
-    }
-
     static double linearInterpolation(double v0, double v1, double t) {
         return (v0 + t * (v1 - v0));
     }
@@ -337,7 +328,6 @@ public class Dedistort extends AbstractFunctionImpl {
                                            DistorsionMap distorsionMap,
                                            int height,
                                            int width) {
-        distorsionMap.computeInterpolators();
         var metadata = MutableMap.<Class<?>, Object>of();
         metadata.putAll(image.metadata());
         var currentY = new AtomicInteger();

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/StackingWorkflow.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/StackingWorkflow.java
@@ -31,6 +31,7 @@ import me.champeau.a4j.jsolex.processing.expr.impl.MosaicComposition;
 import me.champeau.a4j.jsolex.processing.expr.impl.Scaling;
 import me.champeau.a4j.jsolex.processing.expr.impl.SimpleFunctionCall;
 import me.champeau.a4j.jsolex.processing.expr.impl.Stacking;
+import me.champeau.a4j.jsolex.processing.expr.impl.Utilities;
 import me.champeau.a4j.jsolex.processing.file.FileNamingStrategy;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.util.Constants;
@@ -70,7 +71,7 @@ public class StackingWorkflow {
         this.ellipseFit = new EllipseFit(context, broadcaster);
         this.geometryCorrector = new GeometryCorrection(context, broadcaster, ellipseFit);
         this.scaling = new Scaling(context, broadcaster, crop);
-        this.stacking = new Stacking(context, scaling, crop, new SimpleFunctionCall(context, broadcaster), new ImageDraw(context, broadcaster), broadcaster);
+        this.stacking = new Stacking(context, scaling, crop, new SimpleFunctionCall(context, broadcaster), new ImageDraw(context, broadcaster), new Utilities(context, broadcaster), broadcaster);
         this.mosaicComposition = new MosaicComposition(context, broadcaster, stacking, ellipseFit, scaling);
     }
 

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -11,6 +11,7 @@
 
 - Improved banding correction
 - Improved stacking/dedistortion algorithm
+- Added `STACK_DEDIS` function to stack using distortion as weight
 
 ## What's New in Version 4.1.2
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -11,6 +11,7 @@
 
 - Amélioration de la correction des bandes
 - Amélioration de l'algorithme d'alignement/empilement
+- Ajout de la fonction `STACK_DEDIS` pour empiler en prenant en compte la distorsion comme poids
 
 ## Nouveautés de la version 4.1.2
 


### PR DESCRIPTION
This function lets the user stack images which are the result of a DEDISTORT call. The distorsion map is used as an evaluation of the quality of each image and instead of doing an average of all images, we perform a weighted average.

The function supports providing a ratio of images to keep. In addition, it is possible to use local distorsion, in which case the algorithm will analyze the quality of each image around each point. It means that in practice different regions of the disk may use different images for stacking.