### PR TITLE
Fix colorize function

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Colorize.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Colorize.java
@@ -27,6 +27,7 @@ import me.champeau.a4j.jsolex.processing.util.Constants;
 import me.champeau.a4j.jsolex.processing.util.FileBackedImage;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
+import me.champeau.a4j.jsolex.processing.util.Wavelen;
 
 import java.util.List;
 import java.util.Map;
@@ -51,6 +52,18 @@ public class Colorize extends AbstractFunctionImpl {
         var arg = arguments.get("img");
         if (arg instanceof List<?>) {
             return expandToImageList("colorize", "img", arguments, function);
+        }
+        var profileAsNumber = getArgument(Object.class, arguments, "profile");
+        if (profileAsNumber.orElse(null) instanceof Number referenceWl) {
+            if (arg instanceof FileBackedImage fileBackedImage) {
+                arg = fileBackedImage.unwrapToMemory();
+            }
+            if (arg instanceof ImageWrapper32 mono) {
+                return RGBImage.fromMono(mono, data -> {
+                    var ray = new SpectralRay("tmp", null, Wavelen.ofAngstroms(referenceWl.doubleValue()), true, List.of());
+                    return doColorize(mono.width(), mono.height(), data.data(), ray.toRGB());
+                });
+            }
         }
         var profile = stringArg(arguments, "profile", null);
         if (profile == null) {

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -10,6 +10,9 @@
 ## What's New in Version 4.1.4
 
 - Clarify display of conversion from pixels to Angstroms in the process parameters dialog
+- Fix `COLORIZE` not accepting a wavelength parameter as advertised
+- Fix edge case where colorization could fail
+- Fix pixel shift display in observation details
 
 ## What's New in Version 4.1.3
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -10,6 +10,9 @@
 ## Nouveautés de la version 4.1.4
 
 - Clarification de l'affichage de la conversion des pixels en Angströms dans la boîte de dialogue des paramètres de traitement
+- Correction de `COLORIZE` qui n'acceptait pas un paramètre de longueur d'onde comme annoncé
+- Correction d'un cas limite où la colorisation pouvait échouer
+- Correction de l'affichage du décalage de pixels dans les détails d'observation
 
 ## Nouveautés de la version 4.1.3
 


### PR DESCRIPTION
The colorize function didn't accept a number (in Angstroms) as the `profile` parameter as advertised.