### PR TITLE
Let the user set script parameters

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/DefaultImageScriptExecutor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/DefaultImageScriptExecutor.java
@@ -451,7 +451,6 @@ public class DefaultImageScriptExecutor implements ImageMathScriptExecutor {
                 }
             }
         } catch (Exception e) {
-            // Log error but don't fail script execution
             LOGGER.warn("Failed to extract script parameters: " + e.getMessage());
         }
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImage.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImage.java
@@ -442,6 +442,7 @@ public final class FileBackedImage implements ImageWrapper {
             super(referent, queue);
             this.image = image;
             this.source = switch (referent) {
+                case null -> null;
                 case ImageWrapper32 mono ->
                         new ImageWrapper32(mono.width(), mono.height(), mono.data(), mono.metadata());
                 case RGBImage rgb -> new RGBImage(rgb.width(), rgb.height(), rgb.r(), rgb.g(), rgb.b(), rgb.metadata());

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/MetadataEditor.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/MetadataEditor.java
@@ -830,6 +830,10 @@ public class MetadataEditor {
                 var start = metaBlock.getBeginOffset();
                 var end = metaBlock.getEndOffset();
 
+                if (end < script.length() && script.charAt(end) == '\n') {
+                    end++;
+                }
+
                 return script.substring(0, start) + newMetaBlock + script.substring(end);
             } else {
                 return newMetaBlock + "\n" + script;

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ScriptParameterUIBuilder.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ScriptParameterUIBuilder.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.app.jfx;
+
+import javafx.scene.Node;
+import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.GridPane;
+import me.champeau.a4j.jsolex.processing.params.ChoiceParameter;
+import me.champeau.a4j.jsolex.processing.params.NumberParameter;
+import me.champeau.a4j.jsolex.processing.params.ScriptParameter;
+import me.champeau.a4j.jsolex.processing.params.StringParameter;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.ParseException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public class ScriptParameterUIBuilder {
+
+    public static void buildParameterGrid(
+            GridPane grid,
+            List<ScriptParameter> parameters,
+            String currentLanguage,
+            Map<String, Object> initialValues,
+            BiConsumer<String, Boolean> validationCallback,
+            BiConsumer<String, Object> valueChangeCallback) {
+
+        int row = 0;
+        for (var param : parameters) {
+            var displayName = param.getDisplayName(currentLanguage);
+            var label = new Label(displayName + ":");
+            label.getStyleClass().addAll("field-label", "field-label-wrapped");
+            grid.add(label, 0, row);
+
+            var initialValue = initialValues != null ? initialValues.get(param.getName()) : null;
+            var control = createParameterControl(param, initialValue, validationCallback, valueChangeCallback);
+            javafx.scene.layout.GridPane.setHgrow(control, javafx.scene.layout.Priority.ALWAYS);
+            grid.add(control, 1, row);
+
+            var description = param.getDescription(currentLanguage);
+            if (description != null && !description.isEmpty()) {
+                var helpIcon = new Label("?");
+                helpIcon.getStyleClass().addAll("help-icon");
+
+                var customTooltip = new CustomTooltip(description);
+                customTooltip.attachTo(helpIcon);
+
+                grid.add(helpIcon, 2, row);
+            }
+
+            row++;
+        }
+    }
+
+    private static Node createParameterControl(
+            ScriptParameter param,
+            Object initialValue,
+            BiConsumer<String, Boolean> validationCallback,
+            BiConsumer<String, Object> valueChangeCallback) {
+
+        var paramKey = param.getName();
+
+        switch (param) {
+            case ChoiceParameter choiceParam -> {
+                var choiceBox = new ChoiceBox<String>();
+                choiceBox.getItems().addAll(choiceParam.getChoices());
+                if (initialValue != null) {
+                    choiceBox.setValue(initialValue.toString());
+                }
+
+                var initialValidationResult = choiceParam.validate(initialValue != null ? initialValue : choiceParam.getDefaultValue());
+                validationCallback.accept(paramKey, initialValidationResult.isValid());
+
+                if (!initialValidationResult.isValid()) {
+                    choiceBox.setStyle("-fx-border-color: red; -fx-border-width: 2px;");
+                    choiceBox.setTooltip(new Tooltip(initialValidationResult.getErrorMessage()));
+                }
+
+                choiceBox.valueProperty().addListener((obs, oldVal, newVal) -> {
+                    if (newVal != null) {
+                        var validationResult = choiceParam.validate(newVal);
+                        validationCallback.accept(paramKey, validationResult.isValid());
+
+                        if (!validationResult.isValid()) {
+                            choiceBox.setStyle("-fx-border-color: red; -fx-border-width: 2px;");
+                            choiceBox.setTooltip(new Tooltip(validationResult.getErrorMessage()));
+                        } else {
+                            choiceBox.setStyle("");
+                            choiceBox.setTooltip(null);
+                        }
+
+                        valueChangeCallback.accept(param.getName(), newVal);
+                    }
+                });
+                if (initialValue != null) {
+                    valueChangeCallback.accept(param.getName(), initialValue);
+                }
+                return choiceBox;
+            }
+            case NumberParameter numberParam -> {
+                var textField = new TextField();
+                var min = numberParam.getMin() != null ? numberParam.getMin().doubleValue() : Double.NEGATIVE_INFINITY;
+                var max = numberParam.getMax() != null ? numberParam.getMax().doubleValue() : Double.POSITIVE_INFINITY;
+                var value = initialValue instanceof Number num ? num.doubleValue() :
+                           (numberParam.getDefaultValue() instanceof Number defNum ? defNum.doubleValue() : 0.0);
+
+                var formatter = new DecimalFormat("#.###", DecimalFormatSymbols.getInstance(Locale.US));
+                textField.setText(formatter.format(value));
+
+                var initialValidationResult = numberParam.validate(value);
+                validationCallback.accept(paramKey, initialValidationResult.isValid());
+
+                if (!initialValidationResult.isValid()) {
+                    textField.setStyle("-fx-border-color: red; -fx-border-width: 2px;");
+                    textField.setTooltip(new Tooltip(initialValidationResult.getErrorMessage()));
+                }
+
+                textField.textProperty().addListener((obs, oldVal, newVal) -> {
+                    boolean isValid = false;
+                    String errorMessage = null;
+                    try {
+                        var number = formatter.parse(newVal);
+                        var doubleValue = number.doubleValue();
+                        var validationResult = numberParam.validate(doubleValue);
+
+                        if (validationResult.isValid()) {
+                            textField.setStyle("");
+                            textField.setTooltip(null);
+                            valueChangeCallback.accept(param.getName(), doubleValue);
+                            isValid = true;
+                        } else {
+                            errorMessage = validationResult.getErrorMessage();
+                        }
+                    } catch (ParseException e) {
+                        errorMessage = "Invalid number format";
+                    }
+
+                    if (errorMessage != null) {
+                        textField.setStyle("-fx-border-color: red; -fx-border-width: 2px;");
+                        textField.setTooltip(new Tooltip(errorMessage));
+                    }
+
+                    validationCallback.accept(paramKey, isValid);
+                });
+
+                valueChangeCallback.accept(param.getName(), value);
+                return textField;
+            }
+            case StringParameter stringParam -> {
+                var textField = new TextField();
+                var textValue = initialValue != null ? initialValue.toString() :
+                               (stringParam.getDefaultValue() != null ? stringParam.getDefaultValue().toString() : "");
+                textField.setText(textValue);
+
+                var initialValidationResult = stringParam.validate(textValue);
+                validationCallback.accept(paramKey, initialValidationResult.isValid());
+
+                if (!initialValidationResult.isValid()) {
+                    textField.setStyle("-fx-border-color: red; -fx-border-width: 2px;");
+                    textField.setTooltip(new Tooltip(initialValidationResult.getErrorMessage()));
+                }
+
+                textField.textProperty().addListener((obs, oldVal, newVal) -> {
+                    var validationResult = stringParam.validate(newVal);
+                    boolean isValid = validationResult.isValid();
+
+                    if (isValid) {
+                        textField.setStyle("");
+                        textField.setTooltip(null);
+                    } else {
+                        textField.setStyle("-fx-border-color: red; -fx-border-width: 2px;");
+                        textField.setTooltip(new Tooltip(validationResult.getErrorMessage()));
+                    }
+
+                    validationCallback.accept(paramKey, isValid);
+                    valueChangeCallback.accept(param.getName(), newVal);
+                });
+                valueChangeCallback.accept(param.getName(), textValue);
+                return textField;
+            }
+            default -> {
+                return null;
+            }
+        }
+    }
+}

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ScriptParametersDialog.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ScriptParametersDialog.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.app.jfx;
+
+import javafx.geometry.Insets;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.GridPane;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import me.champeau.a4j.jsolex.processing.params.ScriptParameter;
+import me.champeau.a4j.jsolex.processing.util.LocaleUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static me.champeau.a4j.jsolex.app.JSolEx.newScene;
+
+public class ScriptParametersDialog {
+    private final List<ScriptParameter> parameters;
+    private final Map<String, Object> initialValues;
+    private final Map<String, Object> resultValues;
+    private final Map<String, Boolean> validationStates = new HashMap<>();
+    private final CompletableFuture<Map<String, Object>> resultFuture = new CompletableFuture<>();
+    private Button okButton;
+
+    public ScriptParametersDialog(List<ScriptParameter> parameters, Map<String, Object> initialValues) {
+        this.parameters = parameters;
+        this.initialValues = initialValues != null ? initialValues : Map.of();
+        this.resultValues = new HashMap<>(this.initialValues);
+    }
+
+    public Map<String, Object> showAndWait(Stage owner) {
+        var stage = new Stage();
+        stage.initOwner(owner);
+        stage.initModality(Modality.APPLICATION_MODAL);
+        stage.setTitle(I18N.string(ScriptParametersDialog.class, "script-parameters", "script.parameters.title"));
+
+        var root = new BorderPane();
+        root.setStyle("-fx-background-color: #f8f9fa;");
+
+        var headerLabel = new Label(I18N.string(ScriptParametersDialog.class, "script-parameters", "script.parameters.header"));
+        headerLabel.setStyle("-fx-font-weight: bold; -fx-font-size: 14px; -fx-background-color: white; -fx-text-fill: #212529;");
+        headerLabel.setPadding(new Insets(15, 20, 15, 20));
+        headerLabel.setMaxWidth(Double.MAX_VALUE);
+        root.setTop(headerLabel);
+
+        var grid = new GridPane();
+        grid.setHgap(15);
+        grid.setVgap(12);
+        grid.setPadding(new Insets(15));
+        grid.setStyle("-fx-background-color: white;");
+
+        var currentLanguage = LocaleUtils.getConfiguredLocale().toString();
+
+        ScriptParameterUIBuilder.buildParameterGrid(
+            grid,
+            parameters,
+            currentLanguage,
+            initialValues,
+            (paramName, isValid) -> {
+                validationStates.put(paramName, isValid);
+                updateOkButtonState();
+            },
+            resultValues::put
+        );
+
+        var scrollPane = new ScrollPane(grid);
+        scrollPane.setFitToWidth(true);
+        scrollPane.setFitToHeight(true);
+        scrollPane.setStyle("-fx-background-color: transparent; -fx-background: transparent;");
+        BorderPane.setMargin(scrollPane, new Insets(10, 10, 10, 10));
+        root.setCenter(scrollPane);
+
+        var buttonBar = new ButtonBar();
+        buttonBar.setPadding(new Insets(15, 20, 15, 20));
+        buttonBar.setStyle("-fx-background-color: white; -fx-border-color: #dee2e6; -fx-border-width: 1 0 0 0;");
+
+        var cancelButton = new Button(I18N.string(ScriptParametersDialog.class, "script-parameters", "cancel"));
+        cancelButton.getStyleClass().add("default-button");
+        cancelButton.setOnAction(e -> {
+            resultFuture.complete(null);
+            stage.close();
+        });
+        ButtonBar.setButtonData(cancelButton, ButtonBar.ButtonData.CANCEL_CLOSE);
+
+        okButton = new Button(I18N.string(ScriptParametersDialog.class, "script-parameters", "ok"));
+        okButton.getStyleClass().add("primary-button");
+        okButton.setOnAction(e -> {
+            resultFuture.complete(resultValues);
+            stage.close();
+        });
+        ButtonBar.setButtonData(okButton, ButtonBar.ButtonData.OK_DONE);
+        okButton.setDefaultButton(true);
+
+        updateOkButtonState();
+
+        buttonBar.getButtons().addAll(cancelButton, okButton);
+        root.setBottom(buttonBar);
+
+        var scene = newScene(root);
+        stage.setScene(scene);
+        stage.setMinWidth(550);
+        stage.setMinHeight(350);
+        stage.setWidth(600);
+        stage.setHeight(400);
+
+        stage.showAndWait();
+
+        try {
+            return resultFuture.getNow(null);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private void updateOkButtonState() {
+        if (okButton != null) {
+            boolean allValid = validationStates.values().stream().allMatch(Boolean::booleanValue);
+            okButton.setDisable(!allValid);
+        }
+    }
+}

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/app.fxml
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/app.fxml
@@ -1,32 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.ButtonBar?>
-<?import javafx.scene.control.CheckBox?>
-<?import javafx.scene.control.ChoiceBox?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.Menu?>
-<?import javafx.scene.control.MenuBar?>
-<?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.control.ProgressBar?>
-<?import javafx.scene.control.SeparatorMenuItem?>
-<?import javafx.scene.control.SplitPane?>
-<?import javafx.scene.control.Tab?>
-<?import javafx.scene.control.TabPane?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.control.Tooltip?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.BorderPane?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.StackPane?>
-<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 <?import me.champeau.a4j.jsolex.app.jfx.ime.ImageMathTextArea?>
 <?import org.fxmisc.flowless.VirtualizedScrollPane?>
 <?import org.fxmisc.richtext.StyleClassedTextArea?>
-<?import javafx.scene.control.ScrollPane?>
 <BorderPane xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
     <top>
         <MenuBar>
@@ -204,11 +183,11 @@
                                         <bottom>
                                             <HBox alignment="CENTER_LEFT">
                                                 <CheckBox fx:id="clearImagesCheckbox" text="%clear.images"/>
-                                                <ButtonBar prefHeight="40.0" prefWidth="200.0">
+                                                <ButtonBar prefHeight="40.0">
                                                     <buttons>
                                                         <Button fx:id="imageMathLoad" mnemonicParsing="false" text="%imagemath.load" styleClass="default-button"/>
                                                         <Button fx:id="imageMathSave" mnemonicParsing="false" text="%imagemath.save" styleClass="default-button"/>
-                                                        <Button fx:id="imageMathRun" mnemonicParsing="false" text="%imagemath.run" styleClass="primary-button"/>
+                                                        <SplitMenuButton fx:id="imageMathRun" mnemonicParsing="false" text="%imagemath.run" styleClass="primary-button"/>
                                                     </buttons>
                                                 </ButtonBar>
                                             </HBox>

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/app.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/app.properties
@@ -16,6 +16,7 @@ imagemath.script=ImageMath script
 imagemath.run=Run
 imagemath.load=Load
 imagemath.save=Save
+imagemath.params=Run with parameters...
 save.log=Save log
 clear.log=Clear log
 reset.ui=Close all

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/app_fr.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/app_fr.properties
@@ -16,6 +16,7 @@ imagemath.script=Script ImageMath
 imagemath.run=Exécuter
 imagemath.load=Charger
 imagemath.save=Sauvegarder
+imagemath.params=Exécuter avec paramètres...
 save.log=Enregistrer log
 clear.log=Effacer log
 reset.ui=Tout fermer

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/components.css
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/components.css
@@ -47,6 +47,69 @@
     -fx-background-color: #0056b3;
 }
 
+/* SplitMenuButton Primary Style */
+.split-menu-button.primary-button {
+    -fx-background-color: transparent;
+    -fx-background-radius: 6;
+    -fx-effect: dropshadow(gaussian, rgba(0,123,255,0.3), 4, 0, 0, 1);
+    -fx-padding: 0;
+}
+
+.split-menu-button.primary-button .label {
+    -fx-background-color: #007bff;
+    -fx-text-fill: white;
+    -fx-font-weight: 600;
+    -fx-padding: 4 12;
+    -fx-background-radius: 6 0 0 6;
+    -fx-background-insets: 0;
+    -fx-border-color: transparent rgba(255,255,255,0.3) transparent transparent;
+    -fx-border-width: 0 1 0 0;
+    -fx-min-width: -1;
+}
+
+.split-menu-button.primary-button:hover .label {
+    -fx-background-color: #0056b3;
+}
+
+.split-menu-button.primary-button .arrow-button {
+    -fx-background-color: #007bff;
+    -fx-background-radius: 0 6 6 0;
+    -fx-padding: 4 8;
+    -fx-background-insets: 0;
+    -fx-alignment: CENTER;
+}
+
+.split-menu-button.primary-button:hover .arrow-button {
+    -fx-background-color: #0056b3;
+}
+
+.split-menu-button.primary-button .arrow-button .arrow {
+    -fx-background-color: white;
+    -fx-padding: 3;
+    -fx-shape: "M 0 0 L 4 4 L 8 0 Z";
+}
+
+.split-menu-button.primary-button .context-menu {
+    -fx-background-color: white;
+    -fx-border-color: #dee2e6;
+    -fx-border-width: 1;
+    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.15), 8, 0, 0, 2);
+}
+
+.split-menu-button.primary-button .context-menu .menu-item {
+    -fx-background-color: transparent;
+    -fx-text-fill: #212529;
+    -fx-padding: 8 16;
+}
+
+.split-menu-button.primary-button .context-menu .menu-item:hover {
+    -fx-background-color: #f8f9fa;
+}
+
+.split-menu-button.primary-button .context-menu .menu-item:focused {
+    -fx-background-color: #e9ecef;
+}
+
 .default-button {
     -fx-background-color: #ffffff;
     -fx-text-fill: #495057;

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/jfx/script-parameters.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/jfx/script-parameters.properties
@@ -1,0 +1,4 @@
+script.parameters.title=Script Parameters
+script.parameters.header=Configure parameters for the ImageMath script
+ok=OK
+cancel=Cancel

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/jfx/script-parameters_fr.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/jfx/script-parameters_fr.properties
@@ -1,0 +1,4 @@
+script.parameters.title=Paramètres du script
+script.parameters.header=Configurer les paramètres du script ImageMath
+ok=OK
+cancel=Annuler

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -15,6 +15,7 @@
 - Fixed globe not positionned correctly in measure tool when autocrop was not used
 - Fixed SER frames extraction tool only exporting MP4 files even when both MP4 and GIF were selected in advanced parameters
 - Improve memory management so that processing works on lower memory systems
+- Add a way to set script parameters in the script dialog on the main window
 
 ## What's New in Version 4.2.0
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -15,6 +15,7 @@
 - Correction du globe mal positionné dans l'outil de mesure lorsque le recadrage automatique n'était pas utilisé
 - Correction de l'outil d'extraction de frames SER qui n'exportait que des fichiers MP4 même lorsque MP4 et GIF étaient sélectionnés dans les paramètres avancés
 - Amélioration de la gestion de la mémoire pour que le traitement fonctionne sur des systèmes avec moins de mémoire
+- Ajout d'un moyen de définir les paramètres de script dans la boîte de dialogue de script sur la fenêtre principale
 
 ## Nouveautés de la version 4.2.0
 


### PR DESCRIPTION
Before this change, the script pane which shows up at the end of processing wouldn't let the user set values for parameters found in the `meta` section. This is now possible by using a split button.