### PR TITLE
Fix animation creation when P angle correction applied

### DIFF
--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/Corrector.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/Corrector.java
@@ -22,7 +22,6 @@ import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.MetadataSupport;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
-import me.champeau.a4j.math.Point2D;
 import me.champeau.a4j.math.image.Image;
 import me.champeau.a4j.math.image.ImageMath;
 
@@ -34,7 +33,7 @@ public class Corrector {
     }
 
     public static ImageWrapper rotate(ImageWrapper image, double angle, boolean resize) {
-        var result = (ImageWrapper) MetadataSupport.applyMetadata(String.format(message("rotate.radians.format"), angle), () -> {
+        return (ImageWrapper) MetadataSupport.applyMetadata(String.format(message("rotate.radians.format"), angle), () -> {
             var img = image;
             var imageMath = ImageMath.newInstance();
             if (img instanceof FileBackedImage fileBackedImage) {
@@ -53,11 +52,6 @@ public class Corrector {
             }
             throw new IllegalArgumentException("Unsupported image type");
         });
-        result.transformMetadata(ReferenceCoords.class, coords -> {
-            var rotationCenter = new Point2D(image.width() / 2.0, image.height() / 2.0);
-            return coords.addRotation(angle, rotationCenter);
-        });
-        return result;
     }
 
     public static ImageWrapper verticalFlip(ImageWrapper image) {

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
@@ -86,6 +86,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static me.champeau.a4j.jsolex.app.JSolEx.message;
@@ -122,6 +123,7 @@ public class ImageViewer implements WithRootNode {
     private String title;
     private String description;
     private Runnable onDisplayUpdate;
+    private Consumer<ImageWrapper> onStretchedImageUpdate;
     private int rotation;
     private boolean vflip;
     private boolean firstShow = true;
@@ -634,6 +636,9 @@ public class ImageViewer implements WithRootNode {
                 stretchedImage = stretch(rgb);
             }
         }
+        if (onStretchedImageUpdate != null) {
+            onStretchedImageUpdate.accept(stretchedImage);
+        }
         Platform.runLater(() -> stretchedImageDebounce.playFromStart());
         var writable = WritableImageSupport.asWritable(stretchedImage);
         Platform.runLater(() -> updateDisplay(writable, resetZoom));
@@ -661,6 +666,10 @@ public class ImageViewer implements WithRootNode {
     public ImageWrapper getStretchedImage() {
         var result = stretchedImage == null ? image : stretchedImage;
         return result == null ? null : result.unwrapToMemory();
+    }
+
+    public void setOnStretchedImageUpdate(Consumer<ImageWrapper> onStretchedImageUpdate) {
+        this.onStretchedImageUpdate = onStretchedImageUpdate;
     }
 
     @Override

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SingleModeProcessingEventListener.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SingleModeProcessingEventListener.java
@@ -532,7 +532,6 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
         var imageWrapper = payload.image();
         var pixelShift = imageWrapper.findMetadata(PixelShift.class);
         Platform.runLater(() -> {
-            var metadata = imageWrapper.metadata();
             var addedImageViewer = owner.getImagesViewer().addImage(this,
                     rootOperation,
                     title,
@@ -545,13 +544,15 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
                     popupViews,
                     pixelShift.orElse(null),
                     viewer -> viewer,
-                    viewer -> {
+                    viewer -> viewer.setOnStretchedImageUpdate(stretchedImage -> {
                         BackgroundOperations.async(() -> {
-                            var histogram = showHistogram(viewer.getStretchedImage());
-                            Platform.runLater(() -> statsTab.setContent(histogram));
+                            var histogram = showHistogram(stretchedImage);
+                            Platform.runLater(() -> {
+                                statsTab.setContent(histogram);
+                                showMetadata(stretchedImage.metadata());
+                            });
                         });
-                        showMetadata(metadata);
-                    });
+                    }));
             var pixelShiftRange = imageWrapper.findMetadata(PixelShiftRange.class).orElse(new PixelShiftRange(-15, 15, .25));
             int imageWidth = imageWrapper.width();
             int imageHeight = imageWrapper.height();

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -16,6 +16,7 @@
 - Fixed SER frames extraction tool only exporting MP4 files even when both MP4 and GIF were selected in advanced parameters
 - Improve memory management so that processing works on lower memory systems
 - Add a way to set script parameters in the script dialog on the main window
+- Fixed custom animation creation when P angle correction was applied
 
 ## What's New in Version 4.2.0
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -16,6 +16,7 @@
 - Correction de l'outil d'extraction de frames SER qui n'exportait que des fichiers MP4 même lorsque MP4 et GIF étaient sélectionnés dans les paramètres avancés
 - Amélioration de la gestion de la mémoire pour que le traitement fonctionne sur des systèmes avec moins de mémoire
 - Ajout d'un moyen de définir les paramètres de script dans la boîte de dialogue de script sur la fenêtre principale
+- Correction de la création d'animations personnalisées lorsque la correction de l'angle P était appliquée
 
 ## Nouveautés de la version 4.2.0
 


### PR DESCRIPTION
This commit fixes a couple issues:

- most important, the rotation correction was recorded twice, which led to incorrect positionning of the frame when P angle correction was applied
- the metadata displayed in the metadata tab was showing the original metadata, not the transformed image metadata