### PR TITLE
Add a new dedistorsion reference

### DIFF
--- a/jsolex-core/src/main/functions/stack_ref.yml
+++ b/jsolex-core/src/main/functions/stack_ref.yml
@@ -12,8 +12,8 @@ arguments:
     optional: true
     default: sharpness
     description:
-      fr: "Méthode de sélection de la meilleure image. Peut-être `sharpness` (image la plus nette), `average` (moyenne de toutes les images), `median` (médiane de toutes les images) ou `eccentricity` (image du soleil le plus rond). En mode batch, un mode `manual` est aussi disponible."
-      en: "Method for selecting the best image. Can be `sharpness` (sharpest image), `average` (average of all images), `median` (median of all images) or `eccentricity` (roundest sun image). In batch mode, a `manual` mode is also available."
+      fr: "Méthode de sélection de la meilleure image. Peut-être `sharpness` (image la plus nette), `average` (moyenne de toutes les images), `median` (médiane de toutes les images), `eccentricity` (image du soleil le plus rond) ou `consensus` (référence par consensus utilisant la moyenne des champs de déplacement). En mode batch, un mode `manual` est aussi disponible."
+      en: "Method for selecting the best image. Can be `sharpness` (sharpest image), `average` (average of all images), `median` (median of all images), `eccentricity` (roundest sun image) or `consensus` (consensus reference using averaged displacement fields). In batch mode, a `manual` mode is also available."
 examples:
   - "stack_ref(some_images)"
   - "stack_ref(some_images, \"eccentricity\")"

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Stacking.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Stacking.java
@@ -21,6 +21,7 @@ import me.champeau.a4j.jsolex.processing.expr.BestImages;
 import me.champeau.a4j.jsolex.processing.expr.stacking.DistorsionDebugImageCreator;
 import me.champeau.a4j.jsolex.processing.expr.stacking.DistorsionMap;
 import me.champeau.a4j.jsolex.processing.expr.stacking.DistorsionMaps;
+import me.champeau.a4j.jsolex.processing.expr.stacking.ConsensusReference;
 import me.champeau.a4j.jsolex.processing.params.ProcessParams;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.workflow.GeneratedImageKind;
@@ -593,6 +594,12 @@ public class Stacking extends AbstractFunctionImpl {
                         .map(ImageWrapper32.class::cast)
                         .orElseThrow();
             }
+            case CONSENSUS -> {
+                var keyframe = computeReferenceImageAndAdjustWeights(images, null, ReferenceSelection.SHARPNESS, weights);
+                var copy = keyframe.copy();
+                copy.metadata().put(ConsensusReference.class, ConsensusReference.INSTANCE);
+                yield copy;
+            }
         };
     }
 
@@ -721,7 +728,8 @@ public class Stacking extends AbstractFunctionImpl {
         MEDIAN,
         ECCENTRICITY,
         SHARPNESS,
-        MANUAL
+        MANUAL,
+        CONSENSUS
     }
 
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/ConsensusReference.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/ConsensusReference.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.expr.stacking;
+
+/**
+ * Marker class for consensus reference mode in dedistortion.
+ * When present in image metadata, indicates that the dedistortion algorithm
+ * should use multi-frame displacement averaging to estimate the true undistorted geometry.
+ */
+public record ConsensusReference() {
+    public static final ConsensusReference INSTANCE = new ConsensusReference();
+}

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
@@ -255,3 +255,7 @@ user.preset.visibility.update.failed=Failed to update user presets visibility
 repository.scripts.load.failed=Failed to load repository scripts
 user.preset.load.specific.failed=Failed to load user preset: {}
 user.preset.delete.failed=Failed to delete user preset: {}
+consensus.reference.few.images=Consensus reference mode works best with at least 5 images, but only {} provided
+consensus.reference.distortion.increased=Consensus reference iteration {} didn't improve distortion ({} > {}), stopping.
+consensus.reference.comparing=Comparing images
+consensus.reference.computing=Computing pairwise distortion maps

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr.properties
@@ -255,3 +255,7 @@ user.preset.visibility.update.failed=Échec de la mise à jour de la visibilité de
 repository.scripts.load.failed=Échec du chargement des scripts du dépôt
 user.preset.load.specific.failed=Échec du chargement du préréglage utilisateur : {}
 user.preset.delete.failed=Échec de la suppression du préréglage utilisateur : {}
+consensus.reference.few.images=Le mode de référence par consensus fonctionne mieux avec au moins 5 images, mais seulement {} fournies
+consensus.reference.distortion.increased=L'itération {} n'a pas amélioré la distorsion ({} > {}), arrêt.
+consensus.reference.comparing=Comparaison des images
+consensus.reference.computing=Calcul des cartes de distorsion par paires

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -18,6 +18,7 @@
 - Added `SIGMOID_STRETCH` function: applies a sigmoid (S-curve) transformation for smooth contrast enhancement
 - [Experimental GPU Acceleration](#experimental-gpu-acceleration): significantly faster image processing on compatible graphics cards
 - Improved zoom behavior: zooming now centers on the mouse cursor position instead of the top-left corner, keeping the feature of interest centered in the view
+- Added `consensus` reference selection mode in `STACK_REF`: uses averaged displacement fields to estimate true undistorted geometry, improving dedistortion accuracy when no single frame is optimal
 
 ### Experimental GPU Acceleration
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -17,6 +17,7 @@
 - Ajout de la fonction `PERCENTILE_STRETCH` : étire l'histogramme en mappant les percentiles spécifiés aux points noir et blanc
 - Ajout de la fonction `SIGMOID_STRETCH` : applique une transformation sigmoïde (courbe en S) pour une amélioration douce du contraste
 - [Accélération GPU expérimentale](#acceleration-gpu-experimentale) : traitement d'image significativement plus rapide sur les cartes graphiques compatibles
+- Ajout du mode de sélection de référence `consensus` dans `STACK_REF` : utilise la moyenne des champs de déplacement pour estimer la géométrie non distordue réelle, améliorant la précision de la dédistorsion lorsqu'aucune image n'est optimale
 - Amélioration du zoom : le zoom est maintenant centré sur la position du curseur de la souris au lieu du coin supérieur gauche, gardant la zone d'intérêt centrée dans la vue
 
 ### Accélération GPU expérimentale


### PR DESCRIPTION
This method, called `consensus`, computes distorsion between each image (pairwise), averages them to find the "truth" image, then dedistorts against that truth.