### PR TITLE
Optimize dedistorsion

### DIFF
--- a/jsolex-core/src/main/functions/dedistort.yml
+++ b/jsolex-core/src/main/functions/dedistort.yml
@@ -58,6 +58,12 @@ arguments:
     description:
       fr: "Active le mode multi-échelle (1=activé, 0=désactivé). Lorsqu'activé, des tuiles de différentes tailles sont utilisées : grandes tuiles dans les zones à faible gradient, petites tuiles dans les zones à fort gradient. Nécessite sparse > 0."
       en: "Enables multi-scale mode (1=enabled, 0=disabled). When enabled, tiles of different sizes are used: large tiles in low-gradient areas, small tiles in high-gradient areas. Requires sparse > 0."
+  - name: adaptive
+    optional: true
+    default: 1
+    description:
+      fr: "Active la convergence adaptative par tuile en mode consensus (1=activé, 0=désactivé). Lorsqu'activé, les tuiles déjà convergées sont gelées et ignorées dans les itérations suivantes, ce qui accélère significativement les exécutions multi-itérations sans perte de qualité."
+      en: "Enables per-tile adaptive convergence in consensus mode (1=enabled, 0=disabled). When enabled, tiles that have already converged are frozen and skipped in subsequent iterations, significantly speeding up multi-iteration runs without quality loss."
 examples:
   - "crop_rect(img(0), 1024, 1024)"
   - "crop_rect(img: img(0), width: 200, height: 200)"

--- a/jsolex-core/src/main/functions/scale_from_unit.yml
+++ b/jsolex-core/src/main/functions/scale_from_unit.yml
@@ -1,0 +1,20 @@
+name: SCALE_FROM_UNIT
+category: MATHS
+description:
+  fr: "Rééchelonne les valeurs des pixels d'une image en multipliant chaque pixel par 65535, de sorte qu'une image dont les valeurs sont dans la plage [0;1] aura ses valeurs ramenées à [0;65535]. Inverse de scale_to_unit."
+  en: "Rescales the pixel values of an image by multiplying each pixel by 65535, so that an image whose values are in the [0;1] range gets its values mapped to [0;65535]. Inverse of scale_to_unit."
+arguments:
+  - name: img
+    description:
+      fr: "Image(s) ou valeur"
+      en: "Image(s) or value"
+  - name: clamp
+    optional: true
+    default: 1
+    description:
+      fr: "Si 1 (par défaut), les valeurs sont écrêtées dans la plage [0;65535]. Si 0, les valeurs hors plage sont conservées telles quelles."
+      en: "If 1 (default), values are clamped to the [0;65535] range. If 0, out-of-range values are kept as-is."
+examples:
+  - "scale_from_unit(img(0))"
+  - "scale_from_unit(img(0); 0)"
+  - "scale_from_unit(img: img(0); clamp: 0)"

--- a/jsolex-core/src/main/functions/scale_to_unit.yml
+++ b/jsolex-core/src/main/functions/scale_to_unit.yml
@@ -1,0 +1,20 @@
+name: SCALE_TO_UNIT
+category: MATHS
+description:
+  fr: "Rééchelonne les valeurs des pixels d'une image en divisant chaque pixel par 65535, de sorte qu'une image dont les valeurs sont dans la plage [0;65535] aura ses valeurs ramenées à [0;1]. Utile pour les calculs en virgule flottante ou l'interopérabilité avec d'autres outils."
+  en: "Rescales the pixel values of an image by dividing each pixel by 65535, so that an image whose values are in the [0;65535] range gets its values mapped to [0;1]. Useful for floating-point computations or interoperability with other tools."
+arguments:
+  - name: img
+    description:
+      fr: "Image(s) ou valeur"
+      en: "Image(s) or value"
+  - name: clamp
+    optional: true
+    default: 1
+    description:
+      fr: "Si 1 (par défaut), les valeurs sont écrêtées dans la plage [0;1]. Si 0, les valeurs hors plage sont conservées telles quelles."
+      en: "If 1 (default), values are clamped to the [0;1] range. If 0, out-of-range values are kept as-is."
+examples:
+  - "scale_to_unit(img(0))"
+  - "scale_to_unit(img(0); 0)"
+  - "scale_to_unit(img: img(0); clamp: 0)"

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
@@ -420,6 +420,8 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
             case REMOTE_SCRIPTGEN -> remoteScriptGen.callRemoteScriptGen(arguments);
             case RGB -> RGBCombination.combine(arguments);
             case SATURATE -> saturation.saturate(arguments);
+            case SCALE_TO_UNIT -> math.scaleToUnit(arguments);
+            case SCALE_FROM_UNIT -> math.scaleFromUnit(arguments);
             case SHARPEN -> convolution.sharpen(arguments);
             case SIDE_BY_SIDE -> imageCombination.sideBySide(arguments);
             case SIGNED_DIFF -> signedDiff.signedDiff(arguments);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Dedistort.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Dedistort.java
@@ -17,6 +17,7 @@ package me.champeau.a4j.jsolex.processing.expr.impl;
 
 import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.event.ProgressOperation;
+import me.champeau.a4j.jsolex.processing.expr.stacking.ActiveRegionMask;
 import me.champeau.a4j.jsolex.processing.expr.stacking.ConsensusReference;
 import me.champeau.a4j.jsolex.processing.expr.stacking.DistorsionMap;
 import me.champeau.a4j.jsolex.processing.expr.stacking.DistorsionMaps;
@@ -85,6 +86,13 @@ public class Dedistort extends AbstractFunctionImpl {
 
     // Reject bottom N% of samples by confidence (adaptive filtering)
     private static final double CONFIDENCE_REJECTION_PERCENTILE = 0.50;
+
+    // Adaptive per-tile convergence (consensus mode)
+    private static final double FREEZE_ABS_MAGNITUDE = 0.15;
+    private static final double TILE_CONVERGENCE_THRESHOLD = 0.01;
+    private static final int FREEZE_STREAK = 2;
+    private static final int MIN_ITERATIONS_BEFORE_FREEZE = 2;
+    private static final double FULL_FREEZE_FRACTION = 0.98;
 
     private final CorrelationStrategy correlationStrategy = NCCCorrelationStrategy.INSTANCE;
 
@@ -989,6 +997,7 @@ public class Dedistort extends AbstractFunctionImpl {
         var iterations = intArg(arguments, "iterations", 1);
         var useSparse = booleanArg(arguments, "sparse", false);
         var multiscale = booleanArg(arguments, "multiscale", false);
+        var adaptive = booleanArg(arguments, "adaptive", true);
         if (iterations < 1) {
             iterations = 1;
         }
@@ -1009,8 +1018,8 @@ public class Dedistort extends AbstractFunctionImpl {
 
         var width = images.getFirst().width();
         var height = images.getFirst().height();
-        LOGGER.debug("Consensus dedistort: images={}, tileSize={}, sampling={}, iterations={}, sparse={}, multiscale={}",
-                imageCount, tileSize, sampling, iterations, useSparse, multiscale);
+        LOGGER.debug("Consensus dedistort: images={}, tileSize={}, sampling={}, iterations={}, sparse={}, multiscale={}, adaptive={}",
+                imageCount, tileSize, sampling, iterations, useSparse, multiscale, adaptive);
 
         var mainOperation = newOperation().createChild(DEDISTORT);
 
@@ -1018,6 +1027,15 @@ public class Dedistort extends AbstractFunctionImpl {
         var accumulatedMaps = new ArrayList<DistorsionMaps>(imageCount);
         for (int i = 0; i < imageCount; i++) {
             accumulatedMaps.add(new DistorsionMaps(List.of()));
+        }
+
+        // Per-image adaptive convergence state (one entry per image, populated lazily
+        // after the first iteration). Empty when adaptive=false so all checks are no-ops.
+        var perImageConvergence = new ArrayList<TileConvergenceState>(imageCount);
+        if (adaptive) {
+            for (int i = 0; i < imageCount; i++) {
+                perImageConvergence.add(new TileConvergenceState());
+            }
         }
 
         // Current working images (will be warped after each iteration)
@@ -1092,14 +1110,31 @@ public class Dedistort extends AbstractFunctionImpl {
             }
 
             // Collect directed pairs to compute (i → j means distortion from i's perspective)
-            // We compute BOTH directions so each image uses its own interest points
+            // We compute BOTH directions so each image uses its own interest points,
+            // except sources whose convergence state is fully frozen.
             var pairsToCompute = new LinkedHashSet<Long>();
+            int skippedFullyFrozen = 0;
             for (int i = 0; i < imageCount; i++) {
-                for (int j : comparisonsPerSourceImage.get(i)) {
-                    // Add both directions: i→j and j→i
-                    pairsToCompute.add(encodeDirectedPair(i, j, imageCount));
-                    pairsToCompute.add(encodeDirectedPair(j, i, imageCount));
+                var sourceFrozen = adaptive && perImageConvergence.get(i).fullyFrozen();
+                if (sourceFrozen) {
+                    skippedFullyFrozen++;
                 }
+                for (int j : comparisonsPerSourceImage.get(i)) {
+                    if (!sourceFrozen) {
+                        pairsToCompute.add(encodeDirectedPair(i, j, imageCount));
+                    }
+                    if (!(adaptive && perImageConvergence.get(j).fullyFrozen())) {
+                        pairsToCompute.add(encodeDirectedPair(j, i, imageCount));
+                    }
+                }
+            }
+            if (adaptive && skippedFullyFrozen > 0) {
+                LOGGER.debug("Consensus reference iteration {}: {} fully frozen source images skipped",
+                        iteration + 1, skippedFullyFrozen);
+            }
+            if (pairsToCompute.isEmpty()) {
+                LOGGER.info(message("consensus.reference.all.frozen"), iteration + 1);
+                break;
             }
 
             LOGGER.debug("Consensus reference iteration {}: {} directed pairs to compute (from {} comparisons)",
@@ -1113,11 +1148,13 @@ public class Dedistort extends AbstractFunctionImpl {
                     .distinct()
                     .toArray();
             int finalIteration = iteration;
+            boolean adaptiveFinal = adaptive;
             Arrays.stream(sourceIndices)
                     .parallel()
                     .forEach(srcIdx -> {
                         var srcData = currentImages.get(srcIdx).data();
-                        var positions = strategy.selectPositions(srcData, width, height, safeTileSize, signal);
+                        var mask = adaptiveFinal ? perImageConvergence.get(srcIdx).buildMask() : null;
+                        var positions = strategy.selectPositions(srcData, width, height, safeTileSize, signal, mask);
                         positionsPerSource.put(srcIdx, positions);
 
                         // Save debug image showing interest points when debug logging is enabled
@@ -1259,36 +1296,78 @@ public class Dedistort extends AbstractFunctionImpl {
             // For each image, gather maps and compute average
             // Each map is now computed directly (i → j uses i's interest points)
             var iterationMaps = new ArrayList<DistorsionMap>(imageCount);
+            DistorsionMap referenceShapeMap = computedMaps.values().stream().findFirst().orElse(null);
             for (int i = 0; i < imageCount; i++) {
-                var mapsToOthers = new ArrayList<DistorsionMap>(comparisonsPerImage);
+                var sourceFrozen = adaptive && perImageConvergence.get(i).fullyFrozen();
+                DistorsionMap imageToTruth;
+                if (sourceFrozen) {
+                    // Fully frozen image: no source pairs were computed; emit a zero
+                    // correction map shaped like any existing computed map.
+                    var shape = referenceShapeMap;
+                    imageToTruth = new DistorsionMap(width, height,
+                            shape != null ? shape.getTileSize() : tileSize,
+                            shape != null ? shape.getStep() : Math.max(MIN_STEP, (int) (tileSize * sampling)));
+                } else {
+                    var mapsToOthers = new ArrayList<DistorsionMap>(comparisonsPerImage);
+                    for (int j : comparisonsPerSourceImage.get(i)) {
+                        long pairKey = encodeDirectedPair(i, j, imageCount);
+                        var map = computedMaps.get(pairKey);
+                        if (map != null) {
+                            mapsToOthers.add(map);
+                        }
+                    }
 
-                for (int j : comparisonsPerSourceImage.get(i)) {
-                    long pairKey = encodeDirectedPair(i, j, imageCount);
-                    var map = computedMaps.get(pairKey);
-                    mapsToOthers.add(map);
+                    // Average: average(image[i] → image[j]) ≈ -d_i (negative of image[i]'s distortion)
+                    // So we negate to get the correction: image[i] → truth ≈ d_i
+                    var avgMap = DistorsionMap.average(mapsToOthers);
+                    if (adaptive) {
+                        perImageConvergence.get(i).applyFreezeMaskInPlace(avgMap);
+                    }
+                    imageToTruth = avgMap.negate();
                 }
-
-                // Average: average(image[i] → image[j]) ≈ -d_i (negative of image[i]'s distortion)
-                // So we negate to get the correction: image[i] → truth ≈ d_i
-                var avgMap = DistorsionMap.average(mapsToOthers);
-                var imageToTruth = avgMap.negate();
                 iterationMaps.add(imageToTruth);
-                LOGGER.debug("Consensus reference iteration {}: image {}: toTruth distortion={}",
-                        iteration + 1, i, imageToTruth.totalDistorsion());
+                if (adaptive) {
+                    perImageConvergence.get(i).update(imageToTruth, iteration);
+                }
+                LOGGER.debug("Consensus reference iteration {}: image {}: toTruth distortion={}, frozenFraction={}",
+                        iteration + 1, i, imageToTruth.totalDistorsion(),
+                        adaptive ? String.format("%.2f", perImageConvergence.get(i).frozenFraction()) : "n/a");
             }
             broadcaster.broadcast(comparingOperation.complete());
 
             // Check convergence: stop if distortion increased or improvement below threshold
-            var avgDistortion = iterationMaps.stream()
+            var totalDistortion = iterationMaps.stream()
                     .mapToDouble(DistorsionMap::totalDistorsion)
-                    .average()
-                    .orElse(0);
+                    .sum();
+            var avgDistortion = iterationMaps.isEmpty() ? 0 : totalDistortion / iterationMaps.size();
             var relativeImprovement = previousAvgDistortion > 0
                     ? (previousAvgDistortion - avgDistortion) / previousAvgDistortion
                     : 1.0;
 
-            LOGGER.info("Consensus reference iteration {}: avgDistortion={}, improvement={}%",
-                    iteration + 1, avgDistortion, String.format("%.4f", relativeImprovement * 100));
+            LOGGER.info(message("consensus.reference.iteration.summary"),
+                    iteration + 1,
+                    String.format("%.2f", avgDistortion),
+                    String.format("%.2f", relativeImprovement * 100));
+
+            if (adaptive) {
+                var avgFrozenFraction = perImageConvergence.stream()
+                        .mapToDouble(TileConvergenceState::frozenFraction)
+                        .average()
+                        .orElse(0);
+                var fullyFrozenCount = (int) perImageConvergence.stream()
+                        .filter(TileConvergenceState::fullyFrozen)
+                        .count();
+                var totalPositions = positionsPerSource.values().stream()
+                        .mapToInt(SamplingStrategy.SamplePositions::count)
+                        .sum();
+                LOGGER.info(message("consensus.reference.adaptive.summary"),
+                        iteration + 1,
+                        String.format("%.2f", totalDistortion),
+                        String.format("%.1f", avgFrozenFraction * 100),
+                        fullyFrozenCount, imageCount,
+                        pairsToCompute.size(),
+                        totalPositions);
+            }
 
             if (avgDistortion > previousAvgDistortion) {
                 LOGGER.warn(message("consensus.reference.distortion.increased"), iteration + 1, avgDistortion, previousAvgDistortion);
@@ -1619,6 +1698,95 @@ public class Dedistort extends AbstractFunctionImpl {
             LOGGER.debug("Saved interest point debug image: {}", debugFile.getAbsolutePath());
         } catch (IOException e) {
             LOGGER.warn("Failed to save interest point debug image", e);
+        }
+    }
+
+    /**
+     * Tracks per-tile convergence state for one image across multiple iterations of
+     * the consensus dedistortion loop. A tile becomes <em>frozen</em> when its
+     * displacement magnitude has been small and not improving for a configured number
+     * of consecutive iterations; frozen tiles are then skipped from sample selection
+     * in subsequent iterations and zeroed out in the resulting averaged map.
+     */
+    private static final class TileConvergenceState {
+        private boolean[][] frozen;
+        private double[][] lastMagnitude;
+        private int[][] belowStreak;
+        private int gridStep;
+        private int gridXSize;
+        private int gridYSize;
+        private boolean initialized;
+
+        void update(DistorsionMap imageToTruth, int iteration) {
+            var magnitudes = imageToTruth.computeGridMagnitudes();
+            if (!initialized) {
+                gridYSize = magnitudes.length;
+                gridXSize = gridYSize == 0 ? 0 : magnitudes[0].length;
+                gridStep = imageToTruth.getStep();
+                frozen = new boolean[gridYSize][gridXSize];
+                lastMagnitude = new double[gridYSize][gridXSize];
+                belowStreak = new int[gridYSize][gridXSize];
+                initialized = true;
+            }
+            for (var y = 0; y < gridYSize; y++) {
+                for (var x = 0; x < gridXSize; x++) {
+                    if (frozen[y][x]) {
+                        continue;
+                    }
+                    var current = magnitudes[y][x];
+                    var prev = lastMagnitude[y][x];
+                    var improvement = prev > 0 ? (prev - current) / prev : 1.0;
+                    var smallEnough = current < FREEZE_ABS_MAGNITUDE;
+                    var notImproving = improvement < TILE_CONVERGENCE_THRESHOLD;
+                    if (smallEnough && notImproving) {
+                        belowStreak[y][x]++;
+                    } else {
+                        belowStreak[y][x] = 0;
+                    }
+                    if (iteration + 1 >= MIN_ITERATIONS_BEFORE_FREEZE
+                            && belowStreak[y][x] >= FREEZE_STREAK) {
+                        frozen[y][x] = true;
+                    }
+                    lastMagnitude[y][x] = current;
+                }
+            }
+        }
+
+        void applyFreezeMaskInPlace(DistorsionMap avgMap) {
+            if (!initialized) {
+                return;
+            }
+            avgMap.zeroOutFrozenTiles(frozen);
+        }
+
+        ActiveRegionMask buildMask() {
+            if (!initialized) {
+                return null;
+            }
+            return new ActiveRegionMask(frozen, gridStep);
+        }
+
+        double frozenFraction() {
+            if (!initialized) {
+                return 0.0;
+            }
+            var total = gridXSize * gridYSize;
+            if (total == 0) {
+                return 0.0;
+            }
+            var count = 0;
+            for (var row : frozen) {
+                for (var f : row) {
+                    if (f) {
+                        count++;
+                    }
+                }
+            }
+            return (double) count / total;
+        }
+
+        boolean fullyFrozen() {
+            return frozenFraction() >= FULL_FREEZE_FRACTION;
         }
     }
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/MathFunctions.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/MathFunctions.java
@@ -17,8 +17,10 @@ package me.champeau.a4j.jsolex.processing.expr.impl;
 
 import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
+import me.champeau.a4j.jsolex.processing.util.Constants;
 
 import java.util.Map;
+import java.util.function.DoubleUnaryOperator;
 
 public class MathFunctions extends AbstractFunctionImpl {
     public MathFunctions(Map<Class<?>, Object> context, Broadcaster broadcaster) {
@@ -38,6 +40,24 @@ public class MathFunctions extends AbstractFunctionImpl {
     public Object exp(Map<String ,Object> arguments) {
         BuiltinFunction.EXP.validateArgs(arguments);
         return applyUnary(arguments, "exp", "v", Math::exp);
+    }
+
+    public Object scaleToUnit(Map<String, Object> arguments) {
+        BuiltinFunction.SCALE_TO_UNIT.validateArgs(arguments);
+        var clamp = intArg(arguments, "clamp", 1) != 0;
+        DoubleUnaryOperator op = clamp
+                ? v -> Math.max(0d, Math.min(1d, v / Constants.MAX_PIXEL_VALUE))
+                : v -> v / Constants.MAX_PIXEL_VALUE;
+        return applyUnary(Map.of("img", arguments.get("img")), "scale_to_unit", "img", op);
+    }
+
+    public Object scaleFromUnit(Map<String, Object> arguments) {
+        BuiltinFunction.SCALE_FROM_UNIT.validateArgs(arguments);
+        var clamp = intArg(arguments, "clamp", 1) != 0;
+        DoubleUnaryOperator op = clamp
+                ? v -> Math.max(0d, Math.min(Constants.MAX_PIXEL_VALUE, v * Constants.MAX_PIXEL_VALUE))
+                : v -> v * Constants.MAX_PIXEL_VALUE;
+        return applyUnary(Map.of("img", arguments.get("img")), "scale_from_unit", "img", op);
     }
 
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/ActiveRegionMask.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/ActiveRegionMask.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.expr.stacking;
+
+/**
+ * A mask describing which tiles in the output distortion grid have already converged
+ * (frozen) and should be skipped during sampling. Used by the adaptive consensus
+ * dedistortion loop to avoid recomputing phase correlation in regions that no longer
+ * benefit from further refinement.
+ *
+ * @param frozen   per-tile frozen flags, indexed as {@code [ty][tx]} on a grid of
+ *                 spacing {@code gridStep}
+ * @param gridStep grid spacing in pixels
+ */
+public record ActiveRegionMask(boolean[][] frozen, int gridStep) {
+
+    public boolean isFrozenAt(int px, int py) {
+        if (frozen.length == 0) {
+            return false;
+        }
+        var ty = py / gridStep;
+        var tx = px / gridStep;
+        if (ty < 0 || tx < 0 || ty >= frozen.length || tx >= frozen[0].length) {
+            return false;
+        }
+        return frozen[ty][tx];
+    }
+
+    public SamplingStrategy.SamplePositions filter(SamplingStrategy.SamplePositions positions) {
+        var srcCount = positions.count();
+        var srcX = positions.x();
+        var srcY = positions.y();
+        var srcSizes = positions.tileSize();
+
+        var keptX = new int[srcCount];
+        var keptY = new int[srcCount];
+        var keptSizes = new int[srcCount];
+        var kept = 0;
+        for (var i = 0; i < srcCount; i++) {
+            if (!isFrozenAt(srcX[i], srcY[i])) {
+                keptX[kept] = srcX[i];
+                keptY[kept] = srcY[i];
+                keptSizes[kept] = srcSizes[i];
+                kept++;
+            }
+        }
+        if (kept == srcCount) {
+            return positions;
+        }
+        var trimmedX = new int[kept];
+        var trimmedY = new int[kept];
+        var trimmedSizes = new int[kept];
+        System.arraycopy(keptX, 0, trimmedX, 0, kept);
+        System.arraycopy(keptY, 0, trimmedY, 0, kept);
+        System.arraycopy(keptSizes, 0, trimmedSizes, 0, kept);
+        return new SamplingStrategy.SamplePositions(trimmedX, trimmedY, trimmedSizes, kept);
+    }
+
+    public double frozenFraction() {
+        if (frozen.length == 0) {
+            return 0.0;
+        }
+        var total = 0;
+        var frozenCount = 0;
+        for (var row : frozen) {
+            for (var f : row) {
+                total++;
+                if (f) {
+                    frozenCount++;
+                }
+            }
+        }
+        return total == 0 ? 0.0 : (double) frozenCount / total;
+    }
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/DistorsionMap.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/DistorsionMap.java
@@ -940,6 +940,55 @@ public class DistorsionMap {
     }
 
     /**
+     * Returns a newly allocated grid of per-cell displacement magnitudes, aligned with
+     * the {@code dxy} sample grid (one entry per grid cell, in pixels). Used by the
+     * adaptive convergence tracking to evaluate which tiles have settled.
+     */
+    public double[][] computeGridMagnitudes() {
+        var result = new double[gridYSize][gridXSize];
+        for (var y = 0; y < gridYSize; y++) {
+            for (var x = 0; x < gridXSize; x++) {
+                result[y][x] = Math.hypot(dxy[y][x][0], dxy[y][x][1]);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Forces the displacement at every grid cell flagged as frozen to {@code (0, 0)}
+     * and marks it as sampled. Used by adaptive consensus dedistortion to inject
+     * "no further correction" entries for tiles that have already converged in
+     * previous iterations, so that averaging and warping treat them as stable.
+     *
+     * @param frozen frozen mask aligned with the dxy grid (same dimensions). Cells
+     *               outside the mask are left untouched.
+     */
+    public void zeroOutFrozenTiles(boolean[][] frozen) {
+        if (frozen == null || frozen.length == 0) {
+            return;
+        }
+        var rows = Math.min(frozen.length, gridYSize);
+        var cols = Math.min(frozen[0].length, gridXSize);
+        for (var y = 0; y < rows; y++) {
+            var row = frozen[y];
+            for (var x = 0; x < cols; x++) {
+                if (row[x]) {
+                    dxy[y][x][0] = 0;
+                    dxy[y][x][1] = 0;
+                    sampled[y][x] = true;
+                }
+            }
+        }
+        totalDistorsion = -1;
+        cacheLock.lock();
+        try {
+            cachedTileErrors = null;
+        } finally {
+            cacheLock.unlock();
+        }
+    }
+
+    /**
      * Removes outliers and returns a map of rejected samples for debugging.
      *
      * @return boolean array where true indicates the sample was rejected as outlier

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/InterestPointSamplingStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/InterestPointSamplingStrategy.java
@@ -78,26 +78,26 @@ public final class InterestPointSamplingStrategy implements SamplingStrategy {
 
             // Layer 1: Large tiles (tileSize*2) for coarse coverage
             var largeSize = tileSize * 2;
-            addInterestPointLayer(allPoints, width, height, largeSize,
+            addInterestPointLayer(allPoints, referenceData, width, height, largeSize,
                     integralImg, gradientMag, signalThreshold,
                     MAX_GRADIENT_THRESHOLD, "coarse");
 
             // Layer 2: Main tiles (tileSize) - the primary density layer
-            addInterestPointLayer(allPoints, width, height, tileSize,
+            addInterestPointLayer(allPoints, referenceData, width, height, tileSize,
                     integralImg, gradientMag, signalThreshold,
                     MAX_GRADIENT_THRESHOLD, "main");
 
             // Layer 3: Small tiles (tileSize/2) for high-detail areas
             var smallSize = Math.max(MIN_TILE_SIZE, tileSize / 2);
             if (smallSize < tileSize) {
-                addInterestPointLayer(allPoints, width, height, smallSize,
+                addInterestPointLayer(allPoints, referenceData, width, height, smallSize,
                         integralImg, gradientMag, signalThreshold,
                         MAX_GRADIENT_THRESHOLD,
                         "detail");
             }
         } else {
             // Single scale: interest-point selection
-            addInterestPointLayer(allPoints, width, height, tileSize,
+            addInterestPointLayer(allPoints, referenceData, width, height, tileSize,
                     integralImg, gradientMag, signalThreshold,
                     MAX_GRADIENT_THRESHOLD, "uniform");
         }
@@ -139,6 +139,7 @@ public final class InterestPointSamplingStrategy implements SamplingStrategy {
      * Points are placed at actual local maxima of the gradient image.
      */
     private void addInterestPointLayer(List<SelectedPoint> points,
+                                       float[][] referenceData,
                                        int width, int height,
                                        int tileSize,
                                        Image integralImg,
@@ -152,11 +153,29 @@ public final class InterestPointSamplingStrategy implements SamplingStrategy {
         // Get gradient magnitude data directly
         var gradientData = gradientMag.data();
 
-        // First pass: find maximum gradient value for thresholding
+        // First pass: find maximum gradient value for thresholding. We restrict
+        // the max-gradient anchor to "deep interior" pixels — those whose
+        // tile-sized neighborhood is entirely above the signal threshold,
+        // tested via the four corners of the enclosing box. Limb pixels are
+        // excluded because at least one corner of their enclosing box lies in
+        // the sky, which lets on-disk chromospheric features (whose gradients
+        // are much weaker than the solar edge) set the selection threshold
+        // instead of the limb. The test uses only the signal mask, making no
+        // geometric assumption about disk shape — this matters because the
+        // whole point of dedistort is that the input is not yet perfectly
+        // round.
         float maxGradient = 0;
         for (var y = halfTile; y < height - halfTile; y++) {
             var row = gradientData[y];
+            var rowTop = referenceData[y - halfTile];
+            var rowBot = referenceData[y + halfTile];
             for (var x = halfTile; x < width - halfTile; x++) {
+                if (rowTop[x - halfTile] < signalThreshold
+                        || rowTop[x + halfTile] < signalThreshold
+                        || rowBot[x - halfTile] < signalThreshold
+                        || rowBot[x + halfTile] < signalThreshold) {
+                    continue;
+                }
                 maxGradient = Math.max(maxGradient, row[x]);
             }
         }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/SamplingStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/SamplingStrategy.java
@@ -70,6 +70,28 @@ public sealed interface SamplingStrategy permits GridSamplingStrategy, InterestP
                                      float signalThreshold);
 
     /**
+     * Selects sample positions and applies a per-tile active-region mask. Frozen tiles
+     * (already converged in a previous iteration) are excluded from the result.
+     *
+     * @param referenceData    the reference image data
+     * @param width            image width
+     * @param height           image height
+     * @param tileSize         base tile size for correlation
+     * @param signalThreshold  minimum signal level for valid samples
+     * @param mask             active-region mask, or {@code null} for no filtering
+     * @return the selected sample positions, with frozen tiles removed
+     */
+    default SamplePositions selectPositions(float[][] referenceData,
+                                            int width,
+                                            int height,
+                                            int tileSize,
+                                            float signalThreshold,
+                                            ActiveRegionMask mask) {
+        var positions = selectPositions(referenceData, width, height, tileSize, signalThreshold);
+        return mask == null ? positions : mask.filter(positions);
+    }
+
+    /**
      * Returns the recommended grid step for converting sparse results to a regular grid.
      * This determines the resolution of the final distortion map used for warping.
      *

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages.properties
@@ -268,6 +268,9 @@ dedistort.iteration.distortion.increased=Dedistort iteration {} didn't improve d
 dedistort.iteration.converged=Dedistort iteration {} converged (improvement {}% < {}%), stopping.
 consensus.reference.comparing=Comparing images
 consensus.reference.computing=Computing pairwise distortion maps
+consensus.reference.all.frozen=Consensus reference iteration {}: all images fully frozen, stopping
+consensus.reference.iteration.summary=Consensus reference iteration {}: avgDistortion={}, improvement={}%
+consensus.reference.adaptive.summary=Consensus reference iteration {}: totalDistortion={}, avg frozen tiles={}%, fully frozen images={}/{}, pairs={}, sample positions={}
 dedistort.sparse.overrides.sampling=Sparse mode is enabled, 'sampling' parameter will be ignored
 dedistort.multiscale.requires.sparse=Multiscale mode requires sparse > 0, disabling multiscale
 repository.zip.missing.descriptor=Zip file {} is missing main.txt descriptor, skipping

--- a/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr.properties
+++ b/jsolex-core/src/main/resources/me/champeau/a4j/jsolex/processing/util/messages_fr.properties
@@ -268,6 +268,9 @@ dedistort.iteration.distortion.increased=L'itération de dédistorsion {} n'a pas 
 dedistort.iteration.converged=L'itération de dédistorsion {} a convergé (amélioration {}% < {}%), arrêt.
 consensus.reference.comparing=Comparaison des images
 consensus.reference.computing=Calcul des cartes de distorsion par paires
+consensus.reference.all.frozen=Itération de référence par consensus {} : toutes les images sont entièrement gelées, arrêt
+consensus.reference.iteration.summary=Itération de référence par consensus {} : distorsion moyenne={}, amélioration={}%
+consensus.reference.adaptive.summary=Itération de référence par consensus {} : distorsion totale={}, tuiles gelées en moyenne={}%, images entièrement gelées={}/{}, paires={}, positions échantillonnées={}
 dedistort.sparse.overrides.sampling=Le mode clairsemé est activé, le paramètre 'sampling' sera ignoré
 dedistort.multiscale.requires.sparse=Le mode multi-échelle nécessite sparse > 0, désactivation du mode multi-échelle
 repository.zip.missing.descriptor=Le fichier zip {} ne contient pas de descripteur main.txt, ignoré

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/ScaleUnitFunctionsTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/ScaleUnitFunctionsTest.groovy
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.expr
+
+import me.champeau.a4j.jsolex.processing.expr.ImageMathScriptExecutor.SectionKind
+import me.champeau.a4j.jsolex.processing.sun.Broadcaster
+import me.champeau.a4j.jsolex.processing.sun.workflow.PixelShift
+import me.champeau.a4j.jsolex.processing.util.Constants
+import me.champeau.a4j.jsolex.processing.util.FileBackedImage
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32
+import spock.lang.Specification
+
+import java.util.function.Function
+
+class ScaleUnitFunctionsTest extends Specification {
+
+    DefaultImageScriptExecutor executor
+
+    private DefaultImageScriptExecutor executorWith(float[] pixels) {
+        Function<PixelShift, ImageWrapper> imageSupplier = { PixelShift shift ->
+            return new ImageWrapper32(pixels.length, 1, [pixels] as float[][], new LinkedHashMap<>())
+        } as Function
+        return new DefaultImageScriptExecutor(imageSupplier, ScriptExecutionContext.empty(), Broadcaster.NO_OP)
+    }
+
+    private static float[] dataOf(result, String label) {
+        return ((ImageWrapper32) ((FileBackedImage) result.imagesByLabel()[label]).unwrapToMemory()).data()[0]
+    }
+
+    def setup() {
+        // 4 pixels: 0, halfway, max in-range, and over-range (will be clamped if requested)
+        executor = executorWith([0f, 32768f, 65535f, 80000f] as float[])
+    }
+
+    def "scale_to_unit divides pixels by 65535 and clamps by default"() {
+        given:
+        def script = '''
+[outputs]
+out=scale_to_unit(img(0))
+'''
+
+        when:
+        def result = executor.execute(script, SectionKind.SINGLE)
+        def out = dataOf(result, "out")
+
+        then:
+        out[0] == 0f
+        out[1] == (float) (32768d / Constants.MAX_PIXEL_VALUE)
+        out[2] == 1f
+        // 80000/65535 ~= 1.22 — clamped to 1
+        out[3] == 1f
+    }
+
+    def "scale_to_unit with clamp=0 keeps out-of-range values"() {
+        given:
+        def script = '''
+[outputs]
+out=scale_to_unit(img(0); 0)
+'''
+
+        when:
+        def result = executor.execute(script, SectionKind.SINGLE)
+        def out = dataOf(result, "out")
+
+        then:
+        out[3] == (float) (80000d / Constants.MAX_PIXEL_VALUE)
+        out[3] > 1f
+    }
+
+    def "scale_from_unit multiplies pixels by 65535 and clamps by default"() {
+        given:
+        def exec = executorWith([0f, 0.5f, 1f, 1.5f] as float[])
+
+        and:
+        def script = '''
+[outputs]
+out=scale_from_unit(img(0))
+'''
+
+        when:
+        def result = exec.execute(script, SectionKind.SINGLE)
+        def out = dataOf(result, "out")
+
+        then:
+        out[0] == 0f
+        out[1] == 0.5f * Constants.MAX_PIXEL_VALUE
+        out[2] == Constants.MAX_PIXEL_VALUE
+        // 1.5 * 65535 = 98302.5 — clamped to 65535
+        out[3] == Constants.MAX_PIXEL_VALUE
+    }
+
+    def "scale_from_unit with clamp=0 keeps out-of-range values"() {
+        given:
+        def exec = executorWith([0f, 0.5f, 1f, 1.5f] as float[])
+
+        and:
+        def script = '''
+[outputs]
+out=scale_from_unit(img: img(0); clamp: 0)
+'''
+
+        when:
+        def result = exec.execute(script, SectionKind.SINGLE)
+        def out = dataOf(result, "out")
+
+        then:
+        out[3] == 1.5f * Constants.MAX_PIXEL_VALUE
+    }
+
+    def "scale_to_unit and scale_from_unit are inverse for in-range pixels"() {
+        given:
+        def script = '''
+[outputs]
+roundtrip=scale_from_unit(scale_to_unit(img(0)))
+'''
+
+        when:
+        def result = executor.execute(script, SectionKind.SINGLE)
+        def out = dataOf(result, "roundtrip")
+
+        then:
+        out[0] == 0f
+        out[1] == 32768f
+        out[2] == Constants.MAX_PIXEL_VALUE
+    }
+
+    def "both functions also work on scalar values"() {
+        when:
+        def result = executor.execute('''
+[outputs]
+half=scale_to_unit(32767.5)
+back=scale_from_unit(0.5)
+over_clamped=scale_to_unit(80000)
+over_unclamped=scale_to_unit(80000; 0)
+''', SectionKind.SINGLE)
+
+        then:
+        ((Number) result.valuesByLabel()["half"]).doubleValue() == 0.5d
+        ((Number) result.valuesByLabel()["back"]).doubleValue() == 32767.5d
+        ((Number) result.valuesByLabel()["over_clamped"]).doubleValue() == 1.0d
+        ((Number) result.valuesByLabel()["over_unclamped"]).doubleValue() > 1.0d
+    }
+}

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -7,6 +7,7 @@
 - Improved error messages when loading SpectroSolHub repositories fails
 - Re-running an ImageMath script after tweaking a parameter is now much faster: only expressions that depend on the changed parameter are recomputed.
 - Added two ImageMath functions, `scale_to_unit` and `scale_from_unit`, to convert pixel values between the [0;65535] and [0;1] ranges (with optional clamping).
+- Improved `dedistort` quality on multi-iteration consensus runs via adaptive per-tile convergence.
 
 ## What's New in Version 5.0.4
 

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -6,6 +6,7 @@
 - Fixed script repositories with spaces in script filenames failing to download
 - Improved error messages when loading SpectroSolHub repositories fails
 - Re-running an ImageMath script after tweaking a parameter is now much faster: only expressions that depend on the changed parameter are recomputed.
+- Added two ImageMath functions, `scale_to_unit` and `scale_from_unit`, to convert pixel values between the [0;65535] and [0;1] ranges (with optional clamping).
 
 ## What's New in Version 5.0.4
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -6,6 +6,7 @@
 - Correction du téléchargement des dépôts de scripts dont les noms de fichiers contiennent des espaces
 - Amélioration des messages d'erreur lors du chargement des dépôts SpectroSolHub
 - Réexécuter un script ImageMath après avoir modifié un paramètre est désormais beaucoup plus rapide : seules les expressions qui dépendent du paramètre modifié sont recalculées.
+- Ajout de deux fonctions ImageMath, `scale_to_unit` et `scale_from_unit`, pour convertir les valeurs des pixels entre les plages [0;65535] et [0;1] (avec écrêtage optionnel).
 
 ## Nouveautés de la version 5.0.4
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -7,6 +7,7 @@
 - Amélioration des messages d'erreur lors du chargement des dépôts SpectroSolHub
 - Réexécuter un script ImageMath après avoir modifié un paramètre est désormais beaucoup plus rapide : seules les expressions qui dépendent du paramètre modifié sont recalculées.
 - Ajout de deux fonctions ImageMath, `scale_to_unit` et `scale_from_unit`, pour convertir les valeurs des pixels entre les plages [0;65535] et [0;1] (avec écrêtage optionnel).
+- Amélioration de la qualité de `dedistort` sur les exécutions multi-itérations en mode consensus grâce à une convergence adaptative par tuile.
 
 ## Nouveautés de la version 5.0.4
 


### PR DESCRIPTION
This PR optimized dedistorsion algorithm, by computing improvements by tile in addition to globally. The intent is that when we have multiple iterations, we can stop improving some tiles earlier than others because turbulence is not equivalent everywhere on the globe.