### PR TITLE
Fix alignment button behavior

### DIFF
--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
@@ -427,9 +427,15 @@ public class ImageViewer implements WithRootNode {
             dimensions = new Label();
             var zoomLabel = new Label("Zoom");
             var zoomMinus = createButton("-");
-            zoomMinus.setOnAction(evt -> imageView.setZoom(imageView.getZoom() * 0.8));
+            zoomMinus.setOnAction(evt -> {
+                clearPendingAlignment();
+                imageView.setZoom(imageView.getZoom() * 0.8);
+            });
             var zoomPlus = createButton("+");
-            zoomPlus.setOnAction(evt -> imageView.setZoom(imageView.getZoom() * 1.2));
+            zoomPlus.setOnAction(evt -> {
+                clearPendingAlignment();
+                imageView.setZoom(imageView.getZoom() * 1.2);
+            });
             var coordinatesLabel = new Label();
             imageView.setCoordinatesListener((x, y) -> {
                 var extra = "";
@@ -468,12 +474,21 @@ public class ImageViewer implements WithRootNode {
             nextButton.disableProperty().bind(currentImage.isEqualTo(imageHistory.sizeProperty().subtract(1)));
             nextButton.visibleProperty().bind(imageHistory.sizeProperty().greaterThan(1));
             var fitButton = createButton("←fit→");
-            fitButton.setOnAction(evt -> imageView.resetZoom(true));
+            fitButton.setOnAction(evt -> {
+                clearPendingAlignment();
+                imageView.resetZoom(true);
+            });
             var fitToCenter = createButton("→fit←");
             fitToCenter.disableProperty().bind(imageView.canFitToCenterProperty().map(e -> !e));
-            fitToCenter.setOnAction(evt -> imageView.fitToCenter());
+            fitToCenter.setOnAction(evt -> {
+                clearPendingAlignment();
+                imageView.fitToCenter();
+            });
             var oneToOneFit = createButton("1:1");
-            oneToOneFit.setOnAction(evt -> imageView.oneToOneZoomAndCenter());
+            oneToOneFit.setOnAction(evt -> {
+                clearPendingAlignment();
+                imageView.oneToOneZoomAndCenter();
+            });
             var leftRotate = createButton("↶");
             leftRotate.setOnAction(evt -> {
                 rotation = (rotation - 1) % 4;
@@ -697,6 +712,13 @@ public class ImageViewer implements WithRootNode {
     private void maybeRunOnUpdate() {
         if (onDisplayUpdate != null) {
             onDisplayUpdate.run();
+        }
+    }
+
+    private void clearPendingAlignment() {
+        onDisplayUpdate = null;
+        for (var viewer : siblings) {
+            viewer.onDisplayUpdate = null;
         }
     }
 

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -6,6 +6,7 @@
 - SpectroSolHub Live: raw and reconstruction images are no longer uploaded
 - SpectroSolHub Live: in batch mode, only images produced by the `[[batch]]` output section of scripts are uploaded. A warning is logged at the end of a batch if no image was uploaded.
 - Orientation wizards (BASS2000, SpectroSolHub): the GONG reference image can be switched to another observatory via a picker overlaid on the image, and auto-align can be restricted to rotation-only when the image is already correctly flipped.
+- Fixed image viewer alignment not being cancelled when clicking a zoom button (+, -, 1:1, fit) after having activated image alignment.
 
 ## What's New in Version 5.1.0
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -6,6 +6,7 @@
 - SpectroSolHub En Direct : les images brutes et de reconstruction ne sont plus envoyées
 - SpectroSolHub En Direct : en mode lot, seules les images produites par la section de sortie `[[batch]]` des scripts sont envoyées. Un avertissement est consigné à la fin du lot si aucune image n'a été envoyée.
 - Assistants d'orientation (BASS2000, SpectroSolHub) : l'image de référence GONG peut être changée pour celle d'un autre observatoire via un sélecteur superposé à l'image, et l'alignement automatique peut être restreint à la rotation seule quand l'image est déjà correctement retournée.
+- Correction de l'alignement des images qui n'était pas annulé lors d'un clic sur un bouton de zoom (+, -, 1:1, ajuster) après avoir activé l'alignement des images.
 
 ## Nouveautés de la version 5.1.0
 


### PR DESCRIPTION
Pending alignment wasn't cancelled when clicking on another zoom button, which caused an annoying behavior when clicking on an image after resetting the zoom.