### PR TITLE
Performance improvements

### DIFF
--- a/build-logic/src/main/kotlin/me.champeau.astro4j.jfxapp.gradle.kts
+++ b/build-logic/src/main/kotlin/me.champeau.astro4j.jfxapp.gradle.kts
@@ -14,7 +14,7 @@ javafx {
 val os = System.getProperty("os.name").lowercase(Locale.ENGLISH)
 val jvmMemorySettings = listOf(
     providers.systemProperty("memory.settings").getOrElse("-XX:MaxRAMPercentage=80"),
-    "-XX:+UseG1GC",
+    "-XX:+UseZGC",
     "-XX:+HeapDumpOnOutOfMemoryError",
     "-XX:+UseCompactObjectHeaders",
     "-Dpolyglotimpl.DisableMultiReleaseCheck=true"

--- a/jserfile/src/main/java/me/champeau/a4j/ser/Frame.java
+++ b/jserfile/src/main/java/me/champeau/a4j/ser/Frame.java
@@ -21,8 +21,15 @@ import java.util.Optional;
 
 /**
  * A single frame data.
- * @param number the frame number (starting from 0)
- * @param data the binary data of the frame
+ *
+ * @param number    the frame number (starting from 0)
+ * @param data      the binary data of the frame. The buffer is a read-only view of
+ *                  the underlying memory-mapped file region; it is invalidated by
+ *                  the next {@link SerFileReader#nextFrame()},
+ *                  {@link SerFileReader#seekFrame(int)} or
+ *                  {@link SerFileReader#close()} call. Callers that need to retain
+ *                  the bytes must copy them explicitly. The buffer is direct
+ *                  (not heap-backed): {@link ByteBuffer#array()} is unsupported.
  * @param timestamp the timestamp
  */
 public record Frame(int number,

--- a/jserfile/src/main/java/me/champeau/a4j/ser/SerFileCloseEvent.java
+++ b/jserfile/src/main/java/me/champeau/a4j/ser/SerFileCloseEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.ser;
+
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+/**
+ * Emitted when {@link SerFileReader#close()} runs. Pairs with
+ * {@link SerFileOpenEvent} via {@code readerId}.
+ */
+@Name("me.champeau.a4j.ser.SerFileClose")
+@Label("SER file close")
+@Category({"jsolex", "I/O"})
+@StackTrace(false)
+public class SerFileCloseEvent extends Event {
+    @Label("Path")
+    public String path;
+
+    @Label("Reader id")
+    public long readerId;
+}

--- a/jserfile/src/main/java/me/champeau/a4j/ser/SerFileOpenEvent.java
+++ b/jserfile/src/main/java/me/champeau/a4j/ser/SerFileOpenEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.ser;
+
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+/**
+ * Emitted when a {@link SerFileReader} maps a SER file. Pair with
+ * {@link SerFileCloseEvent} via {@code readerId} to track reader
+ * lifetimes and concurrent mapping count.
+ */
+@Name("me.champeau.a4j.ser.SerFileOpen")
+@Label("SER file open")
+@Category({"jsolex", "I/O"})
+@StackTrace(true)
+public class SerFileOpenEvent extends Event {
+    @Label("Path")
+    public String path;
+
+    @Label("Reader id")
+    public long readerId;
+
+    @Label("Frame count")
+    public int frameCount;
+
+    @Label("Mapped bytes")
+    public long mappedBytes;
+}

--- a/jserfile/src/main/java/me/champeau/a4j/ser/SerFileReader.java
+++ b/jserfile/src/main/java/me/champeau/a4j/ser/SerFileReader.java
@@ -18,14 +18,17 @@ package me.champeau.a4j.ser;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -37,42 +40,98 @@ import java.util.Optional;
  */
 public class SerFileReader implements AutoCloseable {
     private static final ZoneId UTC = ZoneId.of("UTC");
-    /** The file ID for JSol'Ex trimmed SER files. */
+    /**
+     * The file ID for JSol'Ex trimmed SER files.
+     */
     public static final String JSOLEX_RECORDER = "JSOLEX-TRIMMED";
+
+    /**
+     * Target page size for the sliding-window mmap, in bytes. Each page is
+     * rounded down to a whole-frame boundary so that no frame straddles two
+     * pages. Configurable via {@code -Dme.champeau.a4j.ser.pageSize=<bytes>}.
+     */
+    private static final long PAGE_SIZE_BYTES =
+            Long.getLong("me.champeau.a4j.ser.pageSize", 256L * 1024 * 1024);
+
+    /**
+     * Maximum number of pages kept resident per reader. With the default
+     * page size this caps each reader at ~1 GB of mmap'd file pages instead
+     * of mapping the entire file.
+     */
+    private static final int PAGE_CACHE_SIZE = 4;
 
     private final File backingFile;
     private final RandomAccessFile accessFile;
-    private final ByteBuffer[] imageBuffers;
+    private final FileChannel channel;
+    private final long dataOffset;
     private final ByteBuffer[] timestampsBuffer;
     private final Header header;
-    private final byte[] frameBuffer;
     private final int bytesPerFrame;
-    private final int maxFramesPerBuffer;
+    private final int framesPerPage;
+    private final ByteOrder imageByteOrder;
+    /**
+     * Sliding-window page cache: each entry maps {@code framesPerPage} consecutive
+     * frames. Oldest entries are evicted when the size exceeds {@link #PAGE_CACHE_SIZE}
+     * so that the resident mmap footprint stays bounded regardless of file size.
+     * Single-threaded contract — callers must serialize access (matches the
+     * existing {@code currentFrame}/{@code seekFrame} contract).
+     */
+    private final LinkedHashMap<Integer, MappedByteBuffer> pageCache;
 
     private int previousFrame = -1;
     private int currentFrame = 0;
     private ZonedDateTime currentTimestamp;
     private volatile boolean closed = false;
 
-    /**
-     * Constructs a new SER file reader.
-     *
-     * @param backingFile the backing file
-     * @param accessFile the random access file
-     * @param imageBuffers the image buffers
-     * @param maxFramesPerBuffer the maximum frames per buffer
-     * @param timestampsBuffer the timestamps buffer
-     * @param header the SER file header
-     */
-    private SerFileReader(File backingFile, RandomAccessFile accessFile, ByteBuffer[] imageBuffers, int maxFramesPerBuffer, ByteBuffer timestampsBuffer, Header header) {
+    private SerFileReader(File backingFile,
+                          RandomAccessFile accessFile,
+                          FileChannel channel,
+                          long dataOffset,
+                          int framesPerPage,
+                          ByteOrder imageByteOrder,
+                          ByteBuffer timestampsBuffer,
+                          Header header) {
         this.backingFile = backingFile;
         this.accessFile = accessFile;
-        this.imageBuffers = imageBuffers;
-        this.maxFramesPerBuffer = maxFramesPerBuffer;
+        this.channel = channel;
+        this.dataOffset = dataOffset;
+        this.framesPerPage = framesPerPage;
+        this.imageByteOrder = imageByteOrder;
         this.timestampsBuffer = new ByteBuffer[]{timestampsBuffer};
         this.header = header;
         this.bytesPerFrame = header.geometry().getBytesPerFrame();
-        this.frameBuffer = new byte[bytesPerFrame];
+        this.pageCache = new LinkedHashMap<>(PAGE_CACHE_SIZE + 1, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<Integer, MappedByteBuffer> eldest) {
+                // Eviction frees the strong reference to the MappedByteBuffer; the
+                // Cleaner attached by FileChannel.map will unmap on the next GC.
+                return size() > PAGE_CACHE_SIZE;
+            }
+        };
+    }
+
+    private MappedByteBuffer pageFor(int pageIdx) {
+        var cached = pageCache.get(pageIdx);
+        if (cached != null) {
+            return cached;
+        }
+        long offset = dataOffset + (long) pageIdx * framesPerPage * bytesPerFrame;
+        long maxSize = (long) framesPerPage * bytesPerFrame;
+        long fileSize;
+        try {
+            fileSize = channel.size();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        long size = Math.min(maxSize, fileSize - offset);
+        try {
+            var buf = channel.map(FileChannel.MapMode.READ_ONLY, offset, size);
+            buf.order(imageByteOrder);
+            pageCache.put(pageIdx, buf);
+            return buf;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     /**
@@ -85,20 +144,27 @@ public class SerFileReader implements AutoCloseable {
     }
 
     /**
-     * Gets the current frame.
+     * Gets the current frame. The returned {@link Frame#data()} is a read-only
+     * view of the underlying memory-mapped file region (no heap copy). The view
+     * is invalidated by the next call to {@link #nextFrame()}, {@link #seekFrame(int)}
+     * or {@link #close()}; callers that need to retain the bytes across those
+     * calls must copy them explicitly. Calling {@link ByteBuffer#array()} on the
+     * returned buffer throws {@link UnsupportedOperationException}.
      *
      * @return the current frame
      */
     public Frame currentFrame() {
         assertNotClosed();
         if (previousFrame != currentFrame) {
-            findBuffer().slice().limit(bytesPerFrame).get(frameBuffer);
             if (timestampsBuffer[0] != null) {
                 currentTimestamp = TimestampConverter.of(timestampsBuffer[0].getLong()).map(c -> c.atZone(UTC)).orElse(null);
             }
             previousFrame = currentFrame;
         }
-        return new Frame(currentFrame, ByteBuffer.wrap(frameBuffer), Optional.ofNullable(currentTimestamp));
+        var pageIdx = currentFrame / framesPerPage;
+        var offset = (currentFrame % framesPerPage) * bytesPerFrame;
+        var slice = pageFor(pageIdx).slice(offset, bytesPerFrame).asReadOnlyBuffer();
+        return new Frame(currentFrame, slice, Optional.ofNullable(currentTimestamp));
     }
 
     private void assertNotClosed() {
@@ -107,19 +173,16 @@ public class SerFileReader implements AutoCloseable {
         }
     }
 
-    /** Moves to the next frame. */
+    /**
+     * Moves to the next frame.
+     */
     public void nextFrame() {
         assertNotClosed();
         currentFrame = (currentFrame + 1) % header.frameCount();
-        positionBuffers();
+        positionTimestampBuffer();
     }
 
-    private ByteBuffer findBuffer() {
-        return imageBuffers[currentFrame / maxFramesPerBuffer];
-    }
-
-    private void positionBuffers() {
-        findBuffer().position((currentFrame % maxFramesPerBuffer) * bytesPerFrame);
+    private void positionTimestampBuffer() {
         if (timestampsBuffer[0] != null) {
             timestampsBuffer[0].position(8 * currentFrame);
         }
@@ -133,15 +196,19 @@ public class SerFileReader implements AutoCloseable {
     public void seekFrame(int frameNb) {
         assertNotClosed();
         currentFrame = frameNb % header.frameCount();
-        positionBuffers();
+        positionTimestampBuffer();
     }
 
-    /** Seeks to the last frame. */
+    /**
+     * Seeks to the last frame.
+     */
     public void seekLast() {
         seekFrame(header.frameCount() - 1);
     }
 
-    /** Seeks to the first frame. */
+    /**
+     * Seeks to the first frame.
+     */
     public void seekFirst() {
         seekFrame(0);
     }
@@ -160,7 +227,7 @@ public class SerFileReader implements AutoCloseable {
     /**
      * Opens a SER file for reading.
      *
-     * @param file the file to read
+     * @param file                  the file to read
      * @param trustDeclaredBitDepth if true, the pixel depth declared in the SER header is used as-is
      *                              and the heuristic detection of the actual pixel depth is skipped
      * @return a new SerFileReader
@@ -168,33 +235,22 @@ public class SerFileReader implements AutoCloseable {
      */
     public static SerFileReader of(File file, boolean trustDeclaredBitDepth) throws IOException {
         var tmpReader = createBaseReader(file);
-        if (trustDeclaredBitDepth) {
-            return tmpReader;
-        }
-        return fixReader(tmpReader);
+        var result = trustDeclaredBitDepth ? tmpReader : fixReader(tmpReader);
+        emitOpenEvent(result);
+        return result;
     }
 
     private static SerFileReader createBaseReader(File file) throws IOException {
         RandomAccessFile raf = new RandomAccessFile(file, "r");
         FileChannel channel = raf.getChannel();
         var headerBuffer = channel
-            .map(FileChannel.MapMode.READ_ONLY, 0, Math.min(65536, channel.size()));
+                .map(FileChannel.MapMode.READ_ONLY, 0, Math.min(65536, channel.size()));
         var fileId = readAsciiString(headerBuffer, 14);
         headerBuffer.order(ByteOrder.LITTLE_ENDIAN);
         Header header = readHeader(fileId, headerBuffer);
         long headerLength = headerBuffer.position();
         var bytesPerFrame = header.geometry().getBytesPerFrame();
-        long maxFramesInBuffer = (long) Math.floor(Integer.MAX_VALUE / (double) bytesPerFrame);
-        int numBuffers = (int) Math.ceil(header.frameCount() / (double) maxFramesInBuffer);
-        ByteBuffer[] imageBuffers = new ByteBuffer[numBuffers];
-        long remainingFrameCount = header.frameCount();
-        for (int i = 0; i < numBuffers; i++) {
-            long nFramesInBuffer = Math.min(remainingFrameCount, maxFramesInBuffer);
-            long offset = headerLength + i * maxFramesInBuffer * bytesPerFrame;
-            long size = nFramesInBuffer * bytesPerFrame;
-            imageBuffers[i] = channel.map(FileChannel.MapMode.READ_ONLY, offset, size).order(header.geometry().imageEndian());
-            remainingFrameCount -= maxFramesInBuffer;
-        }
+        int framesPerPage = framesPerPage(bytesPerFrame, header.frameCount());
         boolean hasTimestamps = header.metadata().localDateTime() != null;
         long dataLength = header.frameCount() * (long) bytesPerFrame;
         if (headerLength + dataLength + 8L * header.frameCount() > file.length()) {
@@ -203,8 +259,30 @@ public class SerFileReader implements AutoCloseable {
             header = new Header(fileId, header.camera(), header.geometry(), header.frameCount(), header.metadata().withoutTimestamps());
         }
         ByteBuffer timestampsBuffer = hasTimestamps ? channel.map(FileChannel.MapMode.READ_ONLY, headerLength + dataLength, 8L * header.frameCount()).order(ByteOrder.LITTLE_ENDIAN) : null;
-        var tmpReader = new SerFileReader(file, raf, imageBuffers, (int) maxFramesInBuffer, timestampsBuffer, header);
-        return tmpReader;
+        return new SerFileReader(file, raf, channel, headerLength, framesPerPage, header.geometry().imageEndian(), timestampsBuffer, header);
+    }
+
+    private static int framesPerPage(int bytesPerFrame, int frameCount) {
+        long target = Math.max(PAGE_SIZE_BYTES / bytesPerFrame, 1L);
+        // Guard against pathologically small files.
+        return (int) Math.min(target, Math.max(frameCount, 1));
+    }
+
+    private static void emitOpenEvent(SerFileReader reader) {
+        var event = new SerFileOpenEvent();
+        if (!event.shouldCommit()) {
+            return;
+        }
+        long perPage = (long) reader.framesPerPage * reader.bytesPerFrame;
+        long mapped = perPage * PAGE_CACHE_SIZE;
+        if (reader.timestampsBuffer[0] != null) {
+            mapped += reader.timestampsBuffer[0].capacity();
+        }
+        event.path = reader.backingFile.getAbsolutePath();
+        event.readerId = System.identityHashCode(reader);
+        event.frameCount = reader.header.frameCount();
+        event.mappedBytes = mapped;
+        event.commit();
     }
 
     /**
@@ -266,8 +344,9 @@ public class SerFileReader implements AutoCloseable {
                 return tmpReader;
             }
             var newGeometry = new ImageGeometry(geometry.colorMode(), geometry.width(), geometry.height(), pixelDepth, geometry.imageEndian());
-            return new SerFileReader(tmpReader.backingFile, tmpReader.accessFile, tmpReader.imageBuffers, tmpReader.maxFramesPerBuffer, tmpReader.timestampsBuffer[0],
-                new Header(tmpReader.header.fileId(), tmpReader.header.camera(), newGeometry, tmpReader.header.frameCount(), tmpReader.header.metadata()));
+            var newHeader = new Header(tmpReader.header.fileId(), tmpReader.header.camera(), newGeometry, tmpReader.header.frameCount(), tmpReader.header.metadata());
+            return new SerFileReader(tmpReader.backingFile, tmpReader.accessFile, tmpReader.channel, tmpReader.dataOffset,
+                    tmpReader.framesPerPage, newGeometry.imageEndian(), tmpReader.timestampsBuffer[0], newHeader);
         }
         return tmpReader;
     }
@@ -347,18 +426,18 @@ public class SerFileReader implements AutoCloseable {
             return LocalDateTime.now().atZone(UTC);
         });
         return new Header(
-            fileId,
-            camera,
-            new ImageGeometry(colorMode.get(), imageWidth, imageHeight, pixelDepthPerPlane, imageByteOrder),
-            frameCount,
-            new ImageMetadata(
-                observer,
-                instrument,
-                telescope,
-                localDate != null,
-                localDate,
-                utcDate
-            )
+                fileId,
+                camera,
+                new ImageGeometry(colorMode.get(), imageWidth, imageHeight, pixelDepthPerPlane, imageByteOrder),
+                frameCount,
+                new ImageMetadata(
+                        observer,
+                        instrument,
+                        telescope,
+                        localDate != null,
+                        localDate,
+                        utcDate
+                )
         );
     }
 
@@ -379,9 +458,18 @@ public class SerFileReader implements AutoCloseable {
 
     @Override
     public void close() throws Exception {
+        if (closed) {
+            return;
+        }
         closed = true;
+        var event = new SerFileCloseEvent();
+        if (event.shouldCommit()) {
+            event.path = backingFile.getAbsolutePath();
+            event.readerId = System.identityHashCode(this);
+            event.commit();
+        }
         accessFile.close();
-        Arrays.fill(imageBuffers, null);
+        pageCache.clear();
         timestampsBuffer[0] = null;
     }
 
@@ -402,13 +490,17 @@ public class SerFileReader implements AutoCloseable {
      */
     public SerFileReader reopen() throws IOException {
         var baseReader = createBaseReader(backingFile);
-        return new SerFileReader(
-            baseReader.backingFile,
-            baseReader.accessFile,
-            baseReader.imageBuffers,
-            baseReader.maxFramesPerBuffer,
-            baseReader.timestampsBuffer[0],
-            header
+        var reopened = new SerFileReader(
+                baseReader.backingFile,
+                baseReader.accessFile,
+                baseReader.channel,
+                baseReader.dataOffset,
+                baseReader.framesPerPage,
+                baseReader.imageByteOrder,
+                baseReader.timestampsBuffer[0],
+                header
         );
+        emitOpenEvent(reopened);
+        return reopened;
     }
 }

--- a/jserfile/src/main/java/me/champeau/a4j/ser/bayer/NoOpConverter.java
+++ b/jserfile/src/main/java/me/champeau/a4j/ser/bayer/NoOpConverter.java
@@ -19,10 +19,14 @@ import me.champeau.a4j.ser.ImageGeometry;
 
 import java.nio.ByteBuffer;
 
-/** An image converter that performs no conversion. */
+/**
+ * An image converter that performs no conversion.
+ */
 public class NoOpConverter implements ImageConverter<byte[]> {
 
-    /** Constructs a no-op converter. */
+    /**
+     * Constructs a no-op converter.
+     */
     public NoOpConverter() {
     }
 
@@ -33,6 +37,6 @@ public class NoOpConverter implements ImageConverter<byte[]> {
 
     @Override
     public void convert(int frameId, ByteBuffer frameData, ImageGeometry geometry, byte[] outputData) {
-        System.arraycopy(frameData.array(), 0, outputData, 0, outputData.length);
+        frameData.duplicate().get(outputData, 0, outputData.length);
     }
 }

--- a/jserfile/src/main/java/module-info.java
+++ b/jserfile/src/main/java/module-info.java
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Provides support for reading and writing SER video files. */
+/**
+ * Provides support for reading and writing SER video files.
+ */
 module me.champeau.a4j.jserfile {
     exports me.champeau.a4j.ser;
     exports me.champeau.a4j.ser.bayer;
+    requires jdk.jfr;
 }

--- a/jserfile/src/test/groovy/me/champeau/a4j/ser/SerFileReaderTest.groovy
+++ b/jserfile/src/test/groovy/me/champeau/a4j/ser/SerFileReaderTest.groovy
@@ -30,6 +30,8 @@ class SerFileReaderTest extends Specification {
     @TempDir
     File tempDir
 
+    private File serFilePath
+
     def cleanup() {
         if (serFile != null) {
             serFile.close()
@@ -50,10 +52,63 @@ class SerFileReaderTest extends Specification {
         serFile.header().geometry().pixelDepthPerPlane() == 8
     }
 
+    def "frame data is a read-only view"() {
+        given:
+        readSerFile "Mars_150414_002445_OSC_F0001-0500"
+
+        when:
+        def buffer = serFile.currentFrame().data()
+
+        then:
+        buffer.isReadOnly()
+    }
+
+    def "frame data matches raw file bytes"() {
+        given:
+        readSerFile "Mars_150414_002445_OSC_F0001-0500"
+        def rawBytes = Files.readAllBytes(serFilePath.toPath())
+        int bytesPerFrame = serFile.header().geometry().getBytesPerFrame()
+        int headerLength = rawBytes.length - bytesPerFrame * serFile.header().frameCount() - 8 * serFile.header().frameCount()
+
+        when:
+        serFile.seekFrame(frame)
+        def buffer = serFile.currentFrame().data()
+        byte[] actual = new byte[bytesPerFrame]
+        buffer.get(actual)
+        byte[] expected = new byte[bytesPerFrame]
+        System.arraycopy(rawBytes, headerLength + frame * bytesPerFrame, expected, 0, bytesPerFrame)
+
+        then:
+        actual == expected
+
+        where:
+        frame << [0, 1, 42, 124]
+    }
+
+    def "currentFrame is idempotent and does not mutate buffer state"() {
+        given:
+        readSerFile "Mars_150414_002445_OSC_F0001-0500"
+        int bytesPerFrame = serFile.header().geometry().getBytesPerFrame()
+
+        when:
+        serFile.seekFrame(10)
+        def first = serFile.currentFrame().data()
+        def second = serFile.currentFrame().data()
+        byte[] firstBytes = new byte[bytesPerFrame]
+        first.get(firstBytes)
+        byte[] secondBytes = new byte[bytesPerFrame]
+        second.get(secondBytes)
+
+        then:
+        !first.is(second)
+        firstBytes == secondBytes
+    }
+
     private void readSerFile(String name) {
         SerFileReaderTest.getResourceAsStream("/${name}.ser").withCloseable { stream ->
             def file = new File(tempDir, "${name}.ser")
             Files.copy(stream, file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            serFilePath = file
             serFile = SerFileReader.of(file)
         }
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/color/ColorCurve.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/color/ColorCurve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2023 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,19 +21,88 @@ import me.champeau.a4j.math.tuples.DoubleTriplet;
 import me.champeau.a4j.math.tuples.IntPair;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.DoubleUnaryOperator;
 
-public record ColorCurve(
-        String ray,
-        int rIn, int rOut,
-        int gIn, int gOut,
-        int bIn, int bOut
-) {
-
+/**
+ * A color curve describing how a monochrome pixel value is mapped to RGB.
+ * Each instance precomputes the three polynomials (red, green, blue) once
+ * in the constructor; per-pixel application reads them as plain final-field
+ * loads instead of going through a global cache. This avoids the per-call
+ * {@code IntPair} allocation that the cache lookup would otherwise produce.
+ */
+public final class ColorCurve {
     private static final Map<IntPair, DoubleUnaryOperator> POLYNOMIALS_CACHE = new ConcurrentHashMap<>();
 
     public static final int MAX = 65535;
+
+    private final String ray;
+    private final int rIn;
+    private final int rOut;
+    private final int gIn;
+    private final int gOut;
+    private final int bIn;
+    private final int bOut;
+    private final DoubleUnaryOperator rPoly;
+    private final DoubleUnaryOperator gPoly;
+    private final DoubleUnaryOperator bPoly;
+
+    public ColorCurve(String ray,
+                      int rIn, int rOut,
+                      int gIn, int gOut,
+                      int bIn, int bOut) {
+        this.ray = ray;
+        this.rIn = rIn;
+        this.rOut = rOut;
+        this.gIn = gIn;
+        this.gOut = gOut;
+        this.bIn = bIn;
+        this.bOut = bOut;
+        this.rPoly = cachedPolynomial(rIn << 8, rOut << 8);
+        this.gPoly = cachedPolynomial(gIn << 8, gOut << 8);
+        this.bPoly = cachedPolynomial(bIn << 8, bOut << 8);
+    }
+
+    public String ray() {
+        return ray;
+    }
+
+    public int rIn() {
+        return rIn;
+    }
+
+    public int rOut() {
+        return rOut;
+    }
+
+    public int gIn() {
+        return gIn;
+    }
+
+    public int gOut() {
+        return gOut;
+    }
+
+    public int bIn() {
+        return bIn;
+    }
+
+    public int bOut() {
+        return bOut;
+    }
+
+    public DoubleUnaryOperator rPoly() {
+        return rPoly;
+    }
+
+    public DoubleUnaryOperator gPoly() {
+        return gPoly;
+    }
+
+    public DoubleUnaryOperator bPoly() {
+        return bPoly;
+    }
 
     private static DoubleTriplet polynomialOf(int in, int out) {
         return LinearRegression.secondOrderRegression(
@@ -53,14 +122,10 @@ public record ColorCurve(
         if (grey < 0 || grey > MAX) {
             throw new IllegalArgumentException("Invalid input " + grey + " : input values must be normalized in range [0..65535]");
         }
-        var rPoly = cachedPolynomial(rIn << 8, rOut << 8);
-        var gPoly = cachedPolynomial(gIn << 8, gOut << 8);
-        var bPoly = cachedPolynomial(bIn << 8, bOut << 8);
-        double v = grey;
         return new DoubleTriplet(
-                apply(v, rPoly),
-                apply(v, gPoly),
-                apply(v, bPoly)
+                apply(grey, rPoly),
+                apply(grey, gPoly),
+                apply(grey, bPoly)
         );
     }
 
@@ -73,5 +138,35 @@ public record ColorCurve(
             return MAX;
         }
         return (int) Math.round(x);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ColorCurve other)) {
+            return false;
+        }
+        return rIn == other.rIn
+                && rOut == other.rOut
+                && gIn == other.gIn
+                && gOut == other.gOut
+                && bIn == other.bIn
+                && bOut == other.bOut
+                && Objects.equals(ray, other.ray);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ray, rIn, rOut, gIn, gOut, bIn, bOut);
+    }
+
+    @Override
+    public String toString() {
+        return "ColorCurve[ray=" + ray
+                + ", rIn=" + rIn + ", rOut=" + rOut
+                + ", gIn=" + gIn + ", gOut=" + gOut
+                + ", bIn=" + bIn + ", bOut=" + bOut + ']';
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
@@ -112,7 +112,9 @@ import java.util.stream.Stream;
 
 import static me.champeau.a4j.jsolex.processing.util.Constants.message;
 
-/** Abstract base class for evaluating image processing expressions. */
+/**
+ * Abstract base class for evaluating image processing expressions.
+ */
 public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluator {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractImageExpressionEvaluator.class);
 
@@ -211,9 +213,9 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
     /**
      * Stores a value in the evaluation context.
      *
-     * @param key the class key
+     * @param key   the class key
      * @param value the value to store
-     * @param <T> the type of the key
+     * @param <T>   the type of the key
      */
     public <T> void putInContext(Class<T> key, Object value) {
         context.put(key, value);
@@ -499,7 +501,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
                         // check if there are too many saturated pixels
                         int count = 0;
                         var limit = image.width() * image.height() / 8;
-                        for (int y=0; y < image.height(); y++) {
+                        for (int y = 0; y < image.height(); y++) {
                             for (int x = 0; x < image.width(); x++) {
                                 if (image.data()[y][x] == Constants.MAX_PIXEL_VALUE) {
                                     count++;
@@ -518,7 +520,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
                     })
                     .sorted(Comparator.comparingDouble(ImageWithAverage::average).reversed())
                     .map(ImageWithAverage::image)
-                    .limit((long) (0.8*samplesSize))
+                    .limit((long) (0.8 * samplesSize))
                     .toList();
             if (!list.isEmpty()) {
                 return (ImageWrapper32) functionCall(BuiltinFunction.MEDIAN, Map.of("list", list));
@@ -576,7 +578,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
      * Determines the wavelength of an image from its metadata.
      *
      * @param context the evaluation context
-     * @param image the image
+     * @param image   the image
      * @return the wavelength in angstroms
      */
     public static double determineWavelengthOf(Map<Class<?>, Object> context, ImageWrapper image) {
@@ -639,7 +641,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
     /**
      * Computes the spectral dispersion for the given parameters.
      *
-     * @param params the processing parameters
+     * @param params  the processing parameters
      * @param lambda0 the reference wavelength
      * @return the spectral dispersion
      */
@@ -663,8 +665,8 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
     /**
      * Computes the pixel shift between two wavelengths.
      *
-     * @param params the processing parameters
-     * @param targetWaveLength the target wavelength
+     * @param params              the processing parameters
+     * @param targetWaveLength    the target wavelength
      * @param referenceWavelength the reference wavelength
      * @return the pixel shift value
      */
@@ -711,7 +713,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
      * Computes the average of a stream with sigma clipping.
      *
      * @param doubleStream the stream of values
-     * @param sigma the sigma threshold for clipping
+     * @param sigma        the sigma threshold for clipping
      * @return the clipped average, or empty if the stream is empty
      */
     public static OptionalDouble applySigmaClippedAverage(DoubleStream doubleStream, double sigma) {
@@ -722,14 +724,14 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
         if (array.length == 1) {
             return OptionalDouble.of(array[0]);
         }
-        
+
         // Calculate mean and standard deviation
         double mean = Arrays.stream(array).average().orElse(0.0);
         double stddev = Math.sqrt(Arrays.stream(array)
                 .map(v -> (v - mean) * (v - mean))
                 .average()
                 .orElse(0.0));
-        
+
         // Apply sigma clipping and compute average
         double threshold = sigma * stddev;
         OptionalDouble result = Arrays.stream(array)
@@ -742,7 +744,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
      * Computes the median of a stream with sigma clipping.
      *
      * @param doubleStream the stream of values
-     * @param sigma the sigma threshold for clipping
+     * @param sigma        the sigma threshold for clipping
      * @return the clipped median, or empty if the stream is empty
      */
     public static OptionalDouble applySigmaClippedMedian(DoubleStream doubleStream, double sigma) {
@@ -753,30 +755,30 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
         if (array.length == 1) {
             return OptionalDouble.of(array[0]);
         }
-        
+
         // Calculate mean and standard deviation
         double mean = Arrays.stream(array).average().orElse(0.0);
         double stddev = Math.sqrt(Arrays.stream(array)
                 .map(v -> (v - mean) * (v - mean))
                 .average()
                 .orElse(0.0));
-        
+
         // Apply sigma clipping
         double threshold = sigma * stddev;
         double[] filteredValues = Arrays.stream(array)
                 .filter(v -> Math.abs(v - mean) <= threshold)
                 .toArray();
-        
+
         // If all values were filtered out, return the original mean
         if (filteredValues.length == 0) {
             return OptionalDouble.of(mean);
         }
-        
+
         // If only one value remains, return it
         if (filteredValues.length == 1) {
             return OptionalDouble.of(filteredValues[0]);
         }
-        
+
         // Calculate median of filtered values
         Arrays.sort(filteredValues);
         int length = filteredValues.length;
@@ -821,18 +823,18 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
     /**
      * Applies a binary operator to images and scalars.
      *
-     * @param leftImage the left image operand
-     * @param rightImage the right image operand
-     * @param leftScalar the left scalar operand
+     * @param leftImage   the left image operand
+     * @param rightImage  the right image operand
+     * @param leftScalar  the left scalar operand
      * @param rightScalar the right scalar operand
-     * @param operator the binary operator
+     * @param operator    the binary operator
      * @return the result of the operation
      */
     public static Object applyOperator(ImageWrapper32 leftImage,
-                                        ImageWrapper32 rightImage,
-                                        Number leftScalar,
-                                        Number rightScalar,
-                                        DoubleBinaryOperator operator) {
+                                       ImageWrapper32 rightImage,
+                                       Number leftScalar,
+                                       Number rightScalar,
+                                       DoubleBinaryOperator operator) {
         if (leftImage != null && rightImage != null) {
             var leftData = leftImage.data();
             var rightData = rightImage.data();
@@ -842,7 +844,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
             if (width != rightImage.width() || height != rightImage.height()) {
                 throw new IllegalArgumentException("Both images must have the same dimensions");
             }
-            float[][] result = new float[height][width];
+            var result = new float[height][width];
             float min = 0;
             for (int y = 0; y < height; y++) {
                 for (int x = 0; x < width; x++) {
@@ -862,7 +864,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
             var leftData = leftImage.data();
             var width = leftImage.width();
             var height = leftImage.height();
-            float[][] result = new float[height][width];
+            var result = new float[height][width];
             float min = 0;
             for (int y = 0; y < height; y++) {
                 for (int x = 0; x < width; x++) {
@@ -881,7 +883,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
             var rightData = rightImage.data();
             var width = rightImage.width();
             var height = rightImage.height();
-            float[][] result = new float[height][width];
+            var result = new float[height][width];
             float min = 0;
             for (int y = 0; y < height; y++) {
                 for (int x = 0; x < width; x++) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/DefaultImageScriptExecutor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/DefaultImageScriptExecutor.java
@@ -205,19 +205,19 @@ public class DefaultImageScriptExecutor implements ImageMathScriptExecutor {
         } catch (Exception e) {
             // Capture Python errors and return them as invalid expressions for display
             var invalidExpression = new InvalidExpression(
-                scriptPath.getFileName().toString(),
-                scriptPath.toString(),
-                e
+                    scriptPath.getFileName().toString(),
+                    scriptPath.toString(),
+                    e
             );
             return new ImageMathScriptResult(
-                Map.of(),
-                Map.of(),
-                Map.of(),
-                List.of(invalidExpression),
-                Collections.emptySet(),
-                Collections.emptySet(),
-                Collections.emptySet(),
-                false
+                    Map.of(),
+                    Map.of(),
+                    Map.of(),
+                    List.of(invalidExpression),
+                    Collections.emptySet(),
+                    Collections.emptySet(),
+                    Collections.emptySet(),
+                    false
             );
         } finally {
             if (!isCollectingShifts() && outputLogging) {
@@ -263,14 +263,14 @@ public class DefaultImageScriptExecutor implements ImageMathScriptExecutor {
         }
 
         return new ImageMathScriptResult(
-            imagesByLabel,
-            filesByLabel,
-            valuesByLabel,
-            List.of(),
-            Collections.emptySet(),
-            Collections.emptySet(),
-            Collections.emptySet(),
-            false
+                imagesByLabel,
+                filesByLabel,
+                valuesByLabel,
+                List.of(),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                false
         );
     }
 
@@ -352,19 +352,19 @@ public class DefaultImageScriptExecutor implements ImageMathScriptExecutor {
         } catch (Exception e) {
             // Capture Python errors and return them as invalid expressions for display
             var invalidExpression = new InvalidExpression(
-                "Python script",
-                script.length() > 100 ? script.substring(0, 100) + "..." : script,
-                e
+                    "Python script",
+                    script.length() > 100 ? script.substring(0, 100) + "..." : script,
+                    e
             );
             return new ImageMathScriptResult(
-                Map.of(),
-                Map.of(),
-                Map.of(),
-                List.of(invalidExpression),
-                Collections.emptySet(),
-                Collections.emptySet(),
-                Collections.emptySet(),
-                false
+                    Map.of(),
+                    Map.of(),
+                    Map.of(),
+                    List.of(invalidExpression),
+                    Collections.emptySet(),
+                    Collections.emptySet(),
+                    Collections.emptySet(),
+                    false
             );
         } finally {
             if (!isCollectingShifts() && outputLogging) {
@@ -692,6 +692,16 @@ public class DefaultImageScriptExecutor implements ImageMathScriptExecutor {
     }
 
     private void executeExpressionsInParallel(int index, MemoizingExpressionEvaluator evaluator, List<Assignment> assignments, Set<Assignment> outputAssignments, AtomicInteger cpt, Map<String, ImageWrapper> imagesByLabel, Map<String, FileOutputResult> filesByLabel, Map<String, Object> valuesByLabel, List<InvalidExpression> invalidExpressions, ReentrantLock resultsLock, ProgressOperation progressOperation) {
+        var runtime = Runtime.getRuntime();
+        if (runtime.freeMemory() < 0.2 * runtime.totalMemory()) {
+            LOGGER.debug("Memory pressure detected ({} MB free of {} MB), running {} script assignments sequentially",
+                    runtime.freeMemory() >> 20, runtime.totalMemory() >> 20, assignments.size());
+            for (var assignment : assignments) {
+                var isFromOutputSection = outputAssignments != null && outputAssignments.contains(assignment);
+                executeSingleExpression(index, evaluator, assignment, isFromOutputSection, cpt, imagesByLabel, filesByLabel, valuesByLabel, invalidExpressions, resultsLock, progressOperation);
+            }
+            return;
+        }
         var forkJoinPool = ForkJoinPool.commonPool();
         try {
             forkJoinPool.submit(() -> assignments.parallelStream().forEach(assignment -> {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/ShiftCollectingImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/ShiftCollectingImageExpressionEvaluator.java
@@ -85,7 +85,23 @@ public class ShiftCollectingImageExpressionEvaluator extends ImageExpressionEval
 
     public ImageWrapper findImage(PixelShift shift) {
         shifts.add(shift.pixelShift());
-        return cache.computeIfAbsent(shift, s -> FileBackedImage.wrap(super.findImage(shift)));
+        var cached = cache.get(shift);
+        if (cached != null) {
+            return cached;
+        }
+        var lock = loadLocks.computeIfAbsent(shift, k -> new ReentrantLock());
+        lock.lock();
+        try {
+            cached = cache.get(shift);
+            if (cached != null) {
+                return cached;
+            }
+            var loaded = FileBackedImage.wrap(super.findImage(shift));
+            cache.put(shift, loaded);
+            return loaded;
+        } finally {
+            lock.unlock();
+        }
     }
 
     public Set<Double> getShifts() {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/AbstractFunctionImpl.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/AbstractFunctionImpl.java
@@ -20,6 +20,7 @@ import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.util.FileBackedImage;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
+import me.champeau.a4j.jsolex.processing.util.MemoryAwareStreams;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
 import me.champeau.a4j.math.regression.Ellipse;
 import org.slf4j.Logger;
@@ -36,7 +37,9 @@ import java.util.function.DoubleUnaryOperator;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
-/** Base class for function implementations. */
+/**
+ * Base class for function implementations.
+ */
 class AbstractFunctionImpl {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractFunctionImpl.class);
 
@@ -53,7 +56,7 @@ class AbstractFunctionImpl {
     /**
      * Creates a new function implementation.
      *
-     * @param context the evaluation context
+     * @param context     the evaluation context
      * @param broadcaster the broadcaster for progress events
      */
     protected AbstractFunctionImpl(Map<Class<?>, Object> context, Broadcaster broadcaster) {
@@ -91,7 +94,7 @@ class AbstractFunctionImpl {
      * Gets an ellipse from arguments or context.
      *
      * @param arguments the function arguments
-     * @param key the argument key
+     * @param key       the argument key
      * @return the ellipse, if found
      */
     protected Optional<Ellipse> getEllipse(Map<String, Object> arguments, String key) {
@@ -112,7 +115,7 @@ class AbstractFunctionImpl {
      * Gets a value from the evaluation context.
      *
      * @param type the type to retrieve
-     * @param <T> the type parameter
+     * @param <T>  the type parameter
      * @return the value, if found
      */
     protected <T> Optional<T> getFromContext(Class<T> type) {
@@ -123,9 +126,9 @@ class AbstractFunctionImpl {
      * Gets an argument from the argument map.
      *
      * @param clazz the expected type
-     * @param args the arguments map
-     * @param key the argument key
-     * @param <T> the type parameter
+     * @param args  the arguments map
+     * @param key   the argument key
+     * @param <T>   the type parameter
      * @return the argument value, if found
      */
     protected <T> Optional<T> getArgument(Class<T> clazz, Map<String, Object> args, String key) {
@@ -135,8 +138,8 @@ class AbstractFunctionImpl {
     /**
      * Gets a double argument with default value.
      *
-     * @param arguments the arguments map
-     * @param key the argument key
+     * @param arguments    the arguments map
+     * @param key          the argument key
      * @param defaultValue the default value
      * @return the argument value or default
      */
@@ -150,8 +153,8 @@ class AbstractFunctionImpl {
     /**
      * Gets a float argument with default value.
      *
-     * @param arguments the arguments map
-     * @param key the argument key
+     * @param arguments    the arguments map
+     * @param key          the argument key
      * @param defaultValue the default value
      * @return the argument value or default
      */
@@ -165,7 +168,7 @@ class AbstractFunctionImpl {
     /**
      * Converts an object to a float value.
      *
-     * @param obj the object to convert
+     * @param obj          the object to convert
      * @param defaultValue the default value if obj is null
      * @return the float value
      */
@@ -184,8 +187,8 @@ class AbstractFunctionImpl {
     /**
      * Gets an int argument with default value.
      *
-     * @param arguments the arguments map
-     * @param key the argument key
+     * @param arguments    the arguments map
+     * @param key          the argument key
      * @param defaultValue the default value
      * @return the argument value or default
      */
@@ -199,8 +202,8 @@ class AbstractFunctionImpl {
     /**
      * Gets a string argument with default value.
      *
-     * @param arguments the arguments map
-     * @param key the argument key
+     * @param arguments    the arguments map
+     * @param key          the argument key
      * @param defaultValue the default value
      * @return the argument value or default
      */
@@ -215,8 +218,8 @@ class AbstractFunctionImpl {
      * Gets a boolean argument with default value.
      * Supports both numeric values (0=false, non-zero=true) and string values ("true"/"false").
      *
-     * @param arguments the arguments map
-     * @param key the argument key
+     * @param arguments    the arguments map
+     * @param key          the argument key
      * @param defaultValue the default value
      * @return the argument value or default
      */
@@ -239,7 +242,7 @@ class AbstractFunctionImpl {
      * Gets an argument as a Number.
      *
      * @param arguments the arguments map
-     * @param key the argument key
+     * @param key       the argument key
      * @return the argument value as a Number
      */
     protected Number getAsNumber(Map<String, Object> arguments, String key) {
@@ -256,9 +259,9 @@ class AbstractFunctionImpl {
      * Expands a list argument to process each element in parallel.
      *
      * @param currentFunction the function name
-     * @param key the argument key
-     * @param arguments the arguments map
-     * @param function the function to apply to each element
+     * @param key             the argument key
+     * @param arguments       the arguments map
+     * @param function        the function to apply to each element
      * @return the list of results
      */
     @SuppressWarnings("unchecked")
@@ -275,8 +278,7 @@ class AbstractFunctionImpl {
                 .toList();
         var progress = new AtomicInteger(0);
         var parallelOperation = newOperation("ImageMath: " + currentFunction);
-        var processed = itemsToProcess.stream()
-                .parallel()
+        var processed = MemoryAwareStreams.maybeParallel(itemsToProcess.stream())
                 .map(o -> {
                     var idx = o.idx;
                     var image = o.image;
@@ -307,10 +309,10 @@ class AbstractFunctionImpl {
     /**
      * Applies a transformation to mono images.
      *
-     * @param name the function name
-     * @param key the argument key
+     * @param name      the function name
+     * @param key       the argument key
      * @param arguments the arguments map
-     * @param consumer the image consumer
+     * @param consumer  the image consumer
      * @return the transformed image or list of images
      */
     public Object monoToMonoImageTransformer(String name, String key, Map<String, Object> arguments, ImageConsumer consumer) {
@@ -329,9 +331,9 @@ class AbstractFunctionImpl {
      * Applies a unary function to images.
      *
      * @param arguments the arguments map
-     * @param name the function name
-     * @param key the argument key
-     * @param function the unary function
+     * @param name      the function name
+     * @param key       the argument key
+     * @param function  the unary function
      * @return the transformed image or list of images
      */
     protected Object applyUnary(Map<String, Object> arguments, String name, String key, DoubleUnaryOperator function) {
@@ -349,9 +351,9 @@ class AbstractFunctionImpl {
     /**
      * Applies a unary transformation to images.
      *
-     * @param arguments the arguments map
-     * @param name the function name
-     * @param key the argument key
+     * @param arguments   the arguments map
+     * @param name        the function name
+     * @param key         the argument key
      * @param transformer the mono image transformer
      * @return the transformed image or list of images
      */
@@ -368,10 +370,10 @@ class AbstractFunctionImpl {
      * Applies a binary function to images.
      *
      * @param arguments the arguments map
-     * @param left the left argument key
-     * @param right the right argument key
-     * @param name the function name
-     * @param function the binary function
+     * @param left      the left argument key
+     * @param right     the right argument key
+     * @param name      the function name
+     * @param function  the binary function
      * @return the transformed image or list of images
      */
     protected Object applyBinary(Map<String, Object> arguments, String left, String right, String name, DoubleBinaryOperator function) {
@@ -425,7 +427,9 @@ class AbstractFunctionImpl {
         throw new IllegalStateException("Unexpected image type " + img);
     }
 
-    /** Functional interface for consuming images. */
+    /**
+     * Functional interface for consuming images.
+     */
     @FunctionalInterface
     public interface ImageConsumer {
         /**
@@ -436,15 +440,17 @@ class AbstractFunctionImpl {
         void accept(ImageWrapper image);
     }
 
-    /** Functional interface for transforming mono images. */
+    /**
+     * Functional interface for transforming mono images.
+     */
     @FunctionalInterface
     public interface MonoImageTransformer {
         /**
          * Transforms image data.
          *
-         * @param width the image width
+         * @param width  the image width
          * @param height the image height
-         * @param data the image data
+         * @param data   the image data
          */
         void transform(int width, int height, float[][] data);
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Dedistort.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Dedistort.java
@@ -41,7 +41,7 @@ import me.champeau.a4j.math.image.Image;
 import me.champeau.a4j.math.image.ImageMath;
 import me.champeau.a4j.math.correlation.CorrelationTools;
 import me.champeau.a4j.math.opencl.GPUImageCache;
-import me.champeau.a4j.math.opencl.GPUMemoryBudget;
+import me.champeau.a4j.math.opencl.GPUImageCacheBudget;
 import me.champeau.a4j.math.opencl.OpenCLContext;
 import me.champeau.a4j.math.opencl.OpenCLSupport;
 import me.champeau.a4j.math.tuples.DoublePair;
@@ -649,15 +649,15 @@ public class Dedistort extends AbstractFunctionImpl {
      * correlation steps differ in implementation.
      */
     private DistorsionMap computeDistortionMapWithStrategy(float[][] referenceData,
-                                                            ImageWrapper32 currentImage,
-                                                            int width,
-                                                            int height,
-                                                            int tileSize,
-                                                            double sampling,
-                                                            float signal,
-                                                            SamplingStrategy strategy,
-                                                            String passName,
-                                                            ProgressOperation parent) {
+                                                           ImageWrapper32 currentImage,
+                                                           int width,
+                                                           int height,
+                                                           int tileSize,
+                                                           double sampling,
+                                                           float signal,
+                                                           SamplingStrategy strategy,
+                                                           String passName,
+                                                           ProgressOperation parent) {
         var safeTileSize = Math.max(ABSOLUTE_MIN_TILE_SIZE, tileSize);
 
         var progressOperation = parent.createChild(FIND_CORRESP_MESSAGE);
@@ -680,15 +680,15 @@ public class Dedistort extends AbstractFunctionImpl {
      * Use this when the same positions should be reused across multiple comparisons.
      */
     private DistorsionMap computeDistortionMapWithPositions(float[][] referenceData,
-                                                             ImageWrapper32 currentImage,
-                                                             int width,
-                                                             int height,
-                                                             int tileSize,
-                                                             double sampling,
-                                                             SamplingStrategy strategy,
-                                                             SamplingStrategy.SamplePositions positions,
-                                                             String passName,
-                                                             ProgressOperation progressOperation) {
+                                                            ImageWrapper32 currentImage,
+                                                            int width,
+                                                            int height,
+                                                            int tileSize,
+                                                            double sampling,
+                                                            SamplingStrategy strategy,
+                                                            SamplingStrategy.SamplePositions positions,
+                                                            String passName,
+                                                            ProgressOperation progressOperation) {
         var safeTileSize = Math.max(ABSOLUTE_MIN_TILE_SIZE, tileSize);
         var outputGridStep = strategy.getOutputGridStep(safeTileSize, sampling);
 
@@ -728,12 +728,12 @@ public class Dedistort extends AbstractFunctionImpl {
      * Tiles are grouped by size to ensure GPU batches contain uniform tile sizes.
      */
     private SparseDistortionField computeDisplacementsAtPositions(float[][] referenceData,
-                                                                    float[][] targetData,
-                                                                    int width,
-                                                                    int height,
-                                                                    int baseTileSize,
-                                                                    SamplingStrategy.SamplePositions positions,
-                                                                    ProgressOperation progressOperation) {
+                                                                  float[][] targetData,
+                                                                  int width,
+                                                                  int height,
+                                                                  int baseTileSize,
+                                                                  SamplingStrategy.SamplePositions positions,
+                                                                  ProgressOperation progressOperation) {
         // Verify reference and target are different arrays
         boolean sameData = (referenceData == targetData);
         if (sameData) {
@@ -912,9 +912,9 @@ public class Dedistort extends AbstractFunctionImpl {
     }
 
     private List<DisplacementSample> processBatchToSamples(List<int[]> gridPositions,
-                                                            List<float[][]> refTilesList,
-                                                            List<float[][]> targetTilesList,
-                                                            int tileSize) {
+                                                           List<float[][]> refTilesList,
+                                                           List<float[][]> targetTilesList,
+                                                           int tileSize) {
         var refTiles = refTilesList.toArray(new float[0][][]);
         var targetTiles = targetTilesList.toArray(new float[0][][]);
 
@@ -1096,7 +1096,7 @@ public class Dedistort extends AbstractFunctionImpl {
         boolean useGPUResidentWarping = false;
 
         if (gpuAvailable && iterations > 1) {
-            var budget = new GPUMemoryBudget(context, safeTileSize, 10000);
+            var budget = new GPUImageCacheBudget(context, safeTileSize, 10000);
             int maxResidentImages = budget.maxResidentImages(width, height);
 
             if (maxResidentImages >= imageCount) {
@@ -1119,153 +1119,151 @@ public class Dedistort extends AbstractFunctionImpl {
         }
 
         try {
-        for (int iteration = 0; iteration < iterations; iteration++) {
-            var suffix = iterations > 1 ? " (" + (iteration + 1) + "/" + iterations + ")" : "";
-            LOGGER.debug("Consensus reference iteration {}/{}: computing distortion maps for {} images",
-                    iteration + 1, iterations, imageCount);
-            var computingMessage = message("consensus.reference.computing");
-            broadcaster.broadcast(mainOperation.update((double) iteration / iterations, computingMessage + suffix));
+            for (int iteration = 0; iteration < iterations; iteration++) {
+                var suffix = iterations > 1 ? " (" + (iteration + 1) + "/" + iterations + ")" : "";
+                LOGGER.debug("Consensus reference iteration {}/{}: computing distortion maps for {} images",
+                        iteration + 1, iterations, imageCount);
+                var computingMessage = message("consensus.reference.computing");
+                broadcaster.broadcast(mainOperation.update((double) iteration / iterations, computingMessage + suffix));
 
-            var comparingOperation = mainOperation.createChild(computingMessage);
+                var comparingOperation = mainOperation.createChild(computingMessage);
 
-            // Determine how many comparisons to make per image
-            var comparisonsPerImage = Math.min(imageCount - 1, MAX_CONSENSUS_COMPARISONS);
-            var useSubsampling = comparisonsPerImage < imageCount - 1;
+                // Determine how many comparisons to make per image
+                var comparisonsPerImage = Math.min(imageCount - 1, MAX_CONSENSUS_COMPARISONS);
+                var useSubsampling = comparisonsPerImage < imageCount - 1;
 
-            // For each image, determine which other images to compare with
-            var comparisonsPerSourceImage = new TreeMap<Integer, List<Integer>>();
-            for (int i = 0; i < imageCount; i++) {
-                var targetIndices = new ArrayList<Integer>(imageCount - 1);
-                for (int j = 0; j < imageCount; j++) {
-                    if (j != i) {
-                        targetIndices.add(j);
-                    }
-                }
-
-                if (useSubsampling) {
-                    var random = new Random(42L + i + (long) iteration * imageCount);
-                    Collections.shuffle(targetIndices, random);
-                    targetIndices = new ArrayList<>(targetIndices.subList(0, comparisonsPerImage));
-                }
-
-                comparisonsPerSourceImage.put(i, targetIndices);
-            }
-
-            // Collect directed pairs to compute (i → j means distortion from i's perspective)
-            // We compute BOTH directions so each image uses its own interest points,
-            // except sources whose convergence state is fully frozen.
-            var pairsToCompute = new LinkedHashSet<Long>();
-            int skippedFullyFrozen = 0;
-            for (int i = 0; i < imageCount; i++) {
-                var sourceFrozen = adaptive && perImageConvergence.get(i).fullyFrozen();
-                if (sourceFrozen) {
-                    skippedFullyFrozen++;
-                }
-                for (int j : comparisonsPerSourceImage.get(i)) {
-                    if (!sourceFrozen) {
-                        pairsToCompute.add(encodeDirectedPair(i, j, imageCount));
-                    }
-                    if (!(adaptive && perImageConvergence.get(j).fullyFrozen())) {
-                        pairsToCompute.add(encodeDirectedPair(j, i, imageCount));
-                    }
-                }
-            }
-            if (adaptive && skippedFullyFrozen > 0) {
-                LOGGER.debug("Consensus reference iteration {}: {} fully frozen source images skipped",
-                        iteration + 1, skippedFullyFrozen);
-            }
-            if (pairsToCompute.isEmpty()) {
-                LOGGER.info(message("consensus.reference.all.frozen"), iteration + 1);
-                break;
-            }
-
-            LOGGER.debug("Consensus reference iteration {}: {} directed pairs to compute (from {} comparisons)",
-                    iteration + 1, pairsToCompute.size(),
-                    comparisonsPerSourceImage.values().stream().mapToInt(List::size).sum());
-
-            // Pre-compute interest points for each unique source image
-            var positionsPerSource = new ConcurrentHashMap<Integer, SamplingStrategy.SamplePositions>();
-            var sourceIndices = pairsToCompute.stream()
-                    .mapToInt(pairKey -> (int) (pairKey / imageCount)) // source index from directed pair
-                    .distinct()
-                    .toArray();
-            int finalIteration = iteration;
-            boolean adaptiveFinal = adaptive;
-            Arrays.stream(sourceIndices)
-                    .parallel()
-                    .forEach(srcIdx -> {
-                        var srcData = currentImages.get(srcIdx).data();
-                        var mask = adaptiveFinal ? perImageConvergence.get(srcIdx).buildMask() : null;
-                        var positions = strategy.selectPositions(srcData, width, height, safeTileSize, signal, mask);
-                        positionsPerSource.put(srcIdx, positions);
-
-                        // Save debug image showing interest points when debug logging is enabled
-                        if (LoggerFactory.getLogger(InterestPointSamplingStrategy.class).isDebugEnabled()
-                                && strategy instanceof InterestPointSamplingStrategy) {
-                            var passName = String.format("Iter_%d_Src_%d", finalIteration + 1, srcIdx + 1);
-                            saveInterestPointDebugImage(srcData, positions, width, height, passName);
-
+                // For each image, determine which other images to compare with
+                var comparisonsPerSourceImage = new TreeMap<Integer, List<Integer>>();
+                for (int i = 0; i < imageCount; i++) {
+                    var targetIndices = new ArrayList<Integer>(imageCount - 1);
+                    for (int j = 0; j < imageCount; j++) {
+                        if (j != i) {
+                            targetIndices.add(j);
                         }
-                    });
-            LOGGER.debug("Consensus reference iteration {}: computed interest points for {} source images",
-                    iteration + 1, positionsPerSource.size());
-
-            // Compute distortion maps for unique pairs only
-            var computedMaps = new HashMap<Long, DistorsionMap>();
-            int pairIndex = 0;
-            int totalPairs = pairsToCompute.size();
-            var pairOperation = comparingOperation.createChild(message("consensus.reference.comparing"));
-
-            // Use outer GPU cache if available, otherwise create per-iteration cache for correlation only
-            boolean useGPUResident = gpuAvailable;
-            GPUImageCache iterationCache = null;
-            GPUImageCache effectiveCache = gpuCache; // Use outer cache if GPU-resident warping enabled
-
-            if (useGPUResident && effectiveCache == null) {
-                // Create per-iteration cache for correlation (no cross-iteration warping)
-                var budget = new GPUMemoryBudget(context, safeTileSize, 10000);
-                int maxResidentImages = budget.maxResidentImages(width, height);
-                useGPUResident = maxResidentImages >= 2;
-
-                if (useGPUResident) {
-                    int cacheCapacity = Math.min(maxResidentImages, imageCount);
-                    if (iteration == 0) {
-                        LOGGER.debug("Using GPU-resident image correlation: cache capacity={}/{} images, tileSize={}, multiscale={}, {}",
-                                cacheCapacity, imageCount, safeTileSize, multiscale, budget);
                     }
 
-                    iterationCache = new GPUImageCache(
-                            context,
-                            cacheCapacity,
-                            width,
-                            height,
-                            idx -> flattenImageData(currentImages.get(idx).data())
-                    );
-                    effectiveCache = iterationCache;
-                } else if (iteration == 0) {
-                    LOGGER.debug("GPU memory insufficient for resident images (max={}, need>=2)", maxResidentImages);
+                    if (useSubsampling) {
+                        var random = new Random(42L + i + (long) iteration * imageCount);
+                        Collections.shuffle(targetIndices, random);
+                        targetIndices = new ArrayList<>(targetIndices.subList(0, comparisonsPerImage));
+                    }
+
+                    comparisonsPerSourceImage.put(i, targetIndices);
                 }
-            } else if (!gpuAvailable && iteration == 0) {
-                if (context == null) {
-                    LOGGER.debug("GPU not available, using CPU correlation");
-                } else {
-                    LOGGER.debug("GPU-resident correlation requires tile size 32, 64, or 128, using CPU (tile size={})", safeTileSize);
+
+                // Collect directed pairs to compute (i → j means distortion from i's perspective)
+                // We compute BOTH directions so each image uses its own interest points,
+                // except sources whose convergence state is fully frozen.
+                var pairsToCompute = new LinkedHashSet<Long>();
+                int skippedFullyFrozen = 0;
+                for (int i = 0; i < imageCount; i++) {
+                    var sourceFrozen = adaptive && perImageConvergence.get(i).fullyFrozen();
+                    if (sourceFrozen) {
+                        skippedFullyFrozen++;
+                    }
+                    for (int j : comparisonsPerSourceImage.get(i)) {
+                        if (!sourceFrozen) {
+                            pairsToCompute.add(encodeDirectedPair(i, j, imageCount));
+                        }
+                        if (!(adaptive && perImageConvergence.get(j).fullyFrozen())) {
+                            pairsToCompute.add(encodeDirectedPair(j, i, imageCount));
+                        }
+                    }
                 }
-            }
+                if (adaptive && skippedFullyFrozen > 0) {
+                    LOGGER.debug("Consensus reference iteration {}: {} fully frozen source images skipped",
+                            iteration + 1, skippedFullyFrozen);
+                }
+                if (pairsToCompute.isEmpty()) {
+                    LOGGER.info(message("consensus.reference.all.frozen"), iteration + 1);
+                    break;
+                }
 
-            try {
-                GPUImageCache finalGpuCache = effectiveCache;
+                LOGGER.debug("Consensus reference iteration {}: {} directed pairs to compute (from {} comparisons)",
+                        iteration + 1, pairsToCompute.size(),
+                        comparisonsPerSourceImage.values().stream().mapToInt(List::size).sum());
 
-                if (useGPUResident) {
-                    // GPU-resident path: process ALL pairs in one lock session
-                    // This eliminates per-pair lock overhead (100-300 lock calls → 1 call)
-                    var outputGridStep = strategy.getOutputGridStep(safeTileSize, sampling);
-                    int finalPairIndex = pairIndex;
+                // Pre-compute interest points for each unique source image
+                var positionsPerSource = new ConcurrentHashMap<Integer, SamplingStrategy.SamplePositions>();
+                var sourceIndices = pairsToCompute.stream()
+                        .mapToInt(pairKey -> (int) (pairKey / imageCount)) // source index from directed pair
+                        .distinct()
+                        .toArray();
+                int finalIteration = iteration;
+                boolean adaptiveFinal = adaptive;
+                Arrays.stream(sourceIndices)
+                        .parallel()
+                        .forEach(srcIdx -> {
+                            var srcData = currentImages.get(srcIdx).data();
+                            var mask = adaptiveFinal ? perImageConvergence.get(srcIdx).buildMask() : null;
+                            var positions = strategy.selectPositions(srcData, width, height, safeTileSize, signal, mask);
+                            positionsPerSource.put(srcIdx, positions);
 
-                    var gpuResults = context.executeWithLock(() -> {
-                        var results = new HashMap<Long, DistorsionMap>();
+                            // Save debug image showing interest points when debug logging is enabled
+                            if (LoggerFactory.getLogger(InterestPointSamplingStrategy.class).isDebugEnabled()
+                                    && strategy instanceof InterestPointSamplingStrategy) {
+                                var passName = String.format("Iter_%d_Src_%d", finalIteration + 1, srcIdx + 1);
+                                saveInterestPointDebugImage(srcData, positions, width, height, passName);
+
+                            }
+                        });
+                LOGGER.debug("Consensus reference iteration {}: computed interest points for {} source images",
+                        iteration + 1, positionsPerSource.size());
+
+                // Compute distortion maps for unique pairs only
+                var computedMaps = new HashMap<Long, DistorsionMap>();
+                int pairIndex = 0;
+                int totalPairs = pairsToCompute.size();
+                var pairOperation = comparingOperation.createChild(message("consensus.reference.comparing"));
+
+                // Use outer GPU cache if available, otherwise create per-iteration cache for correlation only
+                boolean useGPUResident = gpuAvailable;
+                GPUImageCache iterationCache = null;
+                GPUImageCache effectiveCache = gpuCache; // Use outer cache if GPU-resident warping enabled
+
+                if (useGPUResident && effectiveCache == null) {
+                    // Create per-iteration cache for correlation (no cross-iteration warping)
+                    var budget = new GPUImageCacheBudget(context, safeTileSize, 10000);
+                    int maxResidentImages = budget.maxResidentImages(width, height);
+                    useGPUResident = maxResidentImages >= 2;
+
+                    if (useGPUResident) {
+                        int cacheCapacity = Math.min(maxResidentImages, imageCount);
+                        if (iteration == 0) {
+                            LOGGER.debug("Using GPU-resident image correlation: cache capacity={}/{} images, tileSize={}, multiscale={}, {}",
+                                    cacheCapacity, imageCount, safeTileSize, multiscale, budget);
+                        }
+
+                        iterationCache = new GPUImageCache(
+                                context,
+                                cacheCapacity,
+                                width,
+                                height,
+                                idx -> flattenImageData(currentImages.get(idx).data())
+                        );
+                        effectiveCache = iterationCache;
+                    } else if (iteration == 0) {
+                        LOGGER.debug("GPU memory insufficient for resident images (max={}, need>=2)", maxResidentImages);
+                    }
+                } else if (!gpuAvailable && iteration == 0) {
+                    if (context == null) {
+                        LOGGER.debug("GPU not available, using CPU correlation");
+                    } else {
+                        LOGGER.debug("GPU-resident correlation requires tile size 32, 64, or 128, using CPU (tile size={})", safeTileSize);
+                    }
+                }
+
+                try {
+                    GPUImageCache finalGpuCache = effectiveCache;
+
+                    if (useGPUResident) {
+                        // GPU-resident path: process ALL pairs in one lock session
+                        // This eliminates per-pair lock overhead (100-300 lock calls → 1 call)
+                        var outputGridStep = strategy.getOutputGridStep(safeTileSize, sampling);
+                        int finalPairIndex = pairIndex;
+
+                        var gpuResults = new HashMap<Long, DistorsionMap>();
                         int localPairIndex = finalPairIndex;
-
                         for (long pairKey : pairsToCompute) {
                             int i = (int) (pairKey / imageCount);
                             int j = (int) (pairKey % imageCount);
@@ -1278,7 +1276,7 @@ public class Dedistort extends AbstractFunctionImpl {
                             long refBuffer = finalGpuCache.getImage(i);
                             long targetBuffer = finalGpuCache.getImage(j);
 
-                            // Get CPU data for fallback on unsupported tile sizes
+                            // CPU data kept for fallback on unsupported tile sizes
                             var refData = currentImages.get(i).data();
                             var targetDataArray = currentImages.get(j).data();
 
@@ -1287,151 +1285,149 @@ public class Dedistort extends AbstractFunctionImpl {
                                     refData, targetDataArray,
                                     width, height, safeTileSize, positions);
 
-                            results.put(pairKey, sparseField.toRegularGrid(outputGridStep));
+                            gpuResults.put(pairKey, sparseField.toRegularGrid(outputGridStep));
                             localPairIndex++;
                         }
-                        return results;
-                    });
 
-                    computedMaps.putAll(gpuResults);
-                    pairIndex += pairsToCompute.size();
-                } else {
-                    // CPU path: process pairs in parallel
-                    var cpuResults = new ConcurrentHashMap<Long, DistorsionMap>();
-                    var progress = new AtomicInteger(0);
-                    var pairList = new ArrayList<>(pairsToCompute);
-                    pairList.stream()
-                            .parallel()
-                            .forEach(pairKey -> {
-                                int i = (int) (pairKey / imageCount);
-                                int j = (int) (pairKey % imageCount);
+                        computedMaps.putAll(gpuResults);
+                        pairIndex += pairsToCompute.size();
+                    } else {
+                        // CPU path: process pairs in parallel
+                        var cpuResults = new ConcurrentHashMap<Long, DistorsionMap>();
+                        var progress = new AtomicInteger(0);
+                        var pairList = new ArrayList<>(pairsToCompute);
+                        pairList.stream()
+                                .parallel()
+                                .forEach(pairKey -> {
+                                    int i = (int) (pairKey / imageCount);
+                                    int j = (int) (pairKey % imageCount);
 
-                                var sourceImage = currentImages.get(i);
-                                var targetImage = currentImages.get(j);
-                                var positions = positionsPerSource.get(i);
+                                    var sourceImage = currentImages.get(i);
+                                    var targetImage = currentImages.get(j);
+                                    var positions = positionsPerSource.get(i);
 
-                                var passName = String.format("Iter %d - Pair %d→%d (tile=%d, %s)",
-                                        finalIteration + 1, i + 1, j + 1, tileSize, strategy.getName());
-                                var pairMap = computeDistortionMapWithPositions(sourceImage.data(), targetImage, width, height,
-                                        tileSize, sampling, strategy, positions, passName, pairOperation);
+                                    var passName = String.format("Iter %d - Pair %d→%d (tile=%d, %s)",
+                                            finalIteration + 1, i + 1, j + 1, tileSize, strategy.getName());
+                                    var pairMap = computeDistortionMapWithPositions(sourceImage.data(), targetImage, width, height,
+                                            tileSize, sampling, strategy, positions, passName, pairOperation);
 
-                                cpuResults.put(pairKey, pairMap);
-                                var currentProgress = progress.incrementAndGet();
-                                broadcaster.broadcast(pairOperation.update((double) currentProgress / totalPairs,
-                                        String.format("Pair %d/%d", currentProgress, totalPairs)));
-                            });
-                    computedMaps.putAll(cpuResults);
-                    pairIndex += pairsToCompute.size();
+                                    cpuResults.put(pairKey, pairMap);
+                                    var currentProgress = progress.incrementAndGet();
+                                    broadcaster.broadcast(pairOperation.update((double) currentProgress / totalPairs,
+                                            String.format("Pair %d/%d", currentProgress, totalPairs)));
+                                });
+                        computedMaps.putAll(cpuResults);
+                        pairIndex += pairsToCompute.size();
+                    }
+
+                    if (finalGpuCache != null) {
+                        LOGGER.debug("GPU image cache stats: {}", finalGpuCache);
+                    }
+                } finally {
+                    // Clean up only per-iteration cache (outer cache is cleaned up in outer finally)
+                    if (iterationCache != null) {
+                        iterationCache.close();
+                    }
                 }
+                broadcaster.broadcast(pairOperation.complete());
 
-                if (finalGpuCache != null) {
-                    LOGGER.debug("GPU image cache stats: {}", finalGpuCache);
-                }
-            } finally {
-                // Clean up only per-iteration cache (outer cache is cleaned up in outer finally)
-                if (iterationCache != null) {
-                    context.executeWithLock(iterationCache::close);
-                }
-            }
-            broadcaster.broadcast(pairOperation.complete());
-
-            // For each image, gather maps and compute average
-            // Each map is now computed directly (i → j uses i's interest points)
-            var iterationMaps = new ArrayList<DistorsionMap>(imageCount);
-            DistorsionMap referenceShapeMap = computedMaps.values().stream().findFirst().orElse(null);
-            for (int i = 0; i < imageCount; i++) {
-                var sourceFrozen = adaptive && perImageConvergence.get(i).fullyFrozen();
-                DistorsionMap imageToTruth;
-                if (sourceFrozen) {
-                    // Fully frozen image: no source pairs were computed; emit a zero
-                    // correction map shaped like any existing computed map.
-                    var shape = referenceShapeMap;
-                    imageToTruth = new DistorsionMap(width, height,
-                            shape != null ? shape.getTileSize() : tileSize,
-                            shape != null ? shape.getStep() : Math.max(MIN_STEP, (int) (tileSize * sampling)));
-                } else {
-                    var mapsToOthers = new ArrayList<DistorsionMap>(comparisonsPerImage);
-                    for (int j : comparisonsPerSourceImage.get(i)) {
-                        long pairKey = encodeDirectedPair(i, j, imageCount);
-                        var map = computedMaps.get(pairKey);
-                        if (map != null) {
-                            mapsToOthers.add(map);
+                // For each image, gather maps and compute average
+                // Each map is now computed directly (i → j uses i's interest points)
+                var iterationMaps = new ArrayList<DistorsionMap>(imageCount);
+                DistorsionMap referenceShapeMap = computedMaps.values().stream().findFirst().orElse(null);
+                for (int i = 0; i < imageCount; i++) {
+                    var sourceFrozen = adaptive && perImageConvergence.get(i).fullyFrozen();
+                    DistorsionMap imageToTruth;
+                    if (sourceFrozen) {
+                        // Fully frozen image: no source pairs were computed; emit a zero
+                        // correction map shaped like any existing computed map.
+                        var shape = referenceShapeMap;
+                        imageToTruth = new DistorsionMap(width, height,
+                                shape != null ? shape.getTileSize() : tileSize,
+                                shape != null ? shape.getStep() : Math.max(MIN_STEP, (int) (tileSize * sampling)));
+                    } else {
+                        var mapsToOthers = new ArrayList<DistorsionMap>(comparisonsPerImage);
+                        for (int j : comparisonsPerSourceImage.get(i)) {
+                            long pairKey = encodeDirectedPair(i, j, imageCount);
+                            var map = computedMaps.get(pairKey);
+                            if (map != null) {
+                                mapsToOthers.add(map);
+                            }
                         }
-                    }
 
-                    // Average: average(image[i] → image[j]) ≈ -d_i (negative of image[i]'s distortion)
-                    // So we negate to get the correction: image[i] → truth ≈ d_i
-                    var avgMap = DistorsionMap.average(mapsToOthers);
+                        // Average: average(image[i] → image[j]) ≈ -d_i (negative of image[i]'s distortion)
+                        // So we negate to get the correction: image[i] → truth ≈ d_i
+                        var avgMap = DistorsionMap.average(mapsToOthers);
+                        if (adaptive) {
+                            perImageConvergence.get(i).applyFreezeMaskInPlace(avgMap);
+                        }
+                        imageToTruth = avgMap.negate();
+                    }
+                    iterationMaps.add(imageToTruth);
                     if (adaptive) {
-                        perImageConvergence.get(i).applyFreezeMaskInPlace(avgMap);
+                        perImageConvergence.get(i).update(imageToTruth, iteration);
                     }
-                    imageToTruth = avgMap.negate();
+                    LOGGER.debug("Consensus reference iteration {}: image {}: toTruth distortion={}, frozenFraction={}",
+                            iteration + 1, i, imageToTruth.totalDistorsion(),
+                            adaptive ? String.format("%.2f", perImageConvergence.get(i).frozenFraction()) : "n/a");
                 }
-                iterationMaps.add(imageToTruth);
-                if (adaptive) {
-                    perImageConvergence.get(i).update(imageToTruth, iteration);
-                }
-                LOGGER.debug("Consensus reference iteration {}: image {}: toTruth distortion={}, frozenFraction={}",
-                        iteration + 1, i, imageToTruth.totalDistorsion(),
-                        adaptive ? String.format("%.2f", perImageConvergence.get(i).frozenFraction()) : "n/a");
-            }
-            broadcaster.broadcast(comparingOperation.complete());
+                broadcaster.broadcast(comparingOperation.complete());
 
-            // Check convergence: stop if distortion increased or improvement below threshold
-            var totalDistortion = iterationMaps.stream()
-                    .mapToDouble(DistorsionMap::totalDistorsion)
-                    .sum();
-            var avgDistortion = iterationMaps.isEmpty() ? 0 : totalDistortion / iterationMaps.size();
-            var relativeImprovement = previousAvgDistortion > 0
-                    ? (previousAvgDistortion - avgDistortion) / previousAvgDistortion
-                    : 1.0;
-
-            LOGGER.info(message("consensus.reference.iteration.summary"),
-                    iteration + 1,
-                    String.format("%.2f", avgDistortion),
-                    String.format("%.2f", relativeImprovement * 100));
-
-            if (adaptive) {
-                var avgFrozenFraction = perImageConvergence.stream()
-                        .mapToDouble(TileConvergenceState::frozenFraction)
-                        .average()
-                        .orElse(0);
-                var fullyFrozenCount = (int) perImageConvergence.stream()
-                        .filter(TileConvergenceState::fullyFrozen)
-                        .count();
-                var totalPositions = positionsPerSource.values().stream()
-                        .mapToInt(SamplingStrategy.SamplePositions::count)
+                // Check convergence: stop if distortion increased or improvement below threshold
+                var totalDistortion = iterationMaps.stream()
+                        .mapToDouble(DistorsionMap::totalDistorsion)
                         .sum();
-                LOGGER.info(message("consensus.reference.adaptive.summary"),
-                        iteration + 1,
-                        String.format("%.2f", totalDistortion),
-                        String.format("%.1f", avgFrozenFraction * 100),
-                        fullyFrozenCount, imageCount,
-                        pairsToCompute.size(),
-                        totalPositions);
-            }
+                var avgDistortion = iterationMaps.isEmpty() ? 0 : totalDistortion / iterationMaps.size();
+                var relativeImprovement = previousAvgDistortion > 0
+                        ? (previousAvgDistortion - avgDistortion) / previousAvgDistortion
+                        : 1.0;
 
-            if (avgDistortion > previousAvgDistortion) {
-                LOGGER.warn(message("consensus.reference.distortion.increased"), iteration + 1, avgDistortion, previousAvgDistortion);
-                break;
-            }
-            if (relativeImprovement < CONVERGENCE_THRESHOLD && iteration > 0) {
-                LOGGER.info(message("consensus.reference.converged"), iteration + 1, String.format("%.2f", relativeImprovement * 100), CONVERGENCE_THRESHOLD * 100);
+                LOGGER.info(message("consensus.reference.iteration.summary"),
+                        iteration + 1,
+                        String.format("%.2f", avgDistortion),
+                        String.format("%.2f", relativeImprovement * 100));
+
+                if (adaptive) {
+                    var avgFrozenFraction = perImageConvergence.stream()
+                            .mapToDouble(TileConvergenceState::frozenFraction)
+                            .average()
+                            .orElse(0);
+                    var fullyFrozenCount = (int) perImageConvergence.stream()
+                            .filter(TileConvergenceState::fullyFrozen)
+                            .count();
+                    var totalPositions = positionsPerSource.values().stream()
+                            .mapToInt(SamplingStrategy.SamplePositions::count)
+                            .sum();
+                    LOGGER.info(message("consensus.reference.adaptive.summary"),
+                            iteration + 1,
+                            String.format("%.2f", totalDistortion),
+                            String.format("%.1f", avgFrozenFraction * 100),
+                            fullyFrozenCount, imageCount,
+                            pairsToCompute.size(),
+                            totalPositions);
+                }
+
+                if (avgDistortion > previousAvgDistortion) {
+                    LOGGER.warn(message("consensus.reference.distortion.increased"), iteration + 1, avgDistortion, previousAvgDistortion);
+                    break;
+                }
+                if (relativeImprovement < CONVERGENCE_THRESHOLD && iteration > 0) {
+                    LOGGER.info(message("consensus.reference.converged"), iteration + 1, String.format("%.2f", relativeImprovement * 100), CONVERGENCE_THRESHOLD * 100);
+                    warpImagesAfterIteration(iterationMaps, accumulatedMaps, currentImages, mainOperation,
+                            height, width, imageCount, useGPUResidentWarping, gpuCache, context);
+                    break;
+                }
+
+                previousAvgDistortion = avgDistortion;
+
+                // Warp each image and accumulate its distortion map
                 warpImagesAfterIteration(iterationMaps, accumulatedMaps, currentImages, mainOperation,
                         height, width, imageCount, useGPUResidentWarping, gpuCache, context);
-                break;
             }
-
-            previousAvgDistortion = avgDistortion;
-
-            // Warp each image and accumulate its distortion map
-            warpImagesAfterIteration(iterationMaps, accumulatedMaps, currentImages, mainOperation,
-                    height, width, imageCount, useGPUResidentWarping, gpuCache, context);
-        }
         } finally {
             // Clean up outer GPU cache (used for cross-iteration warping)
             if (gpuCache != null) {
-                context.executeWithLock(gpuCache::close);
+                gpuCache.close();
             }
         }
 
@@ -1463,18 +1459,18 @@ public class Dedistort extends AbstractFunctionImpl {
      * Uses GPU-resident warping when available (all images fit in cache).
      */
     private void warpImagesAfterIteration(List<DistorsionMap> iterationMaps,
-                                           List<DistorsionMaps> accumulatedMaps,
-                                           List<ImageWrapper32> currentImages,
-                                           ProgressOperation mainOperation,
-                                           int height,
-                                           int width,
-                                           int imageCount,
-                                           boolean useGPUResidentWarping,
-                                           GPUImageCache gpuCache,
-                                           OpenCLContext context) {
+                                          List<DistorsionMaps> accumulatedMaps,
+                                          List<ImageWrapper32> currentImages,
+                                          ProgressOperation mainOperation,
+                                          int height,
+                                          int width,
+                                          int imageCount,
+                                          boolean useGPUResidentWarping,
+                                          GPUImageCache gpuCache,
+                                          OpenCLContext context) {
         if (useGPUResidentWarping && gpuCache != null && context != null) {
             // GPU-resident warping: warp all images on GPU and update cache buffers
-            context.executeWithLock(() -> {
+            {
                 for (int i = 0; i < imageCount; i++) {
                     var map = iterationMaps.get(i);
                     accumulatedMaps.set(i, accumulatedMaps.get(i).append(map));
@@ -1499,7 +1495,7 @@ public class Dedistort extends AbstractFunctionImpl {
                         currentImages.set(i, new ImageWrapper32(width, height, warpedData, MutableMap.of()));
                     }
                 }
-            });
+            }
             LOGGER.debug("GPU-resident warping completed for {} images", imageCount);
         } else {
             // CPU warping: process images in parallel
@@ -1540,14 +1536,14 @@ public class Dedistort extends AbstractFunctionImpl {
      * Falls back to CPU correlation for tile sizes not supported by GPU (e.g., 256).
      */
     private SparseDistortionField computeDisplacementsGPUResident(OpenCLContext context,
-                                                                   long refImageBuffer,
-                                                                   long targetImageBuffer,
-                                                                   float[][] refData,
-                                                                   float[][] targetData,
-                                                                   int width,
-                                                                   int height,
-                                                                   int baseTileSize,
-                                                                   SamplingStrategy.SamplePositions positions) {
+                                                                  long refImageBuffer,
+                                                                  long targetImageBuffer,
+                                                                  float[][] refData,
+                                                                  float[][] targetData,
+                                                                  int width,
+                                                                  int height,
+                                                                  int baseTileSize,
+                                                                  SamplingStrategy.SamplePositions positions) {
         int numPositions = positions.count();
         if (numPositions == 0) {
             return SparseDistortionField.builder(width, height)
@@ -1653,11 +1649,11 @@ public class Dedistort extends AbstractFunctionImpl {
      * Extracts tiles at the given positions and correlates using the CPU strategy.
      */
     private float[][] correlateTilesCPU(float[][] refData,
-                                         float[][] targetData,
-                                         int width,
-                                         int height,
-                                         int[][] positions,
-                                         int tileSize) {
+                                        float[][] targetData,
+                                        int width,
+                                        int height,
+                                        int[][] positions,
+                                        int tileSize) {
         int tileOffset = tileSize / 2;
         var refTiles = new ArrayList<float[][]>(positions.length);
         var targetTiles = new ArrayList<float[][]>(positions.length);
@@ -1711,10 +1707,10 @@ public class Dedistort extends AbstractFunctionImpl {
     }
 
     private void saveInterestPointDebugImage(float[][] referenceData,
-                                              SamplingStrategy.SamplePositions positions,
-                                              int width,
-                                              int height,
-                                              String passName) {
+                                             SamplingStrategy.SamplePositions positions,
+                                             int width,
+                                             int height,
+                                             String passName) {
         try {
             var debugData = InterestPointSamplingStrategy.createDebugImage(referenceData, positions, width, height);
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ImageDraw.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ImageDraw.java
@@ -40,6 +40,7 @@ import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferInt;
 import java.awt.image.DataBufferUShort;
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;
@@ -568,19 +569,20 @@ public class ImageDraw extends AbstractFunctionImpl {
 
     /**
      * Draws distance scale for prominences outside the solar limb
-     * @param g the graphics context
+     *
+     * @param g       the graphics context
      * @param centerX the center X coordinate of the sun
      * @param centerY the center Y coordinate of the sun
-     * @param radius the radius of the sun in pixels
+     * @param radius  the radius of the sun in pixels
      */
     private void drawProminenceDistanceScale(Graphics2D g,
                                              double centerX,
                                              double centerY,
                                              double radius,
                                              double labelAngleOffset) {
-        var originalFont      = g.getFont();
-        var originalColor     = g.getColor();
-        var originalStroke    = g.getStroke();
+        var originalFont = g.getFont();
+        var originalColor = g.getColor();
+        var originalStroke = g.getStroke();
         var originalTransform = g.getTransform();
 
         g.setFont(originalFont);
@@ -610,7 +612,7 @@ public class ImageDraw extends AbstractFunctionImpl {
                 var distanceText = String.format("%,d km", distanceKm).replace(",", " ");
                 var labelX = centerX + Math.cos(labelAngle) * circleRadius;
                 var labelY = centerY + Math.sin(labelAngle) * circleRadius;
-                
+
                 var tangentAngle = labelAngle + Math.PI / 2;
 
                 var saved = g.getTransform();
@@ -848,22 +850,60 @@ public class ImageDraw extends AbstractFunctionImpl {
     }
 
     private static BufferedImage toBufferedImage(int width, int height, float[][] r, float[][] g, float[][] b) {
-        BufferedImage image;
-        image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-        int[] rgbArray = new int[width * height];
-        for (int x = 0; x < width; x++) {
-            for (int y = 0; y < height; y++) {
-                int rv = round(r[y][x]);
-                int gv = round(g[y][x]);
-                int bv = round(b[y][x]);
-                rv = (rv >> 8) & 0xFF;
-                gv = (gv >> 8) & 0xFF;
-                bv = (bv >> 8) & 0xFF;
-                rgbArray[y * width + x] = (rv << 16) | (gv << 8) | bv;
+        var image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        var rgbArray = ((DataBufferInt) image.getRaster().getDataBuffer()).getData();
+        for (int y = 0; y < height; y++) {
+            var rRow = r[y];
+            var gRow = g[y];
+            var bRow = b[y];
+            int rowOffset = y * width;
+            for (int x = 0; x < width; x++) {
+                int rv = (round(rRow[x]) >> 8) & 0xFF;
+                int gv = (round(gRow[x]) >> 8) & 0xFF;
+                int bv = (round(bRow[x]) >> 8) & 0xFF;
+                rgbArray[rowOffset + x] = (rv << 16) | (gv << 8) | bv;
             }
         }
-        image.setRGB(0, 0, width, height, rgbArray, 0, width);
         return image;
+    }
+
+    /**
+     * Renders {@code consumer}'s annotations into {@code rgb}'s float buffers
+     * in place, returning the same instance. Caller must own the float arrays
+     * and not need them in their original form afterwards. Used by emission
+     * paths that allocate fresh r/g/b inside a converter and would otherwise
+     * round-trip them through {@link Loader#toImageWrapper} just to pick up
+     * a few painted pixels.
+     */
+    public static RGBImage drawOnImageInPlace(RGBImage rgb, BiConsumer<? super Graphics2D, ? super ImageWrapper> consumer) {
+        if (rgb.width() == 0 || rgb.height() == 0) {
+            return rgb;
+        }
+        int width = rgb.width();
+        int height = rgb.height();
+        var image = toBufferedImage(width, height, rgb.r(), rgb.g(), rgb.b());
+        var g2 = image.createGraphics();
+        int greyValue = Math.clamp((80L * maxValue(rgb)) / 100, 0, 255);
+        g2.setColor(new Color(greyValue, greyValue, greyValue));
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        consumer.accept(g2, rgb);
+        var rendered = ((DataBufferInt) image.getRaster().getDataBuffer()).getData();
+        var rArr = rgb.r();
+        var gArr = rgb.g();
+        var bArr = rgb.b();
+        for (int y = 0; y < height; y++) {
+            var rRow = rArr[y];
+            var gRow = gArr[y];
+            var bRow = bArr[y];
+            int rowOffset = y * width;
+            for (int x = 0; x < width; x++) {
+                int pixel = rendered[rowOffset + x];
+                rRow[x] = ((pixel >> 16) & 0xFF) << 8;
+                gRow[x] = ((pixel >> 8) & 0xFF) << 8;
+                bRow[x] = (pixel & 0xFF) << 8;
+            }
+        }
+        return rgb;
     }
 
     private static Coordinates ofSpherical(double ascension, double declination, double radius) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/LaplacianPyramidBlend.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/LaplacianPyramidBlend.java
@@ -15,6 +15,7 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
+
 /**
  * Multi-band image blender using Burt &amp; Adelson Laplacian pyramids.
  * Combines two images according to a soft float mask in {@code [0,1]}
@@ -47,10 +48,10 @@ public final class LaplacianPyramidBlend {
      * A mask value of {@code 0} selects {@code a}, {@code 1} selects {@code b},
      * intermediate values yield a multi-band feathered transition.
      *
-     * @param a        base image
-     * @param b        image to composite over {@code a}
-     * @param mask     per-pixel weight in {@code [0,1]}
-     * @param levels   requested pyramid depth; silently clamped to what the image size allows
+     * @param a      base image
+     * @param b      image to composite over {@code a}
+     * @param mask   per-pixel weight in {@code [0,1]}
+     * @param levels requested pyramid depth; silently clamped to what the image size allows
      * @return the blended image
      */
     public static float[][] blend(float[][] a, float[][] b, float[][] mask, int levels) {
@@ -86,10 +87,10 @@ public final class LaplacianPyramidBlend {
      * pixels below from {@code lower}. The pyramid's multi-band reconstruction hides the
      * hard seam at all frequency scales naturally.
      *
-     * @param upper    image providing content above the midline
-     * @param lower    image providing content below the midline
-     * @param midline  y coordinate of the seam in {@code upper}/{@code lower} frame
-     * @param levels   requested pyramid depth; clamped to what the image size allows
+     * @param upper   image providing content above the midline
+     * @param lower   image providing content below the midline
+     * @param midline y coordinate of the seam in {@code upper}/{@code lower} frame
+     * @param levels  requested pyramid depth; clamped to what the image size allows
      * @return the blended image
      */
     public static float[][] joinAtMidline(float[][] upper, float[][] lower, int midline, int levels) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Loader.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Loader.java
@@ -44,13 +44,13 @@ import java.util.regex.Pattern;
 public class Loader extends AbstractFunctionImpl {
     private static final Logger LOGGER = LoggerFactory.getLogger(Loader.class);
     private static final Set<String> RECOGNIZED_IMAGE_FORMATS = Set.of(
-        "png",
-        "jpg",
-        "jpeg",
-        "tif",
-        "tiff",
-        "fits",
-        "fit"
+            "png",
+            "jpg",
+            "jpeg",
+            "tif",
+            "tiff",
+            "fits",
+            "fit"
     );
 
     public Loader(Map<Class<?>, Object> context, Broadcaster broadcaster) {
@@ -59,7 +59,7 @@ public class Loader extends AbstractFunctionImpl {
 
     private Path workingDirectory = new File(".").getAbsoluteFile().toPath();
 
-    public Object load(Map<String ,Object> arguments) {
+    public Object load(Map<String, Object> arguments) {
         BuiltinFunction.LOAD.validateArgs(arguments);
         var arg = arguments.get("file");
         if (arg instanceof List<?>) {
@@ -140,7 +140,7 @@ public class Loader extends AbstractFunctionImpl {
         }
     }
 
-    public List<ImageWrapper> loadMany(Map<String ,Object> arguments) {
+    public List<ImageWrapper> loadMany(Map<String, Object> arguments) {
         BuiltinFunction.LOAD_MANY.validateArgs(arguments);
         var directory = (String) arguments.get("dir");
         var pattern = Pattern.compile(stringArg(arguments, "pattern", ".*"));
@@ -148,11 +148,11 @@ public class Loader extends AbstractFunctionImpl {
         if (Files.isDirectory(lookupDir)) {
             try (var stream = Files.list(lookupDir)) {
                 return stream.map(Path::toFile)
-                    .filter(p -> pattern.matcher(p.getName()).matches())
-                    .filter(Loader::isImageFile)
-                    .parallel()
-                    .map(Loader::loadImage)
-                    .toList();
+                        .filter(p -> pattern.matcher(p.getName()).matches())
+                        .filter(Loader::isImageFile)
+                        .parallel()
+                        .map(Loader::loadImage)
+                        .toList();
             } catch (IOException e) {
                 LOGGER.error("Unable to load files", e);
                 return List.of();
@@ -178,7 +178,7 @@ public class Loader extends AbstractFunctionImpl {
         this.workingDirectory = workingDirectory;
     }
 
-    public Object chooseFile(Map<String ,Object> arguments) {
+    public Object chooseFile(Map<String, Object> arguments) {
         BuiltinFunction.CHOOSE_FILES.validateArgs(arguments);
         var id = stringArg(arguments, "id", null);
         var message = stringArg(arguments, "message", null);
@@ -200,7 +200,7 @@ public class Loader extends AbstractFunctionImpl {
         return file.map(Loader::loadImage).orElse(ImageWrapper32.createEmpty());
     }
 
-    public Object chooseFiles(Map<String ,Object> arguments) {
+    public Object chooseFiles(Map<String, Object> arguments) {
         BuiltinFunction.CHOOSE_FILES.validateArgs(arguments);
         var id = stringArg(arguments, "id", null);
         var message = stringArg(arguments, "message", null);
@@ -210,8 +210,8 @@ public class Loader extends AbstractFunctionImpl {
         }
         var files = chooser.chooseFiles(id, message);
         return files.<Object>map(fileList -> fileList
-            .stream()
-            .map(Loader::loadImage)
-            .toList()).orElse(List.of());
+                .stream()
+                .map(Loader::loadImage)
+                .toList()).orElse(List.of());
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Stacking.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Stacking.java
@@ -50,6 +50,7 @@ import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 
 import static me.champeau.a4j.jsolex.processing.util.Constants.message;
+import static me.champeau.a4j.jsolex.processing.util.MemoryAwareStreams.maybeParallel;
 
 public class Stacking extends AbstractFunctionImpl {
     private static final Logger LOGGER = LoggerFactory.getLogger(Stacking.class);
@@ -144,8 +145,7 @@ public class Stacking extends AbstractFunctionImpl {
             if (list.size() == 1) {
                 return list.getFirst();
             }
-            var images = list.stream()
-                    .parallel()
+            var images = maybeParallel(list.stream())
                     .filter(ImageWrapper.class::isInstance)
                     .map(img -> {
                         if (img instanceof FileBackedImage fbi) {
@@ -385,8 +385,7 @@ public class Stacking extends AbstractFunctionImpl {
             if (list.size() == 1) {
                 return list.getFirst();
             }
-            var images = list.stream()
-                    .parallel()
+            var images = maybeParallel(list.stream())
                     .filter(ImageWrapper.class::isInstance)
                     .map(img -> {
                         if (img instanceof FileBackedImage fbi) {
@@ -428,8 +427,7 @@ public class Stacking extends AbstractFunctionImpl {
             if (list.size() == 1) {
                 return list.getFirst();
             }
-            var images = list.stream()
-                    .parallel()
+            var images = maybeParallel(list.stream())
                     .filter(ImageWrapper.class::isInstance)
                     .map(img -> {
                         if (img instanceof FileBackedImage fbi) {
@@ -537,7 +535,13 @@ public class Stacking extends AbstractFunctionImpl {
         } else {
             generateDebugImages = params.requestedImages().isEnabled(GeneratedImageKind.DEBUG);
         }
-        var dedistorted = generateDebugImages ? new float[sourceImages.size()][height][width] : null;
+        float[][][] dedistorted = null;
+        if (generateDebugImages) {
+            dedistorted = new float[sourceImages.size()][][];
+            for (int i = 0; i < sourceImages.size(); i++) {
+                dedistorted[i] = new float[height][width];
+            }
+        }
         var finalImage = assembleImage(sourceImages, weights, distorsions, width, height, tileSize, referenceImage, dedistorted);
         var stacked = new ImageWrapper32(width, height, finalImage, metadata);
         if (generateDebugImages) {
@@ -560,9 +564,8 @@ public class Stacking extends AbstractFunctionImpl {
         if (context.get(ImageEmitter.class) instanceof ImageEmitter imageEmitter) {
             var progress = new AtomicInteger(0);
             var progressOperation = newOperation().createChild(message("Generating stacking debug images"));
-            var creator = new DistorsionDebugImageCreator(imageEmitter, scaling, imageDraw);
-            IntStream.range(0, images.size())
-                    .parallel()
+            var creator = new DistorsionDebugImageCreator(imageEmitter, scaling);
+            maybeParallel(IntStream.range(0, images.size()))
                     .forEach(i -> {
                         creator.createDebugImage(referenceImage, stacked, distorsions[i], images.get(i), tileSize, increment, i, dedistorted[i], referenceSelection);
                         var pg = (double) progress.incrementAndGet() / images.size();
@@ -593,8 +596,11 @@ public class Stacking extends AbstractFunctionImpl {
                     .min(Comparator.comparingDouble(a -> a.eccentricity))
                     .map(o -> o.image)
                     .orElseThrow();
+            // Sharpness is computed sequentially: each laplacian allocates
+            // ~5 full-image buffers, and the underlying OpenCL operations are
+            // serialized via a global GPU lock — parallelism multiplies memory
+            // without improving throughput.
             case SHARPNESS -> IntStream.range(0, images.size())
-                    .parallel()
                     .mapToObj(i -> {
                         var img = images.get(i);
                         var v = imageMath.estimateSharpness(img.asImage());

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/python/PythonImageMathBridge.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/python/PythonImageMathBridge.java
@@ -73,9 +73,9 @@ public class PythonImageMathBridge implements AutoCloseable {
     private SerFileReader reopenedReader;
 
     public PythonImageMathBridge(AbstractImageExpressionEvaluator evaluator,
-                                  Map<Class<?>, Object> context,
-                                  Broadcaster broadcaster,
-                                  boolean allowVariableCreation) {
+                                 Map<Class<?>, Object> context,
+                                 Broadcaster broadcaster,
+                                 boolean allowVariableCreation) {
         this.evaluator = evaluator;
         this.context = context;
         this.broadcaster = broadcaster;
@@ -135,7 +135,7 @@ public class PythonImageMathBridge implements AutoCloseable {
     /**
      * Saves an image to a FITS file.
      *
-     * @param img the image to save
+     * @param img  the image to save
      * @param path the file path
      */
     @HostAccess.Export
@@ -148,10 +148,10 @@ public class PythonImageMathBridge implements AutoCloseable {
      * Emits an image to the JSol'Ex UI during script execution.
      * The image will be displayed in the image viewer as a script-generated image.
      *
-     * @param img the image to emit
-     * @param title the display title for the image
-     * @param name the file name (optional, defaults to title)
-     * @param category the category (optional)
+     * @param img         the image to emit
+     * @param title       the display title for the image
+     * @param name        the file name (optional, defaults to title)
+     * @param category    the category (optional)
      * @param description the description (optional)
      */
     @HostAccess.Export
@@ -167,7 +167,7 @@ public class PythonImageMathBridge implements AutoCloseable {
             imageEmitter.newMonoImage(GeneratedImageKind.IMAGE_MATH, category, title, effectiveName, description, mono);
         } else if (unwrapped instanceof RGBImage rgb) {
             imageEmitter.newColorImage(GeneratedImageKind.IMAGE_MATH, category, title, effectiveName, description,
-                    rgb.width(), rgb.height(), rgb.metadata(), () -> new float[][][] {rgb.r(), rgb.g(), rgb.b()});
+                    rgb.width(), rgb.height(), rgb.metadata(), () -> new float[][][]{rgb.r(), rgb.g(), rgb.b()});
         } else {
             LOGGER.warn("Unsupported image type for emit: {}", unwrapped.getClass().getName());
         }
@@ -178,7 +178,7 @@ public class PythonImageMathBridge implements AutoCloseable {
      * Generic function call - invokes any ImageMath builtin function by name.
      *
      * @param functionName the function name (case-insensitive)
-     * @param args the function arguments as a map
+     * @param args         the function arguments as a map
      * @return the function result
      */
     @HostAccess.Export
@@ -192,9 +192,9 @@ public class PythonImageMathBridge implements AutoCloseable {
      * Generic function call with positional arguments - invokes any ImageMath builtin function by name.
      * Positional arguments are mapped to parameter names based on the function's parameter order.
      *
-     * @param functionName the function name (case-insensitive)
+     * @param functionName   the function name (case-insensitive)
      * @param positionalArgs positional arguments as a list
-     * @param kwargs keyword arguments as a map
+     * @param kwargs         keyword arguments as a map
      * @return the function result
      */
     @HostAccess.Export
@@ -241,9 +241,9 @@ public class PythonImageMathBridge implements AutoCloseable {
     /**
      * Calls a user-defined ImageMath function with positional arguments.
      *
-     * @param name the function name
+     * @param name           the function name
      * @param positionalArgs positional arguments as a list
-     * @param kwargs keyword arguments as a map
+     * @param kwargs         keyword arguments as a map
      * @return the function result
      */
     @HostAccess.Export
@@ -275,7 +275,7 @@ public class PythonImageMathBridge implements AutoCloseable {
      * Calls any function by name - tries builtin first, then falls back to user-defined.
      *
      * @param functionName the function name
-     * @param args the function arguments as a map
+     * @param args         the function arguments as a map
      * @return the function result
      */
     @HostAccess.Export
@@ -301,9 +301,9 @@ public class PythonImageMathBridge implements AutoCloseable {
     /**
      * Calls any function by name with positional arguments - tries builtin first, then falls back to user-defined.
      *
-     * @param functionName the function name
+     * @param functionName   the function name
      * @param positionalArgs positional arguments as a list
-     * @param kwargs keyword arguments as a map
+     * @param kwargs         keyword arguments as a map
      * @return the function result
      */
     @HostAccess.Export
@@ -362,7 +362,7 @@ public class PythonImageMathBridge implements AutoCloseable {
     /**
      * Gets a variable from the ImageMath context with a default value.
      *
-     * @param name the variable name
+     * @param name         the variable name
      * @param defaultValue the default value to return if the variable is not found or is null
      * @return the variable value, or the default value if not found or null
      */
@@ -377,7 +377,7 @@ public class PythonImageMathBridge implements AutoCloseable {
      * For embedded Python (via python() function), the variable must already exist.
      * For standalone Python scripts, new variables can be created.
      *
-     * @param name the variable name
+     * @param name  the variable name
      * @param value the variable value
      */
     @HostAccess.Export
@@ -385,8 +385,8 @@ public class PythonImageMathBridge implements AutoCloseable {
         if (!allowVariableCreation && !evaluator.getVariables().containsKey(name)) {
             throw new IllegalArgumentException(
                     "Variable '" + name + "' does not exist. " +
-                    "Variables must be declared in ImageMath before they can be modified by Python. " +
-                    "Example: declare '" + name + " = 0' before the python() call.");
+                            "Variables must be declared in ImageMath before they can be modified by Python. " +
+                            "Example: declare '" + name + " = 0' before the python() call.");
         }
         var convertedValue = convertFromPythonValue(value);
         evaluator.putVariable(name, convertedValue);
@@ -422,9 +422,9 @@ public class PythonImageMathBridge implements AutoCloseable {
     /**
      * Creates a new mono image from pixel data.
      *
-     * @param width the image width
+     * @param width  the image width
      * @param height the image height
-     * @param data the pixel data
+     * @param data   the pixel data
      * @return the new image
      */
     @HostAccess.Export
@@ -475,22 +475,25 @@ public class PythonImageMathBridge implements AutoCloseable {
         int totalElements = width * height;
         var alloc = getAllocator();
 
-        var vector = new Float4Vector("pixels", alloc);
-        vector.allocateNew(totalElements);
-
-        int index = 0;
-        for (float[] row : data) {
-            for (float value : row) {
-                vector.set(index++, value);
+        // try-with-resources releases the Java vector after exportVector has
+        // transferred ownership of the buffers to the C-Data-Interface struct.
+        // Without this, every export leaks ~width*height*4 bytes of off-heap
+        // Arrow memory (backed by shmem under the unsafe allocator).
+        try (var vector = new Float4Vector("pixels", alloc)) {
+            vector.allocateNew(totalElements);
+            int index = 0;
+            for (float[] row : data) {
+                for (float value : row) {
+                    vector.set(index++, value);
+                }
             }
+            vector.setValueCount(totalElements);
+
+            var arrowArray = ArrowArray.allocateNew(alloc);
+            var arrowSchema = ArrowSchema.allocateNew(alloc);
+            Data.exportVector(alloc, vector, null, arrowArray, arrowSchema);
+            return new long[]{arrowArray.memoryAddress(), arrowSchema.memoryAddress(), width, height, 1};
         }
-        vector.setValueCount(totalElements);
-
-        var arrowArray = ArrowArray.allocateNew(alloc);
-        var arrowSchema = ArrowSchema.allocateNew(alloc);
-        Data.exportVector(alloc, vector, null, arrowArray, arrowSchema);
-
-        return new long[]{arrowArray.memoryAddress(), arrowSchema.memoryAddress(), width, height, 1};
     }
 
     private long[] arrowExportRGB(RGBImage rgb) {
@@ -499,33 +502,32 @@ public class PythonImageMathBridge implements AutoCloseable {
         int totalElements = width * height * 3;
         var alloc = getAllocator();
 
-        var vector = new Float4Vector("pixels", alloc);
-        vector.allocateNew(totalElements);
-
-        // Interleave RGB data: [r0, g0, b0, r1, g1, b1, ...]
-        int index = 0;
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                vector.set(index++, rgb.r()[y][x]);
-                vector.set(index++, rgb.g()[y][x]);
-                vector.set(index++, rgb.b()[y][x]);
+        try (var vector = new Float4Vector("pixels", alloc)) {
+            vector.allocateNew(totalElements);
+            // Interleave RGB data: [r0, g0, b0, r1, g1, b1, ...]
+            int index = 0;
+            for (int y = 0; y < height; y++) {
+                for (int x = 0; x < width; x++) {
+                    vector.set(index++, rgb.r()[y][x]);
+                    vector.set(index++, rgb.g()[y][x]);
+                    vector.set(index++, rgb.b()[y][x]);
+                }
             }
+            vector.setValueCount(totalElements);
+
+            var arrowArray = ArrowArray.allocateNew(alloc);
+            var arrowSchema = ArrowSchema.allocateNew(alloc);
+            Data.exportVector(alloc, vector, null, arrowArray, arrowSchema);
+            return new long[]{arrowArray.memoryAddress(), arrowSchema.memoryAddress(), width, height, 3};
         }
-        vector.setValueCount(totalElements);
-
-        var arrowArray = ArrowArray.allocateNew(alloc);
-        var arrowSchema = ArrowSchema.allocateNew(alloc);
-        Data.exportVector(alloc, vector, null, arrowArray, arrowSchema);
-
-        return new long[]{arrowArray.memoryAddress(), arrowSchema.memoryAddress(), width, height, 3};
     }
 
     /**
      * Creates a mono image from Arrow array data.
      *
-     * @param width the image width
-     * @param height the image height
-     * @param arrayAddress the C Data Interface array memory address
+     * @param width         the image width
+     * @param height        the image height
+     * @param arrayAddress  the C Data Interface array memory address
      * @param schemaAddress the C Data Interface schema memory address
      * @return the new mono image
      */
@@ -558,9 +560,9 @@ public class PythonImageMathBridge implements AutoCloseable {
     /**
      * Creates an RGB image from Arrow array data (interleaved RGB format).
      *
-     * @param width the image width
-     * @param height the image height
-     * @param arrayAddress the C Data Interface array memory address
+     * @param width         the image width
+     * @param height        the image height
+     * @param arrayAddress  the C Data Interface array memory address
      * @param schemaAddress the C Data Interface schema memory address
      * @return the new RGB image
      */
@@ -944,9 +946,9 @@ public class PythonImageMathBridge implements AutoCloseable {
         }
 
         boolean hasHFlip = refCoords.operations().stream()
-            .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.HFLIP);
+                .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.HFLIP);
         boolean hasVFlip = refCoords.operations().stream()
-            .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.VFLIP);
+                .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.VFLIP);
 
         result.put("hasHFlip", hasHFlip);
         result.put("hasVFlip", hasVFlip);
@@ -1168,7 +1170,8 @@ public class PythonImageMathBridge implements AutoCloseable {
                     var newX = current.x() - shift + current.y() * shear;
                     current = new Point2D(newX, current.y());
                 }
-                case OFFSET_2D -> current = new Point2D(current.x() - operation.value(0), current.y() - operation.value(1));
+                case OFFSET_2D ->
+                        current = new Point2D(current.x() - operation.value(0), current.y() - operation.value(1));
                 case MARKER -> { /* Skip markers */ }
             }
         }
@@ -1181,8 +1184,8 @@ public class PythonImageMathBridge implements AutoCloseable {
         var cos = Math.cos(angle);
         var sin = Math.sin(angle);
         return new Point2D(
-            rotationCenter.x() + dx * cos - dy * sin,
-            rotationCenter.y() + dx * sin + dy * cos
+                rotationCenter.x() + dx * cos - dy * sin,
+                rotationCenter.y() + dx * sin + dy * cos
         );
     }
 
@@ -1279,9 +1282,9 @@ public class PythonImageMathBridge implements AutoCloseable {
         int latSign = 1;
         if (refCoords != null) {
             var hasHFlip = refCoords.operations().stream()
-                .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.HFLIP);
+                    .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.HFLIP);
             var hasVFlip = refCoords.operations().stream()
-                .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.VFLIP);
+                    .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.VFLIP);
             lonSign = hasHFlip ? -1 : 1;
             latSign = hasVFlip ? -1 : 1;
         }
@@ -1360,9 +1363,9 @@ public class PythonImageMathBridge implements AutoCloseable {
         int latSign = 1;
         if (refCoords != null) {
             var hasHFlip = refCoords.operations().stream()
-                .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.HFLIP);
+                    .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.HFLIP);
             var hasVFlip = refCoords.operations().stream()
-                .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.VFLIP);
+                    .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.VFLIP);
             lonSign = hasHFlip ? -1 : 1;
             latSign = hasVFlip ? -1 : 1;
         }
@@ -1427,9 +1430,9 @@ public class PythonImageMathBridge implements AutoCloseable {
     // Spherical to Cartesian conversion (matching ImageDraw.ofSpherical)
     private double[] sphericalToCartesian(double longitude, double latitude, double radius) {
         return new double[]{
-            Math.sin(longitude) * Math.sin(latitude) * radius,
-            Math.cos(latitude) * radius,
-            Math.cos(longitude) * Math.sin(latitude) * radius
+                Math.sin(longitude) * Math.sin(latitude) * radius,
+                Math.cos(latitude) * radius,
+                Math.cos(longitude) * Math.sin(latitude) * radius
         };
     }
 
@@ -1438,9 +1441,9 @@ public class PythonImageMathBridge implements AutoCloseable {
         double cos = Math.cos(angle);
         double sin = Math.sin(angle);
         return new double[]{
-            coords[0],
-            coords[1] * cos - coords[2] * sin,
-            coords[1] * sin + coords[2] * cos
+                coords[0],
+                coords[1] * cos - coords[2] * sin,
+                coords[1] * sin + coords[2] * cos
         };
     }
 
@@ -1449,9 +1452,9 @@ public class PythonImageMathBridge implements AutoCloseable {
         double cos = Math.cos(angle);
         double sin = Math.sin(angle);
         return new double[]{
-            coords[0] * cos - coords[1] * sin,
-            coords[0] * sin + coords[1] * cos,
-            coords[2]
+                coords[0] * cos - coords[1] * sin,
+                coords[0] * sin + coords[1] * cos,
+                coords[2]
         };
     }
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/DistorsionDebugImageCreator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/DistorsionDebugImageCreator.java
@@ -36,12 +36,10 @@ import static me.champeau.a4j.jsolex.processing.util.Constants.MAX_PIXEL_VALUE;
 public class DistorsionDebugImageCreator {
     private final ImageEmitter imageEmitter;
     private final Scaling scaling;
-    private final ImageDraw imageDraw;
 
-    public DistorsionDebugImageCreator(ImageEmitter imageEmitter, Scaling scaling, ImageDraw draw) {
+    public DistorsionDebugImageCreator(ImageEmitter imageEmitter, Scaling scaling) {
         this.imageEmitter = imageEmitter;
         this.scaling = scaling;
-        this.imageDraw = draw;
     }
 
     public void createDebugImage(ImageWrapper32 referenceImage,
@@ -58,7 +56,7 @@ public class DistorsionDebugImageCreator {
         var separator = 20 + 10 * width / 100;
         var panelHeight = 2 * height + 3 * separator;
         var panelWidth = 4 * width + 5 * separator;
-        var scale = Math.min(0.5, 2160d/panelHeight);
+        var scale = Math.min(0.5, 2160d / panelHeight);
         var scaledWidth = (int) (panelWidth * scale);
         var scaledHeight = (int) (panelHeight * scale);
         imageEmitter.newColorImage(GeneratedImageKind.DEBUG, null, "displacement", "displacementXY_" + index, null, scaledWidth, scaledHeight, new HashMap<>(stacked.metadata()), () -> {
@@ -157,7 +155,8 @@ public class DistorsionDebugImageCreator {
                 }
             }
             double finalMaxAmplitude = maxAmplitude;
-            RGBImage image = (RGBImage) scaling.relativeRescale(Map.of("img", imageDraw.drawOnImage(new RGBImage(heatmap[0][0].length, heatmap[0].length, heatmap[0], heatmap[1], heatmap[2], MutableMap.of()), (g, img) -> {
+            var heatmapImage = new RGBImage(heatmap[0][0].length, heatmap[0].length, heatmap[0], heatmap[1], heatmap[2], MutableMap.of());
+            ImageDraw.drawOnImageInPlace(heatmapImage, (g, img) -> {
                 g.setColor(Color.BLACK);
                 g.setFont(g.getFont().deriveFont(16f * (height / 384f)));
                 g.drawString("Displacement X", 2 * separator + width + width / 6, height + 1.5f * separator);
@@ -182,11 +181,11 @@ public class DistorsionDebugImageCreator {
                 g.drawLine(middleLegend, separator, middleLegend, height + separator);
                 g.setFont(g.getFont().deriveFont(12f * (height / 384f)));
                 var gradient = new GradientPaint(middleLegend - 20, separator, new Color(255, 128, 128),
-                    middleLegend - 20, separator + height / 2, new Color(128, 128, 128));
+                        middleLegend - 20, separator + height / 2, new Color(128, 128, 128));
                 g.setPaint(gradient);
                 g.fillRect(middleLegend - 40, separator, 40, height / 2);
                 gradient = new GradientPaint(middleLegend - 20, separator + height / 2, new Color(128, 128, 128),
-                    middleLegend - 20, separator + height, new Color(128, 128, 255));
+                        middleLegend - 20, separator + height, new Color(128, 128, 255));
                 g.setPaint(gradient);
                 g.fillRect(middleLegend - 40, separator + height / 2, 40, height / 2);
                 g.setPaint(Color.BLACK);
@@ -197,7 +196,8 @@ public class DistorsionDebugImageCreator {
                     g.drawString(String.format(Locale.US, "%.2fpx", pixels), (int) (2 * width + 2.5 * separator) + 15, y);
                 }
 
-            }), "sx", scale, "sy", scale));
+            });
+            RGBImage image = (RGBImage) scaling.relativeRescale(Map.of("img", heatmapImage, "sx", scale, "sy", scale));
 
             return new float[][][]{image.r(), image.g(), image.b()};
         });

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/GPUDedistort.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/GPUDedistort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,23 +15,13 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.stacking;
 
-import me.champeau.a4j.math.opencl.OpenCLContext;
-import me.champeau.a4j.math.opencl.OpenCLException;
-import org.lwjgl.BufferUtils;
-
 import static org.lwjgl.opencl.CL10.CL_MEM_READ_WRITE;
-import static org.lwjgl.opencl.CL10.CL_SUCCESS;
-import static org.lwjgl.opencl.CL10.clEnqueueNDRangeKernel;
-import static org.lwjgl.opencl.CL10.clSetKernelArg1i;
-import static org.lwjgl.opencl.CL10.clSetKernelArg1p;
 
 /**
  * Performs GPU-accelerated image dedistortion using displacement grids.
  * <p>
- * This class provides a GPU-to-GPU dedistortion operation that keeps data
- * on the GPU, avoiding CPU transfers during multi-step processing.
- * <p>
- * All methods must be called within {@link OpenCLContext#executeWithLock}.
+ * Keeps data on the GPU, avoiding CPU transfers during multi-step processing.
+ * Per-call kernel borrow makes this safe to invoke from concurrent threads.
  */
 public final class GPUDedistort {
 
@@ -40,17 +30,8 @@ public final class GPUDedistort {
 
     /**
      * Applies dedistortion to a GPU-resident image using a GPU-resident displacement grid.
-     * <p>
-     * The operation reads from the input image, applies the displacement correction
-     * specified by the grid, and writes to a new output buffer. The input image
-     * and grid are not modified.
-     * <p>
-     * Must be called within executeWithLock.
-     *
-     * @param gpuImage   GPU-resident input image
-     * @param gpuGrid    GPU-resident distortion grid
-     * @param useLanczos true for Lanczos interpolation (sharper), false for bilinear (faster)
-     * @return new GPU-resident image with dedistortion applied (caller must close)
+     * The output is allocated as a fresh buffer wrapped in a new {@link GPUImage}; the
+     * caller owns it and must close.
      */
     public static GPUImage dedistort(GPUImage gpuImage, GPUDistortionGrid gpuGrid, boolean useLanczos) {
         var context = gpuImage.getContext();
@@ -58,41 +39,25 @@ public final class GPUDedistort {
         int height = gpuImage.getHeight();
         int n = width * height;
 
+        // Output buffer's lifetime escapes this call (returned via GPUImage), so it is
+        // allocated directly through the context and not via op.allocateBuffer.
         long outputBuffer = context.allocateBuffer(n * Float.BYTES, CL_MEM_READ_WRITE);
-
         try {
             var kernelName = useLanczos ? "dedistort_sparse_lanczos" : "dedistort_sparse_bilinear";
-            var kernel = context.getKernelManager().getKernel("dedistort", kernelName);
-
-            clSetKernelArg1p(kernel, 0, gpuImage.getBuffer());
-            clSetKernelArg1p(kernel, 1, gpuGrid.getDxBuffer());
-            clSetKernelArg1p(kernel, 2, gpuGrid.getDyBuffer());
-            clSetKernelArg1p(kernel, 3, outputBuffer);
-            clSetKernelArg1i(kernel, 4, width);
-            clSetKernelArg1i(kernel, 5, height);
-            clSetKernelArg1i(kernel, 6, gpuGrid.getGridWidth());
-            clSetKernelArg1i(kernel, 7, gpuGrid.getGridHeight());
-            clSetKernelArg1i(kernel, 8, gpuGrid.getGridStep());
-
-            executeKernel2D(context, kernel, width, height);
-
+            context.runOp(op -> {
+                op.kernel("dedistort", kernelName)
+                        .arg(gpuImage.getBuffer())
+                        .arg(gpuGrid.getDxBuffer())
+                        .arg(gpuGrid.getDyBuffer())
+                        .arg(outputBuffer)
+                        .arg(width).arg(height)
+                        .arg(gpuGrid.getGridWidth()).arg(gpuGrid.getGridHeight()).arg(gpuGrid.getGridStep())
+                        .run(width, height);
+            });
             return GPUImage.fromBuffer(outputBuffer, width, height, context);
         } catch (Exception e) {
             context.releaseBuffer(outputBuffer);
             throw e;
         }
-    }
-
-    private static void executeKernel2D(OpenCLContext context, long kernel, int width, int height) {
-        var globalWorkSize = BufferUtils.createPointerBuffer(2);
-        globalWorkSize.put(0, width);
-        globalWorkSize.put(1, height);
-
-        int err = clEnqueueNDRangeKernel(context.getCommandQueue(), kernel, 2,
-                null, globalWorkSize, null, null, null);
-        if (err != CL_SUCCESS) {
-            throw new OpenCLException("Failed to execute kernel: " + err);
-        }
-        context.finish();
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/GPUDistortionGrid.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/GPUDistortionGrid.java
@@ -23,8 +23,9 @@ import static org.lwjgl.opencl.CL10.CL_MEM_READ_ONLY;
  * GPU-resident distortion grid (dx, dy arrays).
  * Used during refinement loops to avoid uploading grid data repeatedly.
  * <p>
- * This class is intended for use within a single GPU-locked context.
- * All methods must be called within {@link OpenCLContext#executeWithLock}.
+ * Instances are not thread-safe; confine each one to a single owner. The
+ * underlying buffers are allocated directly on the {@link OpenCLContext}
+ * and freed by {@link #close}.
  */
 public class GPUDistortionGrid implements AutoCloseable {
     private final int gridWidth;
@@ -47,7 +48,6 @@ public class GPUDistortionGrid implements AutoCloseable {
 
     /**
      * Uploads distortion grid data from CPU to GPU.
-     * Must be called within executeWithLock.
      *
      * @param gridDx   displacement X values [gridHeight][gridWidth]
      * @param gridDy   displacement Y values [gridHeight][gridWidth]
@@ -76,7 +76,6 @@ public class GPUDistortionGrid implements AutoCloseable {
 
     /**
      * Creates a GPU distortion grid from a CPU DistorsionMap.
-     * Must be called within executeWithLock.
      *
      * @param map     source distortion map
      * @param context OpenCL context
@@ -132,7 +131,6 @@ public class GPUDistortionGrid implements AutoCloseable {
 
     /**
      * Releases GPU memory.
-     * Must be called within executeWithLock.
      */
     @Override
     public void close() {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/GPUImage.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/GPUImage.java
@@ -23,8 +23,9 @@ import static org.lwjgl.opencl.CL10.CL_MEM_READ_WRITE;
  * Holds an image on GPU memory for multi-step processing.
  * Avoids repeated GPU↔CPU transfers during refinement loops.
  * <p>
- * This class is intended for use within a single GPU-locked context.
- * All methods must be called within {@link OpenCLContext#executeWithLock}.
+ * Instances are not thread-safe; confine each one to a single owner. The
+ * underlying buffer is allocated directly on the {@link OpenCLContext}
+ * (escaping any {@code runOp} that produced it) and freed by {@link #close}.
  */
 public class GPUImage implements AutoCloseable {
     private final int width;
@@ -42,7 +43,6 @@ public class GPUImage implements AutoCloseable {
 
     /**
      * Uploads image data from CPU to GPU.
-     * Must be called within executeWithLock.
      *
      * @param data    2D image data [height][width]
      * @param width   image width
@@ -61,7 +61,6 @@ public class GPUImage implements AutoCloseable {
     /**
      * Creates a GPU image from an existing buffer handle.
      * The buffer ownership is transferred to this GPUImage.
-     * Must be called within executeWithLock.
      *
      * @param buffer  existing GPU buffer handle
      * @param width   image width
@@ -75,7 +74,6 @@ public class GPUImage implements AutoCloseable {
 
     /**
      * Downloads image data from GPU to CPU.
-     * Must be called within executeWithLock.
      *
      * @return 2D image data [height][width]
      */
@@ -88,7 +86,6 @@ public class GPUImage implements AutoCloseable {
 
     /**
      * Returns the GPU buffer handle for use in kernel operations.
-     * Must be called within executeWithLock.
      *
      * @return buffer handle
      */
@@ -120,7 +117,6 @@ public class GPUImage implements AutoCloseable {
 
     /**
      * Releases GPU memory.
-     * Must be called within executeWithLock.
      */
     @Override
     public void close() {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/GPUTileExtractor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/stacking/GPUTileExtractor.java
@@ -15,14 +15,15 @@
  */
 package me.champeau.a4j.jsolex.processing.expr.stacking;
 
+import me.champeau.a4j.math.opencl.GpuOp;
 import me.champeau.a4j.math.opencl.OpenCLContext;
 import me.champeau.a4j.math.opencl.OpenCLSupport;
-import org.lwjgl.system.MemoryStack;
-import org.lwjgl.system.MemoryUtil;
 
 import java.util.ArrayList;
 
-import static org.lwjgl.opencl.CL10.*;
+import static org.lwjgl.opencl.CL10.CL_MEM_READ_ONLY;
+import static org.lwjgl.opencl.CL10.CL_MEM_READ_WRITE;
+import static org.lwjgl.opencl.CL10.CL_MEM_WRITE_ONLY;
 
 /**
  * GPU-accelerated tile extraction for distortion map computation.
@@ -52,18 +53,19 @@ public class GPUTileExtractor {
             int validCount,
             int gridWidth,
             int gridHeight
-    ) {}
+    ) {
+    }
 
     /**
      * Extracts tiles from images using GPU acceleration.
      * Falls back to CPU if GPU is unavailable or grid is too small.
      *
-     * @param referenceData reference image data [height][width]
-     * @param targetData    target image data [height][width]
-     * @param width         image width
-     * @param height        image height
-     * @param tileSize      tile size (must be 32, 64, or 128)
-     * @param increment     grid increment
+     * @param referenceData   reference image data [height][width]
+     * @param targetData      target image data [height][width]
+     * @param width           image width
+     * @param height          image height
+     * @param tileSize        tile size (must be 32, 64, or 128)
+     * @param increment       grid increment
      * @param signalThreshold minimum signal threshold
      * @return extraction result with tiles and positions
      */
@@ -92,214 +94,128 @@ public class GPUTileExtractor {
     }
 
     private static ExtractionResult extractGPU(OpenCLContext context,
-                                                float[][] referenceData, float[][] targetData,
-                                                int width, int height, int tileSize, int increment,
-                                                float signalThreshold, int gridWidth, int gridHeight,
-                                                int totalPositions) {
+                                               float[][] referenceData, float[][] targetData,
+                                               int width, int height, int tileSize, int increment,
+                                               float signalThreshold, int gridWidth, int gridHeight,
+                                               int totalPositions) {
         var refFlat = flatten2D(referenceData, width, height);
         var targetFlat = flatten2D(targetData, width, height);
         int imageSize = width * height;
         int tileSizeSq = tileSize * tileSize;
 
-        return context.executeWithLock(() -> {
-            long refImageBuf = 0, targetImageBuf = 0;
-            long refIntegralBuf = 0, targetIntegralBuf = 0;
-            long validMaskBuf = 0, gridXBuf = 0, gridYBuf = 0;
-            long outputIndicesBuf = 0, validCountBuf = 0;
-            long refTilesBuf = 0, targetTilesBuf = 0;
+        return context.runOp(op -> {
+            // Image buffers
+            var refImageBuf = op.allocateBuffer(imageSize * Float.BYTES, CL_MEM_READ_ONLY);
+            var targetImageBuf = op.allocateBuffer(imageSize * Float.BYTES, CL_MEM_READ_ONLY);
+            var refIntegralBuf = op.allocateBuffer(imageSize * Float.BYTES, CL_MEM_READ_WRITE);
+            var targetIntegralBuf = op.allocateBuffer(imageSize * Float.BYTES, CL_MEM_READ_WRITE);
 
-            try {
-                // Allocate image buffers
-                refImageBuf = context.allocateBuffer(imageSize * Float.BYTES, CL_MEM_READ_ONLY);
-                targetImageBuf = context.allocateBuffer(imageSize * Float.BYTES, CL_MEM_READ_ONLY);
-                refIntegralBuf = context.allocateBuffer(imageSize * Float.BYTES, CL_MEM_READ_WRITE);
-                targetIntegralBuf = context.allocateBuffer(imageSize * Float.BYTES, CL_MEM_READ_WRITE);
+            // Grid buffers
+            var validMaskBuf = op.allocateBuffer(totalPositions * Integer.BYTES, CL_MEM_READ_WRITE);
+            var gridXBuf = op.allocateBuffer(totalPositions * Integer.BYTES, CL_MEM_READ_WRITE);
+            var gridYBuf = op.allocateBuffer(totalPositions * Integer.BYTES, CL_MEM_READ_WRITE);
+            var outputIndicesBuf = op.allocateBuffer(totalPositions * Integer.BYTES, CL_MEM_READ_WRITE);
+            var validCountBuf = op.allocateBuffer(Integer.BYTES, CL_MEM_READ_WRITE);
 
-                // Allocate grid buffers
-                validMaskBuf = context.allocateBuffer(totalPositions * Integer.BYTES, CL_MEM_READ_WRITE);
-                gridXBuf = context.allocateBuffer(totalPositions * Integer.BYTES, CL_MEM_READ_WRITE);
-                gridYBuf = context.allocateBuffer(totalPositions * Integer.BYTES, CL_MEM_READ_WRITE);
-                outputIndicesBuf = context.allocateBuffer(totalPositions * Integer.BYTES, CL_MEM_READ_WRITE);
-                validCountBuf = context.allocateBuffer(Integer.BYTES, CL_MEM_READ_WRITE);
+            op.write(refImageBuf, refFlat);
+            op.write(targetImageBuf, targetFlat);
 
-                // Upload images
-                context.writeBuffer(refImageBuf, refFlat);
-                context.writeBuffer(targetImageBuf, targetFlat);
+            // Compute integral images for both inputs
+            computeIntegralImage(op, refImageBuf, refIntegralBuf, width, height);
+            computeIntegralImage(op, targetImageBuf, targetIntegralBuf, width, height);
 
-                // Compute integral images
-                computeIntegralImage(context, refImageBuf, refIntegralBuf, width, height);
-                computeIntegralImage(context, targetImageBuf, targetIntegralBuf, width, height);
+            // Filter positions by signal
+            op.kernel("tile_extraction", "filter_positions_by_signal")
+                    .arg(refIntegralBuf).arg(targetIntegralBuf).arg(validMaskBuf)
+                    .arg(gridXBuf).arg(gridYBuf)
+                    .arg(width).arg(height).arg(tileSize).arg(increment)
+                    .arg(gridWidth).arg(gridHeight).arg(signalThreshold).arg(1) // hasTarget=true
+                    .global(gridWidth, gridHeight)
+                    .run();
 
-                // Filter positions by signal
-                var filterKernel = context.getKernelManager().getKernel("tile_extraction", "filter_positions_by_signal");
-                try (var stack = MemoryStack.stackPush()) {
-                    clSetKernelArg(filterKernel, 0, stack.pointers(refIntegralBuf));
-                    clSetKernelArg(filterKernel, 1, stack.pointers(targetIntegralBuf));
-                    clSetKernelArg(filterKernel, 2, stack.pointers(validMaskBuf));
-                    clSetKernelArg(filterKernel, 3, stack.pointers(gridXBuf));
-                    clSetKernelArg(filterKernel, 4, stack.pointers(gridYBuf));
-                    clSetKernelArg(filterKernel, 5, stack.ints(width));
-                    clSetKernelArg(filterKernel, 6, stack.ints(height));
-                    clSetKernelArg(filterKernel, 7, stack.ints(tileSize));
-                    clSetKernelArg(filterKernel, 8, stack.ints(increment));
-                    clSetKernelArg(filterKernel, 9, stack.ints(gridWidth));
-                    clSetKernelArg(filterKernel, 10, stack.ints(gridHeight));
-                    clSetKernelArg(filterKernel, 11, stack.floats(signalThreshold));
-                    clSetKernelArg(filterKernel, 12, stack.ints(1)); // hasTarget = true
+            // Compute tile indices (prefix sum)
+            op.kernel("tile_extraction", "compute_tile_indices")
+                    .arg(validMaskBuf).arg(outputIndicesBuf).arg(validCountBuf).arg(totalPositions)
+                    .global(1)
+                    .run();
 
-                    var globalSize = stack.pointers(gridWidth, gridHeight);
-                    int err = clEnqueueNDRangeKernel(context.getCommandQueue(), filterKernel, 2, null, globalSize, null, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to enqueue filter_positions_by_signal kernel: " + err);
-                    }
-                }
+            // Read valid count (forces sync)
+            int[] validCountArr = new int[1];
+            op.readInts(validCountBuf, validCountArr);
+            int validCount = validCountArr[0];
 
-                // Compute tile indices (prefix sum)
-                var indexKernel = context.getKernelManager().getKernel("tile_extraction", "compute_tile_indices");
-                try (var stack = MemoryStack.stackPush()) {
-                    clSetKernelArg(indexKernel, 0, stack.pointers(validMaskBuf));
-                    clSetKernelArg(indexKernel, 1, stack.pointers(outputIndicesBuf));
-                    clSetKernelArg(indexKernel, 2, stack.pointers(validCountBuf));
-                    clSetKernelArg(indexKernel, 3, stack.ints(totalPositions));
-
-                    var globalSize = stack.pointers(1);
-                    int err = clEnqueueNDRangeKernel(context.getCommandQueue(), indexKernel, 1, null, globalSize, null, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to enqueue compute_tile_indices kernel: " + err);
-                    }
-                }
-
-                context.finish();
-
-                // Read valid count
-                int[] validCountArr = new int[1];
-                readBufferInt(context, validCountBuf, validCountArr);
-                int validCount = validCountArr[0];
-
-                if (validCount == 0) {
-                    return new ExtractionResult(
-                            new float[0][], new float[0][],
-                            new int[0], new int[0],
-                            0, gridWidth, gridHeight
-                    );
-                }
-
-                // Allocate tile buffers - ensure we don't exceed max allocation size
-                long tileBufferSize = (long) validCount * tileSizeSq * Float.BYTES;
-                refTilesBuf = context.allocateBuffer((int) Math.min(tileBufferSize, Integer.MAX_VALUE), CL_MEM_WRITE_ONLY);
-                targetTilesBuf = context.allocateBuffer((int) Math.min(tileBufferSize, Integer.MAX_VALUE), CL_MEM_WRITE_ONLY);
-
-                // Extract tiles
-                var extractKernel = context.getKernelManager().getKernel("tile_extraction", "extract_tiles");
-                try (var stack = MemoryStack.stackPush()) {
-                    clSetKernelArg(extractKernel, 0, stack.pointers(refImageBuf));
-                    clSetKernelArg(extractKernel, 1, stack.pointers(targetImageBuf));
-                    clSetKernelArg(extractKernel, 2, stack.pointers(gridXBuf));
-                    clSetKernelArg(extractKernel, 3, stack.pointers(gridYBuf));
-                    clSetKernelArg(extractKernel, 4, stack.pointers(validMaskBuf));
-                    clSetKernelArg(extractKernel, 5, stack.pointers(outputIndicesBuf));
-                    clSetKernelArg(extractKernel, 6, stack.pointers(refTilesBuf));
-                    clSetKernelArg(extractKernel, 7, stack.pointers(targetTilesBuf));
-                    clSetKernelArg(extractKernel, 8, stack.ints(width));
-                    clSetKernelArg(extractKernel, 9, stack.ints(tileSize));
-                    clSetKernelArg(extractKernel, 10, stack.ints(totalPositions));
-
-                    var globalSize = stack.pointers(tileSize, tileSize, totalPositions);
-                    int err = clEnqueueNDRangeKernel(context.getCommandQueue(), extractKernel, 3, null, globalSize, null, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to enqueue extract_tiles kernel: " + err);
-                    }
-                }
-
-                context.finish();
-
-                // Read results - use NoSync variants since we just finished
-                float[] refTilesFlat = new float[validCount * tileSizeSq];
-                float[] targetTilesFlat = new float[validCount * tileSizeSq];
-                int[] gridXArr = new int[totalPositions];
-                int[] gridYArr = new int[totalPositions];
-                int[] validMaskArr = new int[totalPositions];
-
-                context.readBufferNoSync(refTilesBuf, refTilesFlat);
-                context.readBufferNoSync(targetTilesBuf, targetTilesFlat);
-                readBufferInt(context, gridXBuf, gridXArr);
-                readBufferInt(context, gridYBuf, gridYArr);
-                readBufferInt(context, validMaskBuf, validMaskArr);
-
-                // Convert to 2D arrays and collect valid positions
-                float[][] refTiles = new float[validCount][tileSizeSq];
-                float[][] targetTiles = new float[validCount][tileSizeSq];
-                int[] validGridX = new int[validCount];
-                int[] validGridY = new int[validCount];
-
-                for (int i = 0; i < validCount; i++) {
-                    System.arraycopy(refTilesFlat, i * tileSizeSq, refTiles[i], 0, tileSizeSq);
-                    System.arraycopy(targetTilesFlat, i * tileSizeSq, targetTiles[i], 0, tileSizeSq);
-                }
-
-                int validIdx = 0;
-                for (int i = 0; i < totalPositions && validIdx < validCount; i++) {
-                    if (validMaskArr[i] == 1) {
-                        validGridX[validIdx] = gridXArr[i];
-                        validGridY[validIdx] = gridYArr[i];
-                        validIdx++;
-                    }
-                }
-
-                return new ExtractionResult(refTiles, targetTiles, validGridX, validGridY,
-                        validCount, gridWidth, gridHeight);
-
-            } finally {
-                safeRelease(context, refImageBuf);
-                safeRelease(context, targetImageBuf);
-                safeRelease(context, refIntegralBuf);
-                safeRelease(context, targetIntegralBuf);
-                safeRelease(context, validMaskBuf);
-                safeRelease(context, gridXBuf);
-                safeRelease(context, gridYBuf);
-                safeRelease(context, outputIndicesBuf);
-                safeRelease(context, validCountBuf);
-                safeRelease(context, refTilesBuf);
-                safeRelease(context, targetTilesBuf);
+            if (validCount == 0) {
+                return new ExtractionResult(
+                        new float[0][], new float[0][],
+                        new int[0], new int[0],
+                        0, gridWidth, gridHeight);
             }
+
+            // Tile output buffers — sized by validCount, capped at int range
+            long tileBufferSize = (long) validCount * tileSizeSq * Float.BYTES;
+            var refTilesBuf = op.allocateBuffer((int) Math.min(tileBufferSize, Integer.MAX_VALUE), CL_MEM_WRITE_ONLY);
+            var targetTilesBuf = op.allocateBuffer((int) Math.min(tileBufferSize, Integer.MAX_VALUE), CL_MEM_WRITE_ONLY);
+
+            op.kernel("tile_extraction", "extract_tiles")
+                    .arg(refImageBuf).arg(targetImageBuf)
+                    .arg(gridXBuf).arg(gridYBuf).arg(validMaskBuf).arg(outputIndicesBuf)
+                    .arg(refTilesBuf).arg(targetTilesBuf)
+                    .arg(width).arg(tileSize).arg(totalPositions)
+                    .global(tileSize, tileSize, totalPositions)
+                    .run();
+
+            float[] refTilesFlat = new float[validCount * tileSizeSq];
+            float[] targetTilesFlat = new float[validCount * tileSizeSq];
+            int[] gridXArr = new int[totalPositions];
+            int[] gridYArr = new int[totalPositions];
+            int[] validMaskArr = new int[totalPositions];
+
+            op.read(refTilesBuf, refTilesFlat);
+            op.read(targetTilesBuf, targetTilesFlat);
+            op.readInts(gridXBuf, gridXArr);
+            op.readInts(gridYBuf, gridYArr);
+            op.readInts(validMaskBuf, validMaskArr);
+
+            float[][] refTiles = new float[validCount][tileSizeSq];
+            float[][] targetTiles = new float[validCount][tileSizeSq];
+            int[] validGridX = new int[validCount];
+            int[] validGridY = new int[validCount];
+
+            for (int i = 0; i < validCount; i++) {
+                System.arraycopy(refTilesFlat, i * tileSizeSq, refTiles[i], 0, tileSizeSq);
+                System.arraycopy(targetTilesFlat, i * tileSizeSq, targetTiles[i], 0, tileSizeSq);
+            }
+
+            int validIdx = 0;
+            for (int i = 0; i < totalPositions && validIdx < validCount; i++) {
+                if (validMaskArr[i] == 1) {
+                    validGridX[validIdx] = gridXArr[i];
+                    validGridY[validIdx] = gridYArr[i];
+                    validIdx++;
+                }
+            }
+
+            return new ExtractionResult(refTiles, targetTiles, validGridX, validGridY,
+                    validCount, gridWidth, gridHeight);
         });
     }
 
-    private static void computeIntegralImage(OpenCLContext context, long inputBuf, long outputBuf,
-                                              int width, int height) {
-        // Horizontal pass
-        var hKernel = context.getKernelManager().getKernel("tile_extraction", "integral_image_horizontal");
-        try (var stack = MemoryStack.stackPush()) {
-            clSetKernelArg(hKernel, 0, stack.pointers(inputBuf));
-            clSetKernelArg(hKernel, 1, stack.pointers(outputBuf));
-            clSetKernelArg(hKernel, 2, stack.ints(width));
-            clSetKernelArg(hKernel, 3, stack.ints(height));
-
-            var globalSize = stack.pointers(1, height);
-            int err = clEnqueueNDRangeKernel(context.getCommandQueue(), hKernel, 2, null, globalSize, null, null, null);
-            if (err != CL_SUCCESS) {
-                throw new RuntimeException("Failed to enqueue integral_image_horizontal kernel: " + err);
-            }
-        }
-
-        // Vertical pass (in-place on output)
-        var vKernel = context.getKernelManager().getKernel("tile_extraction", "integral_image_vertical");
-        try (var stack = MemoryStack.stackPush()) {
-            clSetKernelArg(vKernel, 0, stack.pointers(outputBuf));
-            clSetKernelArg(vKernel, 1, stack.ints(width));
-            clSetKernelArg(vKernel, 2, stack.ints(height));
-
-            var globalSize = stack.pointers(width, 1);
-            int err = clEnqueueNDRangeKernel(context.getCommandQueue(), vKernel, 2, null, globalSize, null, null, null);
-            if (err != CL_SUCCESS) {
-                throw new RuntimeException("Failed to enqueue integral_image_vertical kernel: " + err);
-            }
-        }
+    private static void computeIntegralImage(GpuOp op, long inputBuf, long outputBuf, int width, int height) {
+        // Horizontal pass: writes outputBuf
+        op.kernel("tile_extraction", "integral_image_horizontal")
+                .arg(inputBuf).arg(outputBuf).arg(width).arg(height)
+                .global(1, height)
+                .run();
+        // Vertical pass (in-place on outputBuf)
+        op.kernel("tile_extraction", "integral_image_vertical")
+                .arg(outputBuf).arg(width).arg(height)
+                .global(width, 1)
+                .run();
     }
 
     private static ExtractionResult extractCPU(float[][] referenceData, float[][] targetData,
-                                                int width, int height, int tileSize, int increment,
-                                                float signalThreshold, int gridWidth, int gridHeight) {
+                                               int width, int height, int tileSize, int increment,
+                                               float signalThreshold, int gridWidth, int gridHeight) {
         var signalEvaluator = new SignalEvaluator(referenceData, targetData, width, height);
 
         var refTilesList = new ArrayList<float[]>();
@@ -346,207 +262,4 @@ public class GPUTileExtractor {
         return flat;
     }
 
-    /**
-     * Extracts tiles from GPU-resident images.
-     * Useful for refinement loops where the target image is already on GPU.
-     * Must be called within OpenCLContext.executeWithLock.
-     *
-     * @param context          OpenCL context
-     * @param refImage         GPU-resident reference image
-     * @param targetImage      GPU-resident target image
-     * @param width            image width
-     * @param height           image height
-     * @param tileSize         tile size (32, 64, or 128)
-     * @param increment        grid increment
-     * @param signalThreshold  minimum signal threshold
-     * @return extraction result with tiles and positions
-     */
-    public static ExtractionResult extractFromGPU(OpenCLContext context,
-                                                   GPUImage refImage, GPUImage targetImage,
-                                                   int width, int height, int tileSize, int increment,
-                                                   float signalThreshold) {
-        int maxY = height - tileSize;
-        int maxX = width - tileSize;
-        int gridWidth = (maxX / increment) + 1;
-        int gridHeight = (maxY / increment) + 1;
-        int totalPositions = gridWidth * gridHeight;
-        int imageSize = width * height;
-        int tileSizeSq = tileSize * tileSize;
-
-        long refIntegralBuf = 0, targetIntegralBuf = 0;
-        long validMaskBuf = 0, gridXBuf = 0, gridYBuf = 0;
-        long outputIndicesBuf = 0, validCountBuf = 0;
-        long refTilesBuf = 0, targetTilesBuf = 0;
-
-        try {
-            // Allocate integral image buffers
-            refIntegralBuf = context.allocateBuffer(imageSize * Float.BYTES, CL_MEM_READ_WRITE);
-            targetIntegralBuf = context.allocateBuffer(imageSize * Float.BYTES, CL_MEM_READ_WRITE);
-
-            // Allocate grid buffers
-            validMaskBuf = context.allocateBuffer(totalPositions * Integer.BYTES, CL_MEM_READ_WRITE);
-            gridXBuf = context.allocateBuffer(totalPositions * Integer.BYTES, CL_MEM_READ_WRITE);
-            gridYBuf = context.allocateBuffer(totalPositions * Integer.BYTES, CL_MEM_READ_WRITE);
-            outputIndicesBuf = context.allocateBuffer(totalPositions * Integer.BYTES, CL_MEM_READ_WRITE);
-            validCountBuf = context.allocateBuffer(Integer.BYTES, CL_MEM_READ_WRITE);
-
-            // Compute integral images from GPU-resident images
-            computeIntegralImage(context, refImage.getBuffer(), refIntegralBuf, width, height);
-            computeIntegralImage(context, targetImage.getBuffer(), targetIntegralBuf, width, height);
-
-            // Filter positions by signal
-            var filterKernel = context.getKernelManager().getKernel("tile_extraction", "filter_positions_by_signal");
-            try (var stack = MemoryStack.stackPush()) {
-                clSetKernelArg(filterKernel, 0, stack.pointers(refIntegralBuf));
-                clSetKernelArg(filterKernel, 1, stack.pointers(targetIntegralBuf));
-                clSetKernelArg(filterKernel, 2, stack.pointers(validMaskBuf));
-                clSetKernelArg(filterKernel, 3, stack.pointers(gridXBuf));
-                clSetKernelArg(filterKernel, 4, stack.pointers(gridYBuf));
-                clSetKernelArg(filterKernel, 5, stack.ints(width));
-                clSetKernelArg(filterKernel, 6, stack.ints(height));
-                clSetKernelArg(filterKernel, 7, stack.ints(tileSize));
-                clSetKernelArg(filterKernel, 8, stack.ints(increment));
-                clSetKernelArg(filterKernel, 9, stack.ints(gridWidth));
-                clSetKernelArg(filterKernel, 10, stack.ints(gridHeight));
-                clSetKernelArg(filterKernel, 11, stack.floats(signalThreshold));
-                clSetKernelArg(filterKernel, 12, stack.ints(1)); // hasTarget = true
-
-                var globalSize = stack.pointers(gridWidth, gridHeight);
-                int err = clEnqueueNDRangeKernel(context.getCommandQueue(), filterKernel, 2, null, globalSize, null, null, null);
-                if (err != CL_SUCCESS) {
-                    throw new RuntimeException("Failed to enqueue filter_positions_by_signal kernel: " + err);
-                }
-            }
-
-            // Compute tile indices (prefix sum)
-            var indexKernel = context.getKernelManager().getKernel("tile_extraction", "compute_tile_indices");
-            try (var stack = MemoryStack.stackPush()) {
-                clSetKernelArg(indexKernel, 0, stack.pointers(validMaskBuf));
-                clSetKernelArg(indexKernel, 1, stack.pointers(outputIndicesBuf));
-                clSetKernelArg(indexKernel, 2, stack.pointers(validCountBuf));
-                clSetKernelArg(indexKernel, 3, stack.ints(totalPositions));
-
-                var globalSize = stack.pointers(1);
-                int err = clEnqueueNDRangeKernel(context.getCommandQueue(), indexKernel, 1, null, globalSize, null, null, null);
-                if (err != CL_SUCCESS) {
-                    throw new RuntimeException("Failed to enqueue compute_tile_indices kernel: " + err);
-                }
-            }
-
-            context.finish();
-
-            // Read valid count
-            int[] validCountArr = new int[1];
-            readBufferInt(context, validCountBuf, validCountArr);
-            int validCount = validCountArr[0];
-
-            if (validCount == 0) {
-                return new ExtractionResult(
-                        new float[0][], new float[0][],
-                        new int[0], new int[0],
-                        0, gridWidth, gridHeight
-                );
-            }
-
-            // Allocate tile buffers
-            long tileBufferSize = (long) validCount * tileSizeSq * Float.BYTES;
-            refTilesBuf = context.allocateBuffer((int) Math.min(tileBufferSize, Integer.MAX_VALUE), CL_MEM_WRITE_ONLY);
-            targetTilesBuf = context.allocateBuffer((int) Math.min(tileBufferSize, Integer.MAX_VALUE), CL_MEM_WRITE_ONLY);
-
-            // Extract tiles from GPU-resident images
-            var extractKernel = context.getKernelManager().getKernel("tile_extraction", "extract_tiles");
-            try (var stack = MemoryStack.stackPush()) {
-                clSetKernelArg(extractKernel, 0, stack.pointers(refImage.getBuffer()));
-                clSetKernelArg(extractKernel, 1, stack.pointers(targetImage.getBuffer()));
-                clSetKernelArg(extractKernel, 2, stack.pointers(gridXBuf));
-                clSetKernelArg(extractKernel, 3, stack.pointers(gridYBuf));
-                clSetKernelArg(extractKernel, 4, stack.pointers(validMaskBuf));
-                clSetKernelArg(extractKernel, 5, stack.pointers(outputIndicesBuf));
-                clSetKernelArg(extractKernel, 6, stack.pointers(refTilesBuf));
-                clSetKernelArg(extractKernel, 7, stack.pointers(targetTilesBuf));
-                clSetKernelArg(extractKernel, 8, stack.ints(width));
-                clSetKernelArg(extractKernel, 9, stack.ints(tileSize));
-                clSetKernelArg(extractKernel, 10, stack.ints(totalPositions));
-
-                var globalSize = stack.pointers(tileSize, tileSize, totalPositions);
-                int err = clEnqueueNDRangeKernel(context.getCommandQueue(), extractKernel, 3, null, globalSize, null, null, null);
-                if (err != CL_SUCCESS) {
-                    throw new RuntimeException("Failed to enqueue extract_tiles kernel: " + err);
-                }
-            }
-
-            context.finish();
-
-            // Read results - use NoSync variants since we just finished
-            float[] refTilesFlat = new float[validCount * tileSizeSq];
-            float[] targetTilesFlat = new float[validCount * tileSizeSq];
-            int[] gridXArr = new int[totalPositions];
-            int[] gridYArr = new int[totalPositions];
-            int[] validMaskArr = new int[totalPositions];
-
-            context.readBufferNoSync(refTilesBuf, refTilesFlat);
-            context.readBufferNoSync(targetTilesBuf, targetTilesFlat);
-            readBufferInt(context, gridXBuf, gridXArr);
-            readBufferInt(context, gridYBuf, gridYArr);
-            readBufferInt(context, validMaskBuf, validMaskArr);
-
-            // Convert to 2D arrays and collect valid positions
-            float[][] refTiles = new float[validCount][tileSizeSq];
-            float[][] targetTiles = new float[validCount][tileSizeSq];
-            int[] validGridX = new int[validCount];
-            int[] validGridY = new int[validCount];
-
-            for (int i = 0; i < validCount; i++) {
-                System.arraycopy(refTilesFlat, i * tileSizeSq, refTiles[i], 0, tileSizeSq);
-                System.arraycopy(targetTilesFlat, i * tileSizeSq, targetTiles[i], 0, tileSizeSq);
-            }
-
-            int validIdx = 0;
-            for (int i = 0; i < totalPositions && validIdx < validCount; i++) {
-                if (validMaskArr[i] == 1) {
-                    validGridX[validIdx] = gridXArr[i];
-                    validGridY[validIdx] = gridYArr[i];
-                    validIdx++;
-                }
-            }
-
-            return new ExtractionResult(refTiles, targetTiles, validGridX, validGridY,
-                    validCount, gridWidth, gridHeight);
-
-        } finally {
-            safeRelease(context, refIntegralBuf);
-            safeRelease(context, targetIntegralBuf);
-            safeRelease(context, validMaskBuf);
-            safeRelease(context, gridXBuf);
-            safeRelease(context, gridYBuf);
-            safeRelease(context, outputIndicesBuf);
-            safeRelease(context, validCountBuf);
-            safeRelease(context, refTilesBuf);
-            safeRelease(context, targetTilesBuf);
-        }
-    }
-
-    private static void safeRelease(OpenCLContext context, long buffer) {
-        if (buffer != 0) {
-            try {
-                context.releaseBuffer(buffer);
-            } catch (Exception e) {
-                // Ignore release errors
-            }
-        }
-    }
-
-    private static void readBufferInt(OpenCLContext context, long buffer, int[] data) {
-        var intBuffer = MemoryUtil.memAllocInt(data.length);
-        try {
-            int err = clEnqueueReadBuffer(context.getCommandQueue(), buffer, true, 0, intBuffer, null, null);
-            if (err != CL_SUCCESS) {
-                throw new RuntimeException("Failed to read int buffer: " + err);
-            }
-            intBuffer.rewind();
-            intBuffer.get(data);
-        } finally {
-            MemoryUtil.memFree(intBuffer);
-        }
-    }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/spectrum/FlatCreator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/spectrum/FlatCreator.java
@@ -37,7 +37,6 @@ import me.champeau.a4j.ser.bayer.FloatPrecisionImageConverter;
 import me.champeau.a4j.ser.bayer.ImageConverter;
 import org.apache.commons.math3.complex.Complex;
 
-import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -79,12 +78,9 @@ public class FlatCreator {
                 reader.seekFrame(0);
                 for (int i = 0; i < steps; i++) {
                     broadcaster.broadcast(progressOperation.update(i / (double) steps));
-                    var currentFrame = reader.currentFrame().data().array();
-                    byte[] copy = new byte[currentFrame.length];
-                    System.arraycopy(currentFrame, 0, copy, 0, currentFrame.length);
-                    reader.nextFrame();
                     var buffer = imageConverter.createBuffer(geometry);
-                    imageConverter.convert(i, ByteBuffer.wrap(copy), geometry, buffer);
+                    imageConverter.convert(i, reader.currentFrame().data(), geometry, buffer);
+                    reader.nextFrame();
                     buffers[i] = buffer;
                 }
                 // compute average image with sigma clipping

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/ArcsinhStretchingStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/ArcsinhStretchingStrategy.java
@@ -23,10 +23,6 @@ import me.champeau.a4j.math.opencl.OpenCLSupport;
 import static me.champeau.a4j.jsolex.processing.util.Constants.MAX_PIXEL_VALUE;
 import static org.apache.commons.math3.util.FastMath.asinh;
 import static org.lwjgl.opencl.CL10.CL_MEM_READ_WRITE;
-import static org.lwjgl.opencl.CL10.CL_SUCCESS;
-import static org.lwjgl.opencl.CL10.clEnqueueNDRangeKernel;
-import static org.lwjgl.opencl.CL10.clSetKernelArg;
-import static org.lwjgl.system.MemoryStack.stackPush;
 
 /**
  * Implements arcsinh stretching, as described in SIRIL docs:
@@ -45,7 +41,7 @@ public final class ArcsinhStretchingStrategy implements StretchingStrategy {
      * Creates a new arcsinh stretching strategy.
      *
      * @param blackPoint the black point value
-     * @param stretch the stretch factor
+     * @param stretch    the stretch factor
      * @param maxStretch the maximum stretch value
      */
     public ArcsinhStretchingStrategy(float blackPoint, float stretch, double maxStretch) {
@@ -129,35 +125,18 @@ public final class ArcsinhStretchingStrategy implements StretchingStrategy {
             System.arraycopy(data[y], 0, flatData, y * width, width);
         }
 
-        context.executeWithLock(() -> {
-            long dataBuffer = 0;
-            try {
-                dataBuffer = context.allocateBuffer(n * Float.BYTES, CL_MEM_READ_WRITE);
-                context.writeBuffer(dataBuffer, flatData);
-
-                try (var stack = stackPush()) {
-                    var kernel = context.getKernelManager().getKernel("stretching", "asinh_stretch");
-                    clSetKernelArg(kernel, 0, stack.pointers(dataBuffer));
-                    clSetKernelArg(kernel, 1, stack.floats((float) normalizedBlackPoint));
-                    clSetKernelArg(kernel, 2, stack.floats((float) stretch));
-                    clSetKernelArg(kernel, 3, stack.floats((float) asinh));
-                    clSetKernelArg(kernel, 4, stack.floats(MAX_PIXEL_VALUE));
-                    clSetKernelArg(kernel, 5, stack.ints(n));
-
-                    var globalWorkSize = stack.pointers(n);
-                    int err = clEnqueueNDRangeKernel(context.getCommandQueue(), kernel, 1, null, globalWorkSize, null, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to execute kernel: " + err);
-                    }
-                    context.finish();
-                }
-
-                context.readBuffer(dataBuffer, flatData);
-            } finally {
-                if (dataBuffer != 0) {
-                    context.releaseBuffer(dataBuffer);
-                }
-            }
+        context.runOp(op -> {
+            var dataBuffer = op.allocateBuffer(n * Float.BYTES, CL_MEM_READ_WRITE);
+            op.write(dataBuffer, flatData);
+            op.kernel("stretching", "asinh_stretch")
+                    .arg(dataBuffer)
+                    .arg((float) normalizedBlackPoint)
+                    .arg((float) stretch)
+                    .arg((float) asinh)
+                    .arg(MAX_PIXEL_VALUE)
+                    .arg(n)
+                    .run(n);
+            op.read(dataBuffer, flatData);
         });
 
         for (int y = 0; y < height; y++) {
@@ -186,9 +165,9 @@ public final class ArcsinhStretchingStrategy implements StretchingStrategy {
     @Override
     public void stretch(RGBImage image) {
         var rgb = new float[][][]{
-            image.r(),
-            image.g(),
-            image.b()
+                image.r(),
+                image.g(),
+                image.b()
         };
         double max = MAX_PIXEL_VALUE;
         var bp = blackPoint / max;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/AutohistogramStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/AutohistogramStrategy.java
@@ -19,6 +19,7 @@ import me.champeau.a4j.jsolex.processing.color.ColorCurve;
 import me.champeau.a4j.jsolex.processing.sun.BackgroundRemoval;
 import me.champeau.a4j.jsolex.processing.sun.tasks.ImageAnalysis;
 import me.champeau.a4j.jsolex.processing.util.Histogram;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.math.regression.Ellipse;
 import me.champeau.a4j.math.tuples.FloatPair;
@@ -26,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.DoubleUnaryOperator;
 
 import static me.champeau.a4j.jsolex.processing.util.Constants.MAX_PIXEL_VALUE;
@@ -64,10 +66,10 @@ public final class AutohistogramStrategy implements StretchingStrategy {
     /**
      * Creates a new autohistogram stretching strategy.
      *
-     * @param gamma the gamma correction value (must be greater than 1)
-     * @param adjustBrightness whether to adjust brightness automatically
+     * @param gamma               the gamma correction value (must be greater than 1)
+     * @param adjustBrightness    whether to adjust brightness automatically
      * @param backgroundThreshold the background neutralization threshold (0 to 1)
-     * @param protusStretch the prominence stretch factor (must be non-negative)
+     * @param protusStretch       the prominence stretch factor (must be non-negative)
      */
     public AutohistogramStrategy(double gamma, boolean adjustBrightness, double backgroundThreshold, double protusStretch) {
         if (gamma < 1) {
@@ -99,20 +101,28 @@ public final class AutohistogramStrategy implements StretchingStrategy {
         if (ellipse.isPresent()) {
             var e = ellipse.get();
             var bgNeutralized = iterativeBgNeutralize(image, e, width, height);
+            // Take both copies before forking: from this point clahe, eclipse and
+            // bgNeutralized hold disjoint buffers, so the three stretches that
+            // follow can run in parallel without aliasing each other.
             var clahe = bgNeutralized.copy();
-            CLAHE_STRATEGY.stretch(clahe);
             var eclipse = createEclipse(bgNeutralized, e.rescale(1.005, 1.005), width, height);
-            PROTUS_STRATEGY.stretch(eclipse);
-            var eclipseData = eclipse.data();
-            var expand = ColorCurve.cachedPolynomial(16, (int) Math.clamp(16 * (1 + protusStretch), 16, 255));
-            for (int y = 0; y < height; y++) {
-                for (int x = 0; x < width; x++) {
-                    eclipseData[y][x] = (float) expand.applyAsDouble(eclipseData[y][x]);
+            var claheTask = CompletableFuture.runAsync(() -> CLAHE_STRATEGY.stretch(clahe));
+            var eclipseTask = CompletableFuture.runAsync(() -> {
+                PROTUS_STRATEGY.stretch(eclipse);
+                var eclipseData = eclipse.data();
+                var expand = ColorCurve.cachedPolynomial(16, (int) Math.clamp(16 * (1 + protusStretch), 16, 255));
+                for (int y = 0; y < height; y++) {
+                    for (int x = 0; x < width; x++) {
+                        eclipseData[y][x] = (float) expand.applyAsDouble(eclipseData[y][x]);
+                    }
                 }
-            }
-            var claheData = blend(clahe.data(), eclipseData, width, height, 0.6);
+            });
             new GammaStrategy(gamma).stretch(bgNeutralized);
-            var blended = blend(bgNeutralized.data(), claheData, width, height, 0.8);
+            CompletableFuture.allOf(claheTask, eclipseTask).join();
+            var claheData = new float[height][width];
+            var blended = new float[height][width];
+            blendInto(clahe.data(), eclipse.data(), width, height, 0.6, claheData);
+            blendInto(bgNeutralized.data(), claheData, width, height, 0.8, blended);
             for (int y = 0; y < height; y++) {
                 System.arraycopy(blended[y], 0, output[y], 0, width);
             }
@@ -123,17 +133,15 @@ public final class AutohistogramStrategy implements StretchingStrategy {
         CutoffStretchingStrategy.DEFAULT.stretch(image);
     }
 
-    private static float[][] blend(float[][] img1, float[][] img2, int width, int height, double alpha) {
+    private static void blendInto(float[][] img1, float[][] img2, int width, int height, double alpha, float[][] out) {
         double beta = 1 - alpha;
-        var blended = new float[height][width];
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
                 var v1 = img1[y][x];
                 var v2 = img2[y][x];
-                blended[y][x] = (float) (alpha * v1 + beta * v2);
+                out[y][x] = (float) (alpha * v1 + beta * v2);
             }
         }
-        return blended;
     }
 
     private static ImageWrapper32 createEclipse(ImageWrapper32 denoised, Ellipse e, int width, int height) {
@@ -154,37 +162,52 @@ public final class AutohistogramStrategy implements StretchingStrategy {
     }
 
     private ImageWrapper32 iterativeBgNeutralize(ImageWrapper32 image, Ellipse e, int width, int height) {
-        var denoised = image.copy();
         if (backgroundThreshold >= 1) {
             return image;
         }
         var rescaledEllipse = e.rescale(1.05, 1.05);
-        denoised = new ImageWrapper32(width, height, denoised.data(), Map.of(Ellipse.class, rescaledEllipse));
-        var eclipse = createEclipse(denoised, rescaledEllipse, width, height);
+        var meta = Map.<Class<?>, Object>of(Ellipse.class, rescaledEllipse);
+        // Ping-pong between two buffers across the iteration loop instead of allocating
+        // a fresh float[h][w] copy on every iteration. Each iteration reads from the
+        // "current" buffer and writes into the "scratch" buffer; on accept they swap.
+        var currentData = ImageWrapper.copyData(image.data());
+        var scratchData = new float[height][width];
+        var current = new ImageWrapper32(width, height, currentData, meta);
+        var scratch = new ImageWrapper32(width, height, scratchData, meta);
+        var eclipse = createEclipse(current, rescaledEllipse, width, height);
+        // Shared scratch buffer for the polynomial background model used by both
+        // neutralizeBg calls below; reused across all iterations.
+        var bgModelBuffer = new float[height][width];
         var prevBg = Double.MAX_VALUE;
         var smoothing = (float) (1 - backgroundThreshold);
         var pedestral = -1d;
         int maxIterations = 25;
         boolean foundPedestral = false;
         while (--maxIterations >= 0) {
-            var copy = denoised.copy();
-            neutralizeBg(copy, 2, 1.5, smoothing, null);
-            double bg = neutralizeBg(eclipse, 2, 1.5, smoothing, null);
+            for (int y = 0; y < height; y++) {
+                System.arraycopy(currentData[y], 0, scratchData[y], 0, width);
+            }
+            neutralizeBg(scratch, 2, 1.5, smoothing, null, bgModelBuffer);
+            double bg = neutralizeBg(eclipse, 2, 1.5, smoothing, null, bgModelBuffer);
             if (bg == 0 || bg > prevBg) {
                 break;
             }
             LOGGER.debug("Background neutralization: {} -> {}", prevBg, bg);
             prevBg = bg;
-            denoised = copy;
+            var tmpData = currentData;
+            currentData = scratchData;
+            scratchData = tmpData;
+            var tmp = current;
+            current = scratch;
+            scratch = tmp;
             if (pedestral == -1 || (!foundPedestral && bg < 0.5 * pedestral)) {
                 pedestral = bg;
             } else {
                 foundPedestral = true;
             }
         }
-        if (pedestral>0) {
-            // Background neutralization can result in the image being clamped to 0, which is unnatural,
-            // so we're adding a pedestal to the image.
+        var denoised = current;
+        if (pedestral > 0) {
             for (int y = 0; y < height; y++) {
                 for (int x = 0; x < width; x++) {
                     denoised.data()[y][x] += pedestral / 2;
@@ -219,16 +242,26 @@ public final class AutohistogramStrategy implements StretchingStrategy {
     /**
      * Neutralizes the background of an image using polynomial background modeling.
      *
-     * @param disk the image to process
-     * @param degree the polynomial degree for background modeling
-     * @param sigma the sigma value for outlier rejection
+     * @param disk      the image to process
+     * @param degree    the polynomial degree for background modeling
+     * @param sigma     the sigma value for outlier rejection
      * @param smoothing the smoothing factor for background subtraction
-     * @param e optional ellipse to exclude from background calculation
+     * @param e         optional ellipse to exclude from background calculation
      * @return the average background level after neutralization
      */
     public static double neutralizeBg(ImageWrapper32 disk, int degree, double sigma, float smoothing, Ellipse e) {
+        return neutralizeBg(disk, degree, sigma, smoothing, e, new float[disk.height()][disk.width()]);
+    }
+
+    /**
+     * Same as {@link #neutralizeBg(ImageWrapper32, int, double, float, Ellipse)} but
+     * uses a caller-supplied buffer for the background model, avoiding per-call
+     * {@code float[h][w]} allocation. The buffer must have dimensions matching
+     * {@code disk}; its prior contents are fully overwritten.
+     */
+    public static double neutralizeBg(ImageWrapper32 disk, int degree, double sigma, float smoothing, Ellipse e, float[][] backgroundBuffer) {
         var diskData = disk.data();
-        var optionalModel = BackgroundRemoval.backgroundModel(disk, degree, sigma);
+        var optionalModel = BackgroundRemoval.backgroundModel(disk, degree, sigma, backgroundBuffer);
         if (optionalModel.isPresent()) {
             var data = optionalModel.get().data();
             double avg = 0;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/GammaStrategy.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/stretching/GammaStrategy.java
@@ -21,10 +21,6 @@ import me.champeau.a4j.math.opencl.OpenCLContext;
 import me.champeau.a4j.math.opencl.OpenCLSupport;
 
 import static org.lwjgl.opencl.CL10.CL_MEM_READ_WRITE;
-import static org.lwjgl.opencl.CL10.CL_SUCCESS;
-import static org.lwjgl.opencl.CL10.clEnqueueNDRangeKernel;
-import static org.lwjgl.opencl.CL10.clSetKernelArg;
-import static org.lwjgl.system.MemoryStack.stackPush;
 
 public final class GammaStrategy implements StretchingStrategy {
     private static final int GPU_THRESHOLD = 65536;
@@ -89,67 +85,42 @@ public final class GammaStrategy implements StretchingStrategy {
             System.arraycopy(data[y], 0, flatData, y * width, width);
         }
 
-        context.executeWithLock(() -> {
-            long dataBuffer = 0;
-            long partialMaxBuffer = 0;
-            try {
-                dataBuffer = context.allocateBuffer(n * Float.BYTES, CL_MEM_READ_WRITE);
-                context.writeBuffer(dataBuffer, flatData);
+        int numGroups = (n + WORK_GROUP_SIZE - 1) / WORK_GROUP_SIZE;
+        var partialMax = new float[numGroups];
 
-                int numGroups = (n + WORK_GROUP_SIZE - 1) / WORK_GROUP_SIZE;
-                partialMaxBuffer = context.allocateBuffer(numGroups * Float.BYTES, CL_MEM_READ_WRITE);
+        context.runOp(op -> {
+            var dataBuffer = op.allocateBuffer(n * Float.BYTES, CL_MEM_READ_WRITE);
+            op.write(dataBuffer, flatData);
 
-                try (var stack = stackPush()) {
-                    var findMaxKernel = context.getKernelManager().getKernel("stretching", "find_max");
-                    clSetKernelArg(findMaxKernel, 0, stack.pointers(dataBuffer));
-                    clSetKernelArg(findMaxKernel, 1, stack.pointers(partialMaxBuffer));
-                    clSetKernelArg(findMaxKernel, 2, stack.ints(n));
-                    clSetKernelArg(findMaxKernel, 3, WORK_GROUP_SIZE * Float.BYTES);
+            var partialMaxBuffer = op.allocateBuffer(numGroups * Float.BYTES, CL_MEM_READ_WRITE);
 
-                    long globalWorkSize = (long) numGroups * WORK_GROUP_SIZE;
-                    var globalWorkSizePtr = stack.pointers(globalWorkSize);
-                    var localWorkSizePtr = stack.pointers(WORK_GROUP_SIZE);
-                    int err = clEnqueueNDRangeKernel(context.getCommandQueue(), findMaxKernel, 1, null, globalWorkSizePtr, localWorkSizePtr, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to execute find_max kernel: " + err);
-                    }
-                    context.finish();
-                }
+            op.kernel("stretching", "find_max")
+                    .arg(dataBuffer)
+                    .arg(partialMaxBuffer)
+                    .arg(n)
+                    .argLocalMemory((long) WORK_GROUP_SIZE * Float.BYTES)
+                    .global((long) numGroups * WORK_GROUP_SIZE)
+                    .local(WORK_GROUP_SIZE)
+                    .run();
 
-                var partialMax = new float[numGroups];
-                context.readBuffer(partialMaxBuffer, partialMax);
-                float max = 1e-7f;
-                for (float v : partialMax) {
-                    if (v > max) {
-                        max = v;
-                    }
-                }
+            op.read(partialMaxBuffer, partialMax);
 
-                try (var stack = stackPush()) {
-                    var gammaKernel = context.getKernelManager().getKernel("stretching", "gamma_stretch");
-                    clSetKernelArg(gammaKernel, 0, stack.pointers(dataBuffer));
-                    clSetKernelArg(gammaKernel, 1, stack.floats(max));
-                    clSetKernelArg(gammaKernel, 2, stack.floats((float) gamma));
-                    clSetKernelArg(gammaKernel, 3, stack.floats(Constants.MAX_PIXEL_VALUE));
-                    clSetKernelArg(gammaKernel, 4, stack.ints(n));
-
-                    var globalWorkSize = stack.pointers(n);
-                    int err = clEnqueueNDRangeKernel(context.getCommandQueue(), gammaKernel, 1, null, globalWorkSize, null, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to execute gamma_stretch kernel: " + err);
-                    }
-                    context.finish();
-                }
-
-                context.readBuffer(dataBuffer, flatData);
-            } finally {
-                if (dataBuffer != 0) {
-                    context.releaseBuffer(dataBuffer);
-                }
-                if (partialMaxBuffer != 0) {
-                    context.releaseBuffer(partialMaxBuffer);
+            float max = 1e-7f;
+            for (float v : partialMax) {
+                if (v > max) {
+                    max = v;
                 }
             }
+
+            op.kernel("stretching", "gamma_stretch")
+                    .arg(dataBuffer)
+                    .arg(max)
+                    .arg((float) gamma)
+                    .arg(Constants.MAX_PIXEL_VALUE)
+                    .arg(n)
+                    .run(n);
+
+            op.read(dataBuffer, flatData);
         });
 
         for (int y = 0; y < height; y++) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/AverageImageCreator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/AverageImageCreator.java
@@ -23,7 +23,6 @@ import me.champeau.a4j.ser.ImageGeometry;
 import me.champeau.a4j.ser.SerFileReader;
 import me.champeau.a4j.ser.bayer.ImageConverter;
 
-import java.nio.ByteBuffer;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -47,8 +46,8 @@ public class AverageImageCreator {
      * Creates a new average image creator.
      *
      * @param imageConverter the converter for processing raw frame data
-     * @param rootOperation the root progress operation for reporting progress
-     * @param broadcaster the broadcaster for publishing progress events
+     * @param rootOperation  the root progress operation for reporting progress
+     * @param broadcaster    the broadcaster for publishing progress events
      */
     public AverageImageCreator(ImageConverter<float[][]> imageConverter,
                                ProgressOperation rootOperation,
@@ -92,13 +91,11 @@ public class AverageImageCreator {
             for (int i = 0; i < frameCount; i++) {
                 int frameId = i;
                 broadcaster.broadcast(progressOperation.update(frameId / (double) frameCount));
-                var currentFrame = reader.currentFrame().data().array();
-                byte[] copy = new byte[currentFrame.length];
-                System.arraycopy(currentFrame, 0, copy, 0, currentFrame.length);
+                var frameData = reader.currentFrame().data();
                 reader.nextFrame();
                 ioExecutor.submit(() -> {
-                    var buffer = imageConverter.createBuffer(geometry);
-                    imageConverter.convert(frameId, ByteBuffer.wrap(copy), geometry, buffer);
+                    var buffer = new float[height][width];
+                    imageConverter.convert(frameId, frameData, geometry, buffer);
                     var frameAvg = imageMath.averageOf(buffer);
                     if (frameAvg > threshold) {
                         var local = localAccumulator.get();
@@ -159,13 +156,11 @@ public class AverageImageCreator {
         try (var executor = ParallelExecutor.newExecutor(IO_PARALLELISM)) {
             for (int i = 0; i < frameCount; i += sampling) {
                 reader.seekFrame(i);
-                var currentFrame = reader.currentFrame().data().array();
-                byte[] copy = new byte[currentFrame.length];
-                System.arraycopy(currentFrame, 0, copy, 0, currentFrame.length);
+                var frameData = reader.currentFrame().data();
                 int finalI = i;
                 executor.submit(() -> {
-                    var img = imageConverter.createBuffer(geometry);
-                    imageConverter.convert(finalI, ByteBuffer.wrap(copy), geometry, img);
+                    var img = new float[geometry.height()][geometry.width()];
+                    imageConverter.convert(finalI, frameData, geometry, img);
                     var mean = imageMath.averageOf(img);
                     maxLock.lock();
                     try {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/BackgroundRemoval.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/BackgroundRemoval.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 
@@ -51,12 +52,12 @@ public class BackgroundRemoval {
      * Removes background from image data using a quadratic model based on distance from the solar disk.
      * Applies correction outside the ellipse and performs bilinear smoothing at the edges.
      *
-     * @param width the image width
-     * @param height the image height
-     * @param data the image data array
-     * @param tolerance the correction factor
+     * @param width      the image width
+     * @param height     the image height
+     * @param data       the image data array
+     * @param tolerance  the correction factor
      * @param background the estimated background level
-     * @param ellipse the solar disk ellipse
+     * @param ellipse    the solar disk ellipse
      */
     public static void removeBackground(int width,
                                         int height,
@@ -86,14 +87,23 @@ public class BackgroundRemoval {
      * Neutralizes background by estimating the background level and
      * modeling it using a 2nd order regression.
      *
-     * @param image the image to process
+     * @param image         the image to process
      * @param maxIterations the number of iterations
      * @return the image with background neutralized
      */
     public static ImageWrapper32 neutralizeBackground(ImageWrapper32 image, int maxIterations) {
-        ImageWrapper32 img = image;
-        for (int i = 0; i < maxIterations; i++) {
-            img = neutralizeBackground(img);
+        if (maxIterations <= 0) {
+            return image;
+        }
+        // Reuse a single output buffer across iterations: each call reads from
+        // the previous iteration's result (which lives in `buffer`) and writes
+        // back into the same `buffer`. This is safe because the underlying
+        // ops tolerate same-array input and output. Saves N-1 large
+        // allocations per call vs the previous fresh-buffer-per-iteration.
+        var buffer = new float[image.height()][image.width()];
+        var img = blindBackgroundNeutralization(image, buffer).neutralized();
+        for (int i = 1; i < maxIterations; i++) {
+            img = blindBackgroundNeutralization(img, buffer).neutralized();
         }
         return img;
     }
@@ -117,17 +127,28 @@ public class BackgroundRemoval {
      * @return the neutralization result containing the processed image and average background level
      */
     public static BlindBackgroundNeutralizationResult blindBackgroundNeutralization(ImageWrapper32 image) {
+        return blindBackgroundNeutralization(image, new float[image.height()][image.width()]);
+    }
+
+    /**
+     * Same as {@link #blindBackgroundNeutralization(ImageWrapper32)} but uses a
+     * caller-supplied output buffer for the working image. The buffer is reused
+     * across all retry rounds (bins=64..1024) — the previous attempt's contents
+     * are simply overwritten by the next round's {@code removeZeroPixels} pass.
+     * The buffer may alias {@code image.data()}.
+     */
+    public static BlindBackgroundNeutralizationResult blindBackgroundNeutralization(ImageWrapper32 image, float[][] outputBuffer) {
         int bins = 64;
-        var neut = blindBackgroundNeutralization2(image, bins);
+        var neut = blindBackgroundNeutralization2(image, bins, outputBuffer);
         while (neut.isEmpty() && bins < 1024) {
             bins *= 2;
-            neut = blindBackgroundNeutralization2(image, bins);
+            neut = blindBackgroundNeutralization2(image, bins, outputBuffer);
         }
         return neut.orElse(new BlindBackgroundNeutralizationResult(image, 0));
     }
 
-    private static Optional<BlindBackgroundNeutralizationResult> blindBackgroundNeutralization2(ImageWrapper32 image, int bins) {
-        var copy = removeZeroPixels(image);
+    private static Optional<BlindBackgroundNeutralizationResult> blindBackgroundNeutralization2(ImageWrapper32 image, int bins, float[][] outputBuffer) {
+        var copy = removeZeroPixels(image, outputBuffer);
         var data = copy.data();
         var background = 0.8 * estimateBackgroundLevel(copy.data(), bins);
         LOGGER.debug("Background neutralization level: {}", background);
@@ -175,8 +196,8 @@ public class BackgroundRemoval {
                 for (int x = 0; x < width; x++) {
                     var value = data[y][x];
                     var estimated = coefficients[0] + coefficients[1] * x + coefficients[2] * y
-                                    + coefficients[3] * x * x + coefficients[4] * y * y
-                                    + coefficients[5] * x * y;
+                            + coefficients[3] * x * x + coefficients[4] * y * y
+                            + coefficients[5] * x * y;
                     avgBackground += estimated;
                     data[y][x] = (float) Math.max(0, value - estimated);
                 }
@@ -196,12 +217,23 @@ public class BackgroundRemoval {
      * Computes a background model for the given image using polynomial regression.
      * The model is fitted to background pixels (outside the solar disk) and filtered using sigma clipping.
      *
-     * @param image the image to process
+     * @param image  the image to process
      * @param degree the polynomial degree for the model
-     * @param sigma the sigma threshold for outlier filtering
+     * @param sigma  the sigma threshold for outlier filtering
      * @return the background model if sufficient samples are available, empty otherwise
      */
     public static Optional<ImageWrapper32> backgroundModel(ImageWrapper32 image, int degree, double sigma) {
+        return backgroundModel(image, degree, sigma, new float[image.height()][image.width()]);
+    }
+
+    /**
+     * Computes the background model into a caller-supplied output buffer. The buffer
+     * must have dimensions {@code [image.height()][image.width()]}; every cell is
+     * overwritten by {@code generateBackgroundCPU} so prior contents are irrelevant.
+     * Use this overload when the caller can pool/reuse the buffer to avoid the
+     * per-call {@code float[h][w]} allocation.
+     */
+    public static Optional<ImageWrapper32> backgroundModel(ImageWrapper32 image, int degree, double sigma, float[][] background) {
         var data = image.data();
         int height = image.height();
         int width = image.width();
@@ -226,15 +258,15 @@ public class BackgroundRemoval {
         // Filter samples using sigma
         var mean = yVector.stream().mapToDouble(Double::doubleValue).average().orElse(0);
         var stddev = Math.sqrt(yVector.stream()
-                                   .mapToDouble(v -> (v - mean) * (v - mean))
-                                   .sum() / (yVector.size() - 1));
+                .mapToDouble(v -> (v - mean) * (v - mean))
+                .sum() / (yVector.size() - 1));
         var hiThreshold = mean + stddev * sigma;
         var loThreshold = mean - stddev * sigma;
         List<double[]> filteredX = new ArrayList<>(xMatrix.size());
         List<Double> filteredY = new ArrayList<>(yVector.size());
         for (int i = 0; i < yVector.size(); i++) {
             var v = yVector.get(i);
-            if (v>0 && v < hiThreshold && v > loThreshold) {
+            if (v > 0 && v < hiThreshold && v > loThreshold) {
                 filteredX.add(xMatrix.get(i));
                 filteredY.add(yVector.get(i));
             }
@@ -242,7 +274,6 @@ public class BackgroundRemoval {
         xMatrix = filteredX;
         yVector = filteredY;
 
-        var background = new float[height][width];
         // Check for sufficient samples
         if (xMatrix.size() < numTerms) {
             LOGGER.debug("Insufficient samples: {} < {} for background model", xMatrix.size(), numTerms);
@@ -270,7 +301,7 @@ public class BackgroundRemoval {
     private static double[] generatePolynomialTermsDeg1(double x, double y, int width, int height) {
         double xNorm = x / (width - 1);
         double yNorm = y / (height - 1);
-        return new double[] {
+        return new double[]{
                 1.0,
                 xNorm,
                 yNorm
@@ -280,7 +311,7 @@ public class BackgroundRemoval {
     private static double[] generatePolynomialTermsDeg2(double x, double y, int width, int height) {
         double xNorm = x / (width - 1);
         double yNorm = y / (height - 1);
-        return new double[] {
+        return new double[]{
                 1.0,
                 xNorm,
                 yNorm,
@@ -396,7 +427,7 @@ public class BackgroundRemoval {
                 double x2 = xNorm * xNorm;
                 double x3 = x2 * xNorm;
                 double bgValue = yTerms + c1 * xNorm + c3 * x2 + c6 * x3
-                               + c4y * xNorm + c7y * x2 + c8y2 * xNorm;
+                        + c4y * xNorm + c7y * x2 + c8y2 * xNorm;
                 background[y][x] = (float) Math.clamp(bgValue, 0, Constants.MAX_PIXEL_VALUE);
             }
         }
@@ -442,32 +473,44 @@ public class BackgroundRemoval {
      * @return a copy of the image with zero pixels replaced by the minimal non-zero value
      */
     public static ImageWrapper32 removeZeroPixels(ImageWrapper32 image) {
-        var copy = image.copy();
-        var data = copy.data();
+        return removeZeroPixels(image, new float[image.height()][image.width()]);
+    }
+
+    /**
+     * Same as {@link #removeZeroPixels(ImageWrapper32)} but writes the result
+     * into a caller-supplied {@code float[height][width]} output buffer instead
+     * of allocating one. The output buffer's prior contents are fully
+     * overwritten. {@code output} may alias {@code image.data()} (the function
+     * tolerates same-array input and output).
+     */
+    public static ImageWrapper32 removeZeroPixels(ImageWrapper32 image, float[][] output) {
+        var src = image.data();
+        int height = src.length;
+        int width = src[0].length;
         var minValue = Float.MAX_VALUE;
-        for (var line : data) {
+        for (var line : src) {
             for (float v : line) {
                 if (v >= 1 && v < minValue) {
                     minValue = v;
                 }
             }
         }
-        for (var line : data) {
-            for (int i = 0; i < line.length; i++) {
-                float v = line[i];
-                if (v == 0) {
-                    line[i] = minValue;
-                }
+        for (int y = 0; y < height; y++) {
+            var srcLine = src[y];
+            var dstLine = output[y];
+            for (int x = 0; x < width; x++) {
+                float v = srcLine[x];
+                dstLine[x] = (v == 0) ? minValue : v;
             }
         }
-        return copy;
+        return new ImageWrapper32(width, height, output, new LinkedHashMap<>(image.metadata()));
     }
 
     /**
      * Result of blind background neutralization containing the processed image
      * and the estimated average background level.
      *
-     * @param neutralized the image with neutralized background
+     * @param neutralized       the image with neutralized background
      * @param averageBackground the estimated average background level
      */
     public record BlindBackgroundNeutralizationResult(

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/FlatCorrection.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/FlatCorrection.java
@@ -26,6 +26,7 @@ import org.apache.commons.math3.fitting.WeightedObservedPoints;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.concurrent.ForkJoinPool;
 import java.util.stream.IntStream;
 
 public class FlatCorrection {
@@ -77,19 +78,25 @@ public class FlatCorrection {
         var lo = diskHistogram.percentile(loPercentile);
         var hi = diskHistogram.percentile(hiPercentile);
         var avgValues = new double[height];
-        IntStream.range(0, height).parallel().forEach(y -> {
-            double total = 0;
-            double count = 0;
-            for (int x = 0; x < width; x++) {
-                if (ellipse.isWithin(x, y)) {
-                    var v = data[y][x];
-                    if (v > lo && v < hi) {
-                        total += v;
-                        count++;
+        var chunkCount = Math.min(height, Math.max(1, ForkJoinPool.commonPool().getParallelism()));
+        var chunkSize = (height + chunkCount - 1) / chunkCount;
+        IntStream.range(0, chunkCount).parallel().forEach(chunk -> {
+            int yStart = chunk * chunkSize;
+            int yEnd = Math.min(yStart + chunkSize, height);
+            for (int y = yStart; y < yEnd; y++) {
+                double total = 0;
+                double count = 0;
+                for (int x = 0; x < width; x++) {
+                    if (ellipse.isWithin(x, y)) {
+                        var v = data[y][x];
+                        if (v > lo && v < hi) {
+                            total += v;
+                            count++;
+                        }
                     }
                 }
+                avgValues[y] = count == 0 ? 0 : total / count;
             }
-            avgValues[y] = count == 0 ? 0 : total / count;
         });
         var weights = new double[height];
         // iterate over median values. If a value is 0, then replace it with the closest non-zero value
@@ -144,8 +151,8 @@ public class FlatCorrection {
 
     public ImageWrapper32 correctImage(ImageWrapper32 source) {
         return source.findMetadata(Ellipse.class)
-            .map(ellipse -> correctImage(source, computeCorrectionFactors(source, ellipse)))
-            .orElse(source);
+                .map(ellipse -> correctImage(source, computeCorrectionFactors(source, ellipse)))
+                .orElse(source);
     }
 
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/ImageUtils.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/ImageUtils.java
@@ -200,16 +200,35 @@ public class ImageUtils {
         float[][] r = new float[height][width];
         float[][] g = new float[height][width];
         float[][] b = new float[height][width];
+        // Hoist the precomputed polynomials out of the inner loop and apply
+        // them directly: avoids allocating an IntPair per cache lookup and a
+        // DoubleTriplet per pixel — both were dominant per-pixel allocations.
+        var rPoly = curve.rPoly();
+        var gPoly = curve.gPoly();
+        var bPoly = curve.bPoly();
         for (int y = 0; y < height; y++) {
             float[] line = mono[y];
+            float[] rRow = r[y];
+            float[] gRow = g[y];
+            float[] bRow = b[y];
             for (int x = 0; x < line.length; x++) {
-                var rgb = curve.toRGB(line[x]);
-                r[y][x] = (float) rgb.a();
-                g[y][x] = (float) rgb.b();
-                b[y][x] = (float) rgb.c();
+                double v = line[x];
+                rRow[x] = clampToRange(rPoly.applyAsDouble(v));
+                gRow[x] = clampToRange(gPoly.applyAsDouble(v));
+                bRow[x] = clampToRange(bPoly.applyAsDouble(v));
             }
         }
         return new float[][][]{r, g, b};
+    }
+
+    private static float clampToRange(double v) {
+        if (v < 0) {
+            return 0f;
+        }
+        if (v > ColorCurve.MAX) {
+            return ColorCurve.MAX;
+        }
+        return (float) Math.round(v);
     }
 
     public static void bilinearSmoothing(Ellipse e, int width, int height, float[][] data) {
@@ -227,7 +246,13 @@ public class ImageUtils {
     }
 
     public static float[][][] fromRGBtoHSL(float[][][] rgb) {
-        return fromRGBtoHSL(rgb, new float[4][rgb[0].length][rgb[0][0].length]);
+        int height = rgb[0].length;
+        int width = rgb[0][0].length;
+        var output = new float[4][][];
+        for (int i = 0; i < 4; i++) {
+            output[i] = new float[height][width];
+        }
+        return fromRGBtoHSL(rgb, output);
     }
 
     public static float[][][] fromRGBtoHSL(float[][][] rgb, float[][][] output) {
@@ -288,7 +313,13 @@ public class ImageUtils {
     }
 
     public static float[][][] fromHSLtoRGB(float[][][] hsl) {
-        return fromHSLtoRGB(hsl, new float[4][hsl[0].length][hsl[0][0].length]);
+        int height = hsl[0].length;
+        int width = hsl[0][0].length;
+        var output = new float[4][][];
+        for (int i = 0; i < 4; i++) {
+            output[i] = new float[height][width];
+        }
+        return fromHSLtoRGB(hsl, output);
     }
 
     public static float[][][] fromHSLtoRGB(float[][][] hsl, float[][][] output) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -91,6 +91,7 @@ import me.champeau.a4j.jsolex.processing.util.FilesUtils;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.LocaleUtils;
+import me.champeau.a4j.jsolex.processing.util.MemoryAwareStreams;
 import me.champeau.a4j.jsolex.processing.util.MutableMap;
 import me.champeau.a4j.jsolex.processing.util.ProcessingException;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
@@ -133,20 +134,15 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiFunction;
 import java.util.function.DoubleUnaryOperator;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static me.champeau.a4j.jsolex.processing.expr.impl.ImageDraw.drawOnImage;
 import static me.champeau.a4j.jsolex.processing.spectrum.FlatCreator.prepareFlatFromAverage;
 import static me.champeau.a4j.jsolex.processing.sun.BackgroundRemoval.removeZeroPixels;
 import static me.champeau.a4j.jsolex.processing.util.Constants.MAX_PIXEL_VALUE;
@@ -156,11 +152,8 @@ import static me.champeau.a4j.ser.SerFileReader.JSOLEX_RECORDER;
 
 public class SolexVideoProcessor implements Broadcaster {
     private static final Logger LOGGER = LoggerFactory.getLogger(SolexVideoProcessor.class);
-    public static final int INMEMORY_BUFFERS_PER_CORE = 32;
+    public static final int INMEMORY_BUFFERS_PER_CORE = 4;
 
-    private static final ExecutorService DETECTION_POOL = Executors.newFixedThreadPool(
-            Math.max(2, Runtime.getRuntime().availableProcessors() / 2),
-            daemonThreadFactory("detection-worker"));
     private static final ExecutorService CONVERSION_POOL = Executors.newFixedThreadPool(
             Math.max(2, Runtime.getRuntime().availableProcessors()),
             daemonThreadFactory("conversion-worker"));
@@ -186,7 +179,8 @@ public class SolexVideoProcessor implements Broadcaster {
     private PixelShiftRange pixelShiftRange;
     private boolean ignoreIncompleteShifts;
     private boolean forceDetectActiveRegions;
-    private Runnable onReconstructionComplete = () -> {};
+    private Runnable onReconstructionComplete = () -> {
+    };
     private EllipseFittingTask.Result cachedEllipse;
     private Map<Class<?>, Object> additionalContext;
 
@@ -280,9 +274,6 @@ public class SolexVideoProcessor implements Broadcaster {
         broadcast(ProcessingStartEvent.of(System.nanoTime(), processParams));
         var converter = ImageUtils.createImageConverter(processParams.videoParams().colorMode(), processParams.geometryParams().isSpectrumVFlip());
         var detector = new AverageImageCreator(converter, rootOperation, this);
-        AtomicInteger frameCountRef = new AtomicInteger();
-        AtomicReference<Header> headerRef = new AtomicReference<>();
-        AtomicReference<Double> fpsRef = new AtomicReference<>();
         try (SerFileReader reader = SerFileReader.of(serFile, processParams.videoParams().trustSerFileBitDepth())) {
             var header = reader.header();
             broadcast(new VideoMetadataEvent(header));
@@ -296,22 +287,14 @@ public class SolexVideoProcessor implements Broadcaster {
             LOGGER.info(message("width.height"), geometry.width(), geometry.height());
             LOGGER.info(message("solar.parameters"), SolarParametersUtils.computeSolarParams(dateTime));
             LOGGER.info(message("computing.average.image.limb.detect"));
-            // We use the IO executor to make sure we only read as single SER file at a time
             if (averageImage == null) {
                 detector.computeAverageImage(reader);
-            }
-            frameCountRef.set(frameCount);
-            headerRef.set(header);
-            fpsRef.set(reader.estimateFps().orElse(null));
-        } catch (Exception e) {
-            broadcastError(e);
-        }
-        var header = headerRef.get();
-        if (header != null) {
-            if (averageImage == null) {
                 averageImage = detector.getAverageImage();
             }
-            generateImages(converter, header, fpsRef.get(), serFile);
+            var fps = reader.estimateFps().orElse(null);
+            generateImages(converter, header, fps, serFile, reader);
+        } catch (Exception e) {
+            broadcastError(e);
         }
     }
 
@@ -370,7 +353,7 @@ public class SolexVideoProcessor implements Broadcaster {
         broadcast(new NotificationEvent(new Notification(Notification.AlertType.ERROR, message("unexpected.error"), message("error.during.processing"), trace)));
     }
 
-    private void generateImages(ImageConverter<float[][]> converter, Header header, Double fps, File serFile) {
+    private void generateImages(ImageConverter<float[][]> converter, Header header, Double fps, File serFile, SerFileReader reader) {
         List<WorkflowState> imageList = new ArrayList<>();
         var imageNamingStrategy = new FileNamingStrategy(processParams.extraParams().fileNamePattern(), processParams.extraParams().datetimeFormat(), processParams.extraParams().dateFormat(), processingDate, header);
         var baseName = serFile.getName().substring(0, serFile.getName().lastIndexOf("."));
@@ -410,7 +393,6 @@ public class SolexVideoProcessor implements Broadcaster {
         if (polynomialCoefficients == null) {
             polynomialCoefficients = analysis.distortionQuadruplet().orElse(null);
         }
-        var serFileReader = new AtomicReference<SerFileReader>();
         if (maybePolynomial.isPresent()) {
             var polynomial = maybePolynomial.get();
             var analyzer = new SpectrumFrameAnalyzer(width, height, header.isJSolexTrimmedSer(), null);
@@ -485,7 +467,7 @@ public class SolexVideoProcessor implements Broadcaster {
             for (int i = 0; i < batches.size(); i++) {
                 var batch = batches.get(i);
                 LOGGER.info(message("processing.batch"), i + 1, batches.size());
-                try (var reader = serFileReader.get() != null ? serFileReader.get().reopen() : SerFileReader.of(serFile, processParams.videoParams().trustSerFileBitDepth())) {
+                try {
                     long serFileSize = Files.size(serFile.toPath());
                     long unitSd = System.nanoTime();
                     var outputs = performImageReconstruction(converter, reader, 0, end, geometry, width, height, polynomial, current, totalImages, imageNamingStrategy, batch.toArray(new WorkflowState[0]));
@@ -500,8 +482,6 @@ public class SolexVideoProcessor implements Broadcaster {
                     if (flares == null && outputs.flares != null) {
                         flares = outputs.flares;
                     }
-                    serFileReader.set(reader);
-                    // Compute megabytes processed per second
                     long ed = System.nanoTime();
                     long time = ed - unitSd;
                     double mbps = (serFileSize / 1024.0 / 1024.0) / (time / 1_000_000_000.0);
@@ -509,7 +489,7 @@ public class SolexVideoProcessor implements Broadcaster {
                 } catch (Exception e) {
                     throw new ProcessingException(e);
                 }
-                FileBackedImage.flushImages();
+                Thread.startVirtualThread(FileBackedImage::flushImages);
             }
 
             onReconstructionComplete.run();
@@ -528,7 +508,7 @@ public class SolexVideoProcessor implements Broadcaster {
                 // ignore
             }
             LOGGER.info(message("processing.done.generate.images"));
-            broadcast(ReconstructionDoneEvent.of(serFileReader.get()));
+            broadcast(ReconstructionDoneEvent.of(reader));
             var generationOperation = rootOperation.createChild(message("generating.images"));
             broadcast(generationOperation);
             startWorkflow(header, fps, imageList, imageNamingStrategy, baseName);
@@ -551,7 +531,7 @@ public class SolexVideoProcessor implements Broadcaster {
                 var mathImages = processParams.combinedImageMathParams();
                 var missingShiftLock = new ReentrantLock();
                 generateImageMaths(imageNamingStrategy, baseName, imageList, mathImages,
-                        shift -> computeMissingImageShift(converter, header, fps, serFile, 0, end, shift, missingShiftLock, width, newHeight, geometry, height, polynomial, imageNamingStrategy, baseName, imageList),
+                        (sharedReader, shift) -> computeMissingImageShift(converter, header, fps, sharedReader, 0, end, shift, missingShiftLock, width, newHeight, geometry, height, polynomial, imageNamingStrategy, baseName, imageList),
                         minShift, maxShift,
                         header);
             });
@@ -646,7 +626,7 @@ public class SolexVideoProcessor implements Broadcaster {
                 activeRegions == null ? 0 : activeRegions.regionList().size(),
                 (int) (flares != null ? flares.flares().stream().filter(f -> f.kind() == Flare.Kind.ELLERMAN_BOMB).count() : 0),
                 (int) (flares != null ? flares.flares().stream().filter(f -> f.kind() == Flare.Kind.FLARE).count() : 0),
-                serFileReader.get(),
+                reader,
                 polynomialCoefficients
         ));
     }
@@ -667,10 +647,17 @@ public class SolexVideoProcessor implements Broadcaster {
      * for performance reasons it is important to avoid calling this method too often
      * since it will not perform reconstruction in parallel like with precomputed shifts.
      */
+
+    /**
+     * Computes a single image at a pixel shift not pre-computed during the
+     * main reconstruction. The supplied reader's lifetime is owned by the
+     * caller; {@code missingShiftLock} serializes concurrent invocations
+     * sharing it.
+     */
     private ImageWrapper computeMissingImageShift(ImageConverter<float[][]> converter,
                                                   Header header,
                                                   Double fps,
-                                                  File serFile,
+                                                  SerFileReader reader,
                                                   int start,
                                                   int end,
                                                   PixelShift shift,
@@ -684,7 +671,7 @@ public class SolexVideoProcessor implements Broadcaster {
                                                   String baseName,
                                                   List<WorkflowState> imageList) {
         missingShiftLock.lock();
-        try (var reader = SerFileReader.of(serFile, processParams.videoParams().trustSerFileBitDepth())) {
+        try {
             var state = new WorkflowState(width, newHeight, shift.pixelShift());
             imageList.add(state);
             state.setInternal(true);
@@ -697,8 +684,6 @@ public class SolexVideoProcessor implements Broadcaster {
                 return geo.corrected();
             }
             return null;
-        } catch (Exception e) {
-            throw new ProcessingException(e);
         } finally {
             missingShiftLock.unlock();
         }
@@ -714,8 +699,10 @@ public class SolexVideoProcessor implements Broadcaster {
         var progress = new AtomicInteger(0);
         var imageEmitterFactory = createImageEmitterFactory(imageList, imageNamingStrategy, baseName);
         var initialFit = performInitialEllipseFit(imageList);
-        imageList.stream()
-                .parallel()
+        // Per-state preparation is independent across pixel shifts: each state
+        // has its own emitter, results map, and metadata. Run them concurrently
+        // when the heap can afford the parallel working set.
+        MemoryAwareStreams.maybeParallel(imageList.stream())
                 .forEach(i -> {
                     initialFit.ifPresent(e -> i.recordResult(WorkflowResults.INITIAL_ELLIPSE_FITTING, e));
                     double pg = ((double) progress.incrementAndGet()) / imageList.size();
@@ -724,29 +711,33 @@ public class SolexVideoProcessor implements Broadcaster {
                 });
         broadcast(prepareOperation.complete());
         var fitting = performEllipseFitting(imageList, imageEmitterFactory);
-        IntStream.range(0, imageList.size()).parallel().forEach(i -> {
-            var state = imageList.get(i);
+        for (var state : imageList) {
             state.recordResult(WorkflowResults.MAIN_ELLIPSE_FITTING, fitting);
-            // update metadata of images to determine if the ellipse crosses the truncation
             updateTruncatedDiskMetadata(fitting, state);
-        });
+        }
         if (processParams.enhancementParams().artificialFlatCorrection()) {
             performFlatCorrection(imageList, fitting, processParams.enhancementParams());
         }
         var generationOperation = newOperation(message("generating.images"));
         progress.set(0);
-        IntStream.range(0, imageList.size()).mapToObj(i -> new Object() {
-            private final WorkflowState state = imageList.get(i);
-            private final int step = i;
-        }).forEach(o -> {
-            broadcast(generationOperation.update(((double) progress.get()) / imageList.size()));
-            var state = o.state;
-            var step = o.step;
-            var ief = new ProcessAwareImageEmitterFactory(state, imageNamingStrategy, baseName);
-            var workflow = new ProcessingWorkflow(generationOperation, this, outputDirectory, imageList, step, processParams, fps, ief, serFile.toPath(), header);
-            workflow.start();
-            broadcast(generationOperation.update(((double) progress.incrementAndGet()) / imageList.size()));
-        });
+        // Each pixel shift's full ProcessingWorkflow (geometry, color, doppler,
+        // image generation) is independent: it reads from imageList but writes
+        // only to its own state. Run them concurrently when heap permits — this
+        // is the dominant single-file throughput win.
+        MemoryAwareStreams.maybeParallel(IntStream.range(0, imageList.size()))
+                .mapToObj(i -> new Object() {
+                    private final WorkflowState state = imageList.get(i);
+                    private final int step = i;
+                })
+                .forEach(o -> {
+                    broadcast(generationOperation.update(((double) progress.get()) / imageList.size()));
+                    var state = o.state;
+                    var step = o.step;
+                    var ief = new ProcessAwareImageEmitterFactory(state, imageNamingStrategy, baseName);
+                    var workflow = new ProcessingWorkflow(generationOperation, this, outputDirectory, imageList, step, processParams, fps, ief, serFile.toPath(), header);
+                    workflow.start();
+                    broadcast(generationOperation.update(((double) progress.incrementAndGet()) / imageList.size()));
+                });
         broadcast(generationOperation.complete());
     }
 
@@ -808,11 +799,10 @@ public class SolexVideoProcessor implements Broadcaster {
         }
         var ellipse = fitting.ellipse();
         var flatCorrector = new FlatCorrection(enhancementParams.artificialFlatCorrectionLoPercentile(), enhancementParams.artificialFlatCorrectionHiPercentile(), enhancementParams.artificialFlatCorrectionOrder());
-        IntStream.range(0, imageList.size()).parallel().forEach(i -> {
-            var state = imageList.get(i);
+        for (var state : imageList) {
             var corrected = flatCorrector.correctImage(state.image(), flatCorrector.computeCorrectionFactors(state.image(), ellipse));
             state.setImage(corrected);
-        });
+        }
     }
 
     private void prepareImageForCorrections(WorkflowState state, Header header, Ellipse ellipse, ImageEmitter emitter) {
@@ -1087,16 +1077,12 @@ public class SolexVideoProcessor implements Broadcaster {
                         rgb.g()[y][correctedX] = 0;
                         rgb.b()[y][correctedX] = 0;
                     }
-                    var draw = new ImageDraw(Map.of(), Broadcaster.NO_OP);
                     var copy = new RGBImage(w, 2 * h + spacing, rgb.r(), rgb.g(), rgb.b(), Map.of());
-                    RGBImage color = (RGBImage) drawOnImage(copy, (g, img) -> {
+                    ImageDraw.drawOnImageInPlace(copy, (g, img) -> {
                         g.setColor(Color.GREEN);
                         g.setFont(g.getFont().deriveFont(16f));
                         g.drawString("Frame " + frameNb + " shift " + redshift.relPixelShift(), 16, img.height() - 16);
                     });
-                    System.arraycopy(color.r(), 0, rgb.r(), 0, color.r().length);
-                    System.arraycopy(color.g(), 0, rgb.g(), 0, color.g().length);
-                    System.arraycopy(color.b(), 0, rgb.b(), 0, color.b().length);
                 });
                 var targetFile = outputDirectory.resolve(fileNamingStrategy.render(sequenceNumber, "redshift", Constants.TYPE_PROCESSED, "redshift", baseName + "_" + redshift.id(), image));
                 broadcast(new ImageGeneratedEvent(
@@ -1117,7 +1103,7 @@ public class SolexVideoProcessor implements Broadcaster {
                                     String baseName,
                                     List<WorkflowState> imageList,
                                     ImageMathParams mathImages,
-                                    Function<PixelShift, ImageWrapper> missingShiftSupplier,
+                                    BiFunction<SerFileReader, PixelShift, ImageWrapper> missingShiftSupplier,
                                     double minShift,
                                     double maxShift,
                                     Header header) {
@@ -1153,76 +1139,76 @@ public class SolexVideoProcessor implements Broadcaster {
             // Create a shared SerFileReader for scripts that need SER file access
             try (var scriptsReader = SerFileReader.of(serFile, processParams.videoParams().trustSerFileBitDepth());
                  var scriptExecutor = Executors.newVirtualThreadPerTaskExecutor()) {
-            var scriptFutures = mathImages.scriptFiles().stream().map(scriptFile -> CompletableFuture.runAsync(() -> {
-                broadcast(scriptsOperation.update(0, message("running.scripts") + " : " + scriptFile.getName()));
-                var context = createMetadata(processParams, serFile.toPath(), pixelShiftRange, header)
-                    .imageEmitter(emitter)
-                    .progressOperation(scriptsOperation)
-                    .serFileReader(scriptsReader)
-                    .ellipse(circle)
-                    .imageStats(finalImageStats)
-                    .spectralLinePolynomial(polynomialCoefficients != null ? new SpectralLinePolynomial(polynomialCoefficients) : null)
-                    .build()
-                    .mergeAll(additionalContext);
-                var scriptRunner = new DefaultImageScriptExecutor(shift -> {
-                    double lookup = shift.pixelShift();
-                    if (lookup < minShift) {
-                        LOGGER.warn("Cropping window doesn't allow use of shift {}, replacing with {}", lookup, minShift);
-                        lookup = minShift;
-                    } else if (lookup > maxShift) {
-                        LOGGER.warn("Cropping window doesn't allow use of shift {}, replacing with {}", lookup, maxShift);
-                        lookup = maxShift;
-                    }
-                    var img = images.get(lookup);
-                    if (img == null) {
-                        // this can happen in situations where a shift is dynamic and cannot be computed
-                        // in advance, for example with expression find_shift(5254) + 1
-                        img = missingShiftSupplier.apply(new PixelShift(lookup));
-                        images.put(lookup, img);
-                    }
-                    return img;
-                }, context, this);
-                var fileParams = mathImages.parameterValues().get(scriptFile);
-                if (fileParams != null) {
-                    for (Map.Entry<String, Object> entry : fileParams.entrySet()) {
-                        scriptRunner.putVariable(entry.getKey(), entry.getValue());
-                    }
-                }
-                try {
-                    var result = scriptRunner.execute(scriptFile.toPath(), ImageMathScriptExecutor.SectionKind.SINGLE);
-                    var outputsMetadata = extractOutputsMetadata(scriptFile);
-                    var language = LocaleUtils.getConfiguredLocale().getLanguage();
-                    ImageMathScriptExecutor.render(result, emitter, (outputLabel, fileOutput) -> {
-                        var displayFile = fileOutput.displayFile();
-                        // Save non-display files with naming strategy
-                        var targetName = imageNamingStrategy.render(sequenceNumber, null, GeneratedImageKind.IMAGE_MATH.directoryKind().name().toLowerCase(Locale.US), outputLabel, baseName, null);
-                        try {
-                            FilesUtils.saveNonDisplayFiles(fileOutput, outputDirectory, targetName);
-                        } catch (IOException e) {
-                            throw new ProcessingException(e);
+                var scriptFutures = mathImages.scriptFiles().stream().map(scriptFile -> CompletableFuture.runAsync(() -> {
+                    broadcast(scriptsOperation.update(0, message("running.scripts") + " : " + scriptFile.getName()));
+                    var context = createMetadata(processParams, serFile.toPath(), pixelShiftRange, header)
+                            .imageEmitter(emitter)
+                            .progressOperation(scriptsOperation)
+                            .serFileReader(scriptsReader)
+                            .ellipse(circle)
+                            .imageStats(finalImageStats)
+                            .spectralLinePolynomial(polynomialCoefficients != null ? new SpectralLinePolynomial(polynomialCoefficients) : null)
+                            .build()
+                            .mergeAll(additionalContext);
+                    var scriptRunner = new DefaultImageScriptExecutor(shift -> {
+                        double lookup = shift.pixelShift();
+                        if (lookup < minShift) {
+                            LOGGER.warn("Cropping window doesn't allow use of shift {}, replacing with {}", lookup, minShift);
+                            lookup = minShift;
+                        } else if (lookup > maxShift) {
+                            LOGGER.warn("Cropping window doesn't allow use of shift {}, replacing with {}", lookup, maxShift);
+                            lookup = maxShift;
                         }
-                        // Let emitter handle the display file
-                        var metadata = outputsMetadata.get(outputLabel);
-                        var displayTitle = metadata != null ? metadata.getDisplayTitle(language) : outputLabel;
-                        var description = metadata != null ? metadata.getDisplayDescription(language) : null;
-                        emitter.newGenericFile(GeneratedImageKind.IMAGE_MATH, null, displayTitle, outputLabel, description, displayFile);
-                    }, outputsMetadata, language);
-                    if (!result.invalidExpressions().isEmpty()) {
-                        var sb = new StringBuilder();
-                        for (InvalidExpression expression : result.invalidExpressions()) {
-                            LOGGER.error("Found invalid expression {} ({}): {}", expression.label(), expression.expression(), expression.error().getMessage());
-                            sb.append("Found invalid expression %s (%s): %s%n".formatted(expression.label(), expression.expression(), expression.error())).append("\n");
+                        var img = images.get(lookup);
+                        if (img == null) {
+                            // this can happen in situations where a shift is dynamic and cannot be computed
+                            // in advance, for example with expression find_shift(5254) + 1
+                            img = missingShiftSupplier.apply(scriptsReader, new PixelShift(lookup));
+                            images.put(lookup, img);
                         }
-                        broadcast(new NotificationEvent(new Notification(Notification.AlertType.ERROR, message("invalid.expressions"), message("invalid.expressions"), sb.toString())));
+                        return img;
+                    }, context, this);
+                    var fileParams = mathImages.parameterValues().get(scriptFile);
+                    if (fileParams != null) {
+                        for (Map.Entry<String, Object> entry : fileParams.entrySet()) {
+                            scriptRunner.putVariable(entry.getKey(), entry.getValue());
+                        }
                     }
-                    broadcast(new ScriptExecutionResultEvent(result));
-                } catch (IOException e) {
-                    throw new ProcessingException(e);
-                } finally {
-                    broadcast(scriptsOperation.update(1.0, "Running script " + scriptFile.getName()));
-                }
-            }, scriptExecutor)).toList();
-            scriptFutures.forEach(CompletableFuture::join);
+                    try {
+                        var result = scriptRunner.execute(scriptFile.toPath(), ImageMathScriptExecutor.SectionKind.SINGLE);
+                        var outputsMetadata = extractOutputsMetadata(scriptFile);
+                        var language = LocaleUtils.getConfiguredLocale().getLanguage();
+                        ImageMathScriptExecutor.render(result, emitter, (outputLabel, fileOutput) -> {
+                            var displayFile = fileOutput.displayFile();
+                            // Save non-display files with naming strategy
+                            var targetName = imageNamingStrategy.render(sequenceNumber, null, GeneratedImageKind.IMAGE_MATH.directoryKind().name().toLowerCase(Locale.US), outputLabel, baseName, null);
+                            try {
+                                FilesUtils.saveNonDisplayFiles(fileOutput, outputDirectory, targetName);
+                            } catch (IOException e) {
+                                throw new ProcessingException(e);
+                            }
+                            // Let emitter handle the display file
+                            var metadata = outputsMetadata.get(outputLabel);
+                            var displayTitle = metadata != null ? metadata.getDisplayTitle(language) : outputLabel;
+                            var description = metadata != null ? metadata.getDisplayDescription(language) : null;
+                            emitter.newGenericFile(GeneratedImageKind.IMAGE_MATH, null, displayTitle, outputLabel, description, displayFile);
+                        }, outputsMetadata, language);
+                        if (!result.invalidExpressions().isEmpty()) {
+                            var sb = new StringBuilder();
+                            for (InvalidExpression expression : result.invalidExpressions()) {
+                                LOGGER.error("Found invalid expression {} ({}): {}", expression.label(), expression.expression(), expression.error().getMessage());
+                                sb.append("Found invalid expression %s (%s): %s%n".formatted(expression.label(), expression.expression(), expression.error())).append("\n");
+                            }
+                            broadcast(new NotificationEvent(new Notification(Notification.AlertType.ERROR, message("invalid.expressions"), message("invalid.expressions"), sb.toString())));
+                        }
+                        broadcast(new ScriptExecutionResultEvent(result));
+                    } catch (IOException e) {
+                        throw new ProcessingException(e);
+                    } finally {
+                        broadcast(scriptsOperation.update(1.0, "Running script " + scriptFile.getName()));
+                    }
+                }, scriptExecutor)).toList();
+                scriptFutures.forEach(CompletableFuture::join);
             } catch (Exception e) {
                 throw new ProcessingException(e);
             }
@@ -1309,7 +1295,7 @@ public class SolexVideoProcessor implements Broadcaster {
             var original = rotated.data();
             var width = rotated.width();
             var height = rotated.height();
-            float[][] flipped = new float[height][width];
+            var flipped = new float[height][width];
             for (int y = 0; y < height; y++) {
                 for (int x = 0; x < width; x++) {
                     var nx = hflip ? width - x - 1 : x;
@@ -1402,7 +1388,7 @@ public class SolexVideoProcessor implements Broadcaster {
         var height = rotated.height();
         var newWidth = height;
         var newHeight = width;
-        float[][] newData = new float[newHeight][newWidth];
+        var newData = new float[newHeight][newWidth];
 
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
@@ -1545,7 +1531,14 @@ public class SolexVideoProcessor implements Broadcaster {
         var hasRedshifts = new AtomicBoolean();
         var hasActiveRegions = new AtomicBoolean();
         var hasFlares = new AtomicBoolean();
-        var semaphore = new Semaphore(INMEMORY_BUFFERS_PER_CORE * Math.max(2, Runtime.getRuntime().availableProcessors()));
+        int laneCount = INMEMORY_BUFFERS_PER_CORE * Math.max(2, Runtime.getRuntime().availableProcessors());
+        // Per-lane pre-allocated buffer: each lane in a batch owns buffers[k] for
+        // its conversion + detection. No slot/refcount logic — the lane owns the
+        // buffer for the whole batch and the next batch reuses the same buffers.
+        var buffers = new float[laneCount][][];
+        for (int k = 0; k < laneCount; k++) {
+            buffers[k] = new float[geometry.height()][geometry.width()];
+        }
         var jSolexSer = reader.header().isJSolexTrimmedSer();
         var flat = loadReadFlat(geometry.width(), geometry.height()).orElse(null);
         var detectRedshifts = processParams.spectrumParams().ray().label().equalsIgnoreCase(SpectralRay.H_ALPHA.label()) && processParams.requestedImages().isEnabled(GeneratedImageKind.REDSHIFT);
@@ -1553,26 +1546,36 @@ public class SolexVideoProcessor implements Broadcaster {
         var detectActiveRegions = forceDetectActiveRegions || processParams.requestedImages().isEnabled(GeneratedImageKind.ACTIVE_REGIONS);
         var detectBorders = processParams.enhancementParams().jaggingCorrectionParams().enabled();
         var detectPhenomena = detectBorders || detectRedshifts || detectEllermanBombs || detectActiveRegions;
-        var ops = new TaskCoordinator();
-        var reconstructedImages = new float[images.length][totalLines][width];
+        if (detectPhenomena) {
+            phenomenaDetector.setDetectBorders(detectBorders);
+            phenomenaDetector.setDetectRedshifts(detectRedshifts);
+            phenomenaDetector.setDetectEllermanBombsOrFlares(detectEllermanBombs);
+            phenomenaDetector.setDetectActiveRegions(detectActiveRegions);
+        }
+        var reconstructedImages = new float[images.length][][];
+        for (int i = 0; i < images.length; i++) {
+            reconstructedImages[i] = new float[totalLines][width];
+        }
         var reconstructionOperation = newOperation(message("reconstruction"));
         var completedFrames = new AtomicInteger(0);
         try {
-            for (int i = start, j = 0; i < end; i++, j += 1) {
-                semaphore.acquire();
-                var currentFrame = reader.currentFrame().data().array();
-                byte[] copy = new byte[currentFrame.length];
-                System.arraycopy(currentFrame, 0, copy, 0, currentFrame.length);
-                reader.nextFrame();
-                var original = converter.createBuffer(geometry);
-                int y = j;
-                int frameId = i;
-                ops.countUp();
-                CONVERSION_POOL.submit(() -> {
-                    boolean detectionSubmitted = false;
-                    try {
-                        // The converter makes sure we only have a single channel
-                        converter.convert(frameId, ByteBuffer.wrap(copy), geometry, original);
+            for (int batchStart = start; batchStart < end; batchStart += laneCount) {
+                int batchEnd = Math.min(batchStart + laneCount, end);
+                int batchSize = batchEnd - batchStart;
+                // Stage frame data on the main thread — the SerFileReader is sequential.
+                var frameDataBatch = new ByteBuffer[batchSize];
+                for (int k = 0; k < batchSize; k++) {
+                    frameDataBatch[k] = reader.currentFrame().data();
+                    reader.nextFrame();
+                }
+                var futures = new CompletableFuture<?>[batchSize];
+                for (int k = 0; k < batchSize; k++) {
+                    int lane = k;
+                    int frameId = batchStart + k;
+                    int y = frameId - start;
+                    futures[k] = CompletableFuture.runAsync(() -> {
+                        var original = buffers[lane];
+                        converter.convert(frameId, frameDataBatch[lane], geometry, original);
                         if (flat != null) {
                             applyFlatCorrection(original, flat);
                         }
@@ -1583,41 +1586,23 @@ public class SolexVideoProcessor implements Broadcaster {
                             processSingleFrame(state.isInternal(), width, height, buffer, y, original, polynomial, state.pixelShift(), totalLines, jSolexSer, truncationDetails);
                             state.setTruncationDetails(truncationDetails);
                             if (detectPhenomena && state.pixelShift() == 0) {
-                                detectionSubmitted = true;
-                                ops.countUp();
-                                DETECTION_POOL.submit(() -> {
-                                    try {
-                                        phenomenaDetector.setDetectBorders(detectBorders);
-                                        phenomenaDetector.setDetectRedshifts(detectRedshifts);
-                                        phenomenaDetector.setDetectEllermanBombsOrFlares(detectEllermanBombs);
-                                        phenomenaDetector.setDetectActiveRegions(detectActiveRegions);
-                                        phenomenaDetector.performDetection(frameId, width, height, original, polynomial, reader.header());
-                                        if (phenomenaDetector.isRedShiftDetectionEnabled()) {
-                                            hasRedshifts.set(true);
-                                        }
-                                        if (phenomenaDetector.isActiveRegionsDetectionEnabled()) {
-                                            hasActiveRegions.set(true);
-                                        }
-                                        if (phenomenaDetector.isEllermanBombsDetectionEnabled()) {
-                                            hasFlares.set(true);
-                                        }
-                                    } finally {
-                                        semaphore.release();
-                                        ops.countDown();
-                                    }
-                                });
+                                phenomenaDetector.performDetection(frameId, width, height, original, polynomial, reader.header());
+                                if (phenomenaDetector.isRedShiftDetectionEnabled()) {
+                                    hasRedshifts.set(true);
+                                }
+                                if (phenomenaDetector.isActiveRegionsDetectionEnabled()) {
+                                    hasActiveRegions.set(true);
+                                }
+                                if (phenomenaDetector.isEllermanBombsDetectionEnabled()) {
+                                    hasFlares.set(true);
+                                }
                             }
                         }
-                    } finally {
-                        if (!detectionSubmitted) {
-                            semaphore.release();
-                        }
                         broadcast(reconstructionOperation.update((double) completedFrames.incrementAndGet() / totalLines));
-                        ops.countDown();
-                    }
-                });
+                    }, CONVERSION_POOL);
+                }
+                CompletableFuture.allOf(futures).join();
             }
-            ops.awaitZero();
             broadcast(reconstructionOperation.complete());
             if (hasRedshifts.get() && !phenomenaDetector.hasRedshifts()) {
                 LOGGER.warn(message("no.redshifts.detected"));
@@ -1630,9 +1615,6 @@ public class SolexVideoProcessor implements Broadcaster {
                 state.recordResult(WorkflowResults.RECONSTRUCTED, recon);
                 state.recordResult(WorkflowResults.BORDERS, borders);
             }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new ProcessingException(e);
         } catch (Exception e) {
             throw new ProcessingException(e);
         }
@@ -1697,7 +1679,8 @@ public class SolexVideoProcessor implements Broadcaster {
                             System.arraycopy(buffer[y], 0, g[y], 0, width);
                             System.arraycopy(buffer[y], 0, b[y], 0, width);
                         }
-                        var rgb = (RGBImage) drawOnImage(new RGBImage(width, height, r, g, b, MutableMap.of()), (gc, img) -> {
+                        var rgb = new RGBImage(width, height, r, g, b, MutableMap.of());
+                        ImageDraw.drawOnImageInPlace(rgb, (gc, img) -> {
                             gc.setColor(Color.green);
                             var font = gc.getFont();
                             var size = height / 4f;
@@ -1928,40 +1911,6 @@ public class SolexVideoProcessor implements Broadcaster {
             Flares flares
     ) {
 
-    }
-
-    private static class TaskCoordinator {
-        private final Lock lock = new ReentrantLock();
-        private final Condition condition = lock.newCondition();
-        private final AtomicInteger counter = new AtomicInteger();
-
-        public void countUp() {
-            counter.incrementAndGet();
-        }
-
-        public void countDown() {
-            counter.decrementAndGet();
-            lock.lock();
-            try {
-                condition.signalAll();
-            } finally {
-                lock.unlock();
-            }
-        }
-
-        public void awaitZero() {
-            lock.lock();
-            try {
-                while (counter.get() > 0) {
-                    condition.await();
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new ProcessingException(e);
-            } finally {
-                lock.unlock();
-            }
-        }
     }
 
     private static Map<String, OutputMetadata> extractOutputsMetadata(File scriptFile) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/detection/PhenomenaDetector.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/detection/PhenomenaDetector.java
@@ -44,8 +44,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.DoubleUnaryOperator;
@@ -62,13 +63,14 @@ public class PhenomenaDetector {
     private static final double SPEED_OF_LIGHT = 299792.458d;
     private static final double ELLERMAN_WING_LIMIT_ANGSTROMS = 0.35;
     private static final double ELLERMAN_MAX_RANGE_ANGSTROMS = 5;
-    private static final int MAX_ELLERMAN_STOP_DETECTION = 20;
+    private static final int MAX_ELLERMAN_CANDIDATE_LIMIT = 50;
     private static final int MAX_ELLERMAN_COUNT = 5;
     private static final int ELLERMAN_LOCAL_RANGE = 8;
     private static final int ELLERMAN_MIN_WIDTH_FOR_DETECTION = 12 * ELLERMAN_LOCAL_RANGE;
+    private static final int FLARE_DEDUP_DISTANCE = 16;
 
     private final Map<Integer, List<Redshift>> redshiftsPerFrame = new ConcurrentHashMap<>();
-    private final List<CandidateFlare> candidateFlares = new CopyOnWriteArrayList<>();
+    private final Queue<CandidateFlare> candidateFlares = new ConcurrentLinkedQueue<>();
     private final Map<Integer, BitSet> activeRegionsPerFrame = new ConcurrentHashMap<>();
     private volatile BorderDetection borderDetection;
     private final Lock lock = new ReentrantLock();
@@ -170,7 +172,8 @@ public class PhenomenaDetector {
             var columnsAverages = new double[width];
             var columnsStddevs = new double[width];
             // reduce noise
-            var blurred = imageMath.convolve(new Image(width, height, original), Kernel33.GAUSSIAN_BLUR).data();
+            var blurred = new float[height][width];
+            imageMath.convolve(new Image(width, height, original), Kernel33.GAUSSIAN_BLUR, blurred);
             for (int x = left; x < right; x++) {
                 var columnAvg = columnAverage(x, height, original);
                 columnStats[x] = computeColumnStatsForEllermanDetection(frameId, x, height, blurred, polynomial);
@@ -197,9 +200,14 @@ public class PhenomenaDetector {
                     : Arrays.stream(columnStats).filter(Objects::nonNull).mapToDouble(c -> c.centerLineStats().average()).average().orElse(0);
             int leftBorder = left;
             int rightBorder = right;
-            borderPoints.add(new Point2D(leftBorder, frameId));
-            borderPoints.add(new Point2D(rightBorder, frameId));
-            for (int x=left; x<=right; x++) {
+            lock.lock();
+            try {
+                borderPoints.add(new Point2D(leftBorder, frameId));
+                borderPoints.add(new Point2D(rightBorder, frameId));
+            } finally {
+                lock.unlock();
+            }
+            for (int x = left; x <= right; x++) {
                 analyzeColumn(frameId, x, width, height, original, polynomial, wingShiftInPixels, collector, finalAvgCenterLine, finalAvgOfColumnAverages, columnsAverages, columnsStddevs, models.avgModel(), models.stddevModel(), activeRegionsMask, columnStats, globalLineAvgForEllermanDetection, globalWingAvgForEllermanDetection, leftBorder, rightBorder);
             }
             if (!collector.isEmpty()) {
@@ -212,21 +220,25 @@ public class PhenomenaDetector {
     }
 
     private static ColumnModels computeColumnModels(int height, float[][] original, int left, int right, double[] columnsAverages, double[] columnsStddevs) {
-        var avgPoints = new ArrayList<Point2D>(right-left);
-        var stddevPoints = new ArrayList<Point2D>(right-left);
-        for (int x = left; x < right; x++) {
+        int n = right - left;
+        double[] xs = new double[n];
+        double[] avgYs = new double[n];
+        double[] stddevYs = new double[n];
+        for (int i = 0; i < n; i++) {
+            int x = left + i;
             var avg = columnsAverages[x];
-            avgPoints.add(new Point2D(x, avg));
+            xs[i] = x;
+            avgYs[i] = avg;
             double stddev = 0;
             for (int y = 0; y < height; y++) {
                 var delta = original[y][x] - avg;
                 stddev += delta * delta;
             }
             columnsStddevs[x] = Math.sqrt(stddev / height);
-            stddevPoints.add(new Point2D(x, columnsStddevs[x]));
+            stddevYs[i] = columnsStddevs[x];
         }
-        var avgModel = LinearRegression.thirdOrderRegression(avgPoints.toArray(Point2D[]::new)).asPolynomial();
-        var stddevModel = LinearRegression.thirdOrderRegression(stddevPoints.toArray(Point2D[]::new)).asPolynomial();
+        var avgModel = LinearRegression.asPolynomial(LinearRegression.kOrderRegression(xs, avgYs, 3));
+        var stddevModel = LinearRegression.asPolynomial(LinearRegression.kOrderRegression(xs, stddevYs, 3));
         return new ColumnModels(avgModel, stddevModel);
     }
 
@@ -366,7 +378,7 @@ public class PhenomenaDetector {
         if (detectRedshifts) {
             performRedshiftDetection(frameId, x, width, height, original, polynomial, wingShiftInPixels, collector, avgLineValue, avgOfcolumnAverages, columnsAverages);
         }
-        if (detectEllermanBombs && globalWingAvgForEllermanDetection > 0 && candidateFlares.size() < MAX_ELLERMAN_STOP_DETECTION && x > leftBorder + 16 && x < rightBorder - 16) {
+        if (detectEllermanBombs && globalWingAvgForEllermanDetection > 0 && x > leftBorder + 16 && x < rightBorder - 16) {
             performEllermanBombDetection(frameId, x, width, leftBorder, rightBorder, polynomial, columnStats, globalLineAvgForEllermanDetection, globalWingAvgForEllermanDetection)
                     .ifPresent(flare ->
                             candidateFlares.add(new CandidateFlare(
@@ -533,19 +545,29 @@ public class PhenomenaDetector {
         if (flares != null) {
             return new Flares(flares);
         }
-        filterFlaresTooCloseToBorder();
+        var candidates = new ArrayList<>(candidateFlares);
+        filterFlaresTooCloseToBorder(candidates);
         // remove candidate flares detected on too small spans
-        candidateFlares.sort(Comparator.<CandidateFlare>comparingDouble(c -> c.flare().score()).reversed());
-        if (!candidateFlares.isEmpty()) {
-            List<Flare> bombs = candidateFlares.stream().map(CandidateFlare::flare).collect(Collectors.toList());
-            // remove flares that are too close to each other
+        candidates.sort(Comparator.<CandidateFlare>comparingDouble(c -> c.flare().score()).reversed());
+        if (!candidates.isEmpty()) {
+            // Take the top-N highest-scoring candidates before the O(n²) dedup.
+            // Caps cost and acts as a noise filter: anything past rank N is too
+            // weak to compete with the strongest detections in this image.
+            var topCandidates = candidates.size() > MAX_ELLERMAN_CANDIDATE_LIMIT
+                    ? candidates.subList(0, MAX_ELLERMAN_CANDIDATE_LIMIT)
+                    : candidates;
+            List<Flare> bombs = topCandidates.stream().map(CandidateFlare::flare).collect(Collectors.toList());
+            // remove flares that are too close to each other; the dedup
+            // distance is wider for FLARE than ELLERMAN_BOMB because flares
+            // are spatially broader phenomena than thin Ellerman bombs.
             for (int i = 0; i < bombs.size(); i++) {
                 var bomb = bombs.get(i);
                 var p1 = new Point2D(bomb.x(), bomb.y());
+                var dedupDistance = bomb.kind() == Flare.Kind.FLARE ? FLARE_DEDUP_DISTANCE : ELLERMAN_LOCAL_RANGE;
                 for (int j = bombs.size() - 1; j > i; j--) {
                     var otherBomb = bombs.get(j);
                     var p2 = new Point2D(otherBomb.x(), otherBomb.y());
-                    if (p1.distanceTo(p2) < ELLERMAN_LOCAL_RANGE) {
+                    if (p1.distanceTo(p2) < dedupDistance) {
                         bombs.remove(j);
                     }
                 }
@@ -562,13 +584,13 @@ public class PhenomenaDetector {
         return new Flares(flares);
     }
 
-    private void filterFlaresTooCloseToBorder() {
+    private void filterFlaresTooCloseToBorder(List<CandidateFlare> candidates) {
         try {
             var ellipse = new EllipseRegression(borderPoints).solve();
             var semiAxis = ellipse.semiAxis();
             var maxDist = Math.max(semiAxis.a(), semiAxis.b());
             var limit = 0.08d * maxDist;
-            candidateFlares.removeIf(c -> {
+            candidates.removeIf(c -> {
                 var flare = c.flare();
                 var frameId = c.frameId();
                 var sourceX = flare.sourceX();
@@ -769,8 +791,8 @@ public class PhenomenaDetector {
     /**
      * Checks if 2 areas are less than distance apart
      *
-     * @param area1 the first area
-     * @param area2 the second area
+     * @param area1    the first area
+     * @param area2    the second area
      * @param distance the distance
      * @return true if the areas are less than distance apart
      */

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/AbstractImageWriterTask.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/AbstractImageWriterTask.java
@@ -26,7 +26,9 @@ import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import java.io.File;
 import java.util.function.Supplier;
 
-/** Abstract base class for tasks that write images to files. */
+/**
+ * Abstract base class for tasks that write images to files.
+ */
 public abstract class AbstractImageWriterTask extends AbstractTask<Void> {
     private final File outputDirectory;
     private final String title;
@@ -37,14 +39,14 @@ public abstract class AbstractImageWriterTask extends AbstractTask<Void> {
     /**
      * Creates an image writer task.
      *
-     * @param broadcaster the broadcaster
-     * @param operation the progress operation
-     * @param image the image supplier
+     * @param broadcaster     the broadcaster
+     * @param operation       the progress operation
+     * @param image           the image supplier
      * @param outputDirectory the output directory
-     * @param title the image title
-     * @param name the output file name
-     * @param description the image description
-     * @param kind the image kind
+     * @param title           the image title
+     * @param name            the output file name
+     * @param description     the image description
+     * @param kind            the image kind
      */
     protected AbstractImageWriterTask(Broadcaster broadcaster,
                                       ProgressOperation operation,
@@ -62,7 +64,12 @@ public abstract class AbstractImageWriterTask extends AbstractTask<Void> {
         this.description = description;
     }
 
-    /** Transforms the image before writing. Subclasses can override this method. */
+    /**
+     * Transforms the image before writing. Subclasses can override this method.
+     * As with the rest of the {@link AbstractTask} contract, overrides must
+     * not mutate the work image — they should allocate their own buffer if
+     * a transformed result is needed.
+     */
     public void transform() {
 
     }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/AbstractTask.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/AbstractTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2023 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,9 +27,33 @@ import java.util.function.Supplier;
 /**
  * Abstract base class for processing tasks.
  *
+ * <p><b>Contract:</b> a task is a function from an input image to a result.
+ * The input image — the {@code workImage} field set by {@link #prepareImage()}
+ * — is treated as <b>read-only</b>. Subclasses must not mutate
+ * {@code workImage.data()} (the float[][] buffer), nor add/remove entries
+ * from {@code workImage.metadata()}. Reassigning the {@code workImage} field
+ * to point at a different {@link ImageWrapper32} is fine; that is not a
+ * mutation of the input.
+ *
+ * <p>If a task needs a buffer it can write to, it allocates one explicitly
+ * (typically via {@code workImage.copy()} at the top of {@link #doCall()}).
+ * Making mutation visible at the call site is the point — the previous
+ * always-copy default hid an expensive allocation per task and was wasted
+ * for every read-only subclass.
+ *
+ * <p><b>Mutation guard (development aid):</b> setting the environment
+ * variable {@code JSOLEX_TASK_MUTATION_GUARD=true} enables a hash-based
+ * before/after check around {@link #doCall()} that throws if the input
+ * image was mutated. The guard is gated on a {@code static final boolean}
+ * read once at class load, so when the variable is unset the JIT
+ * dead-code-eliminates the check entirely (zero runtime cost).
+ *
  * @param <T> the result type
  */
 public abstract class AbstractTask<T> implements Callable<T>, Supplier<T> {
+    private static final boolean MUTATION_GUARD_ENABLED =
+            "true".equalsIgnoreCase(System.getenv("JSOLEX_TASK_MUTATION_GUARD"));
+
     /**
      * The progress operation for tracking task execution.
      */
@@ -46,7 +70,8 @@ public abstract class AbstractTask<T> implements Callable<T>, Supplier<T> {
     protected final Broadcaster broadcaster;
 
     /**
-     * The work image being processed.
+     * The work image being processed. Treated as read-only by subclasses
+     * (see class-level contract).
      */
     protected ImageWrapper32 workImage;
 
@@ -61,12 +86,11 @@ public abstract class AbstractTask<T> implements Callable<T>, Supplier<T> {
     protected int height;
 
     /**
-     * Creates an abstract task
+     * Creates an abstract task.
      *
-     * @param broadcaster the broadcaster for progress events
-     * @param operation the progress operation
-     * @param imageSupplier the current image. A copy will be created in the
-     * constructor, so that this task works with its own buffer
+     * @param broadcaster   the broadcaster for progress events
+     * @param operation     the progress operation
+     * @param imageSupplier the source image; this task must not mutate it
      */
     protected AbstractTask(Broadcaster broadcaster,
                            ProgressOperation operation,
@@ -79,13 +103,32 @@ public abstract class AbstractTask<T> implements Callable<T>, Supplier<T> {
     @Override
     public final T call() throws Exception {
         prepareImage();
-        return doCall();
+        ImageWrapper32 input = null;
+        int hashBefore = 0;
+        if (MUTATION_GUARD_ENABLED) {
+            input = workImage;
+            hashBefore = hashImage(input);
+        }
+        T result = doCall();
+        if (MUTATION_GUARD_ENABLED) {
+            int hashAfter = hashImage(input);
+            if (hashBefore != hashAfter) {
+                throw new IllegalStateException(getClass().getName()
+                        + " mutated its input image (data hash " + hashBefore
+                        + " -> " + hashAfter + ")");
+            }
+        }
+        return result;
     }
 
-    /** Prepares the image for processing by creating a working copy. */
+    /**
+     * Prepares the image for processing. Stores the source image directly —
+     * no defensive copy. Subclasses that need to mutate must allocate their
+     * own buffer in {@link #doCall()}.
+     */
     protected void prepareImage() {
         var image = workImageSupplier.get();
-        this.workImage = image.copy();
+        this.workImage = image;
         this.width = image.width();
         this.height = image.height();
     }
@@ -96,7 +139,7 @@ public abstract class AbstractTask<T> implements Callable<T>, Supplier<T> {
      * @return the task result
      * @throws Exception if an error occurs
      */
-    protected abstract T doCall() throws Exception ;
+    protected abstract T doCall() throws Exception;
 
     @Override
     public final T get() {
@@ -108,7 +151,8 @@ public abstract class AbstractTask<T> implements Callable<T>, Supplier<T> {
     }
 
     /**
-     * Returns this task image buffer
+     * Returns this task image buffer. Subclasses must not mutate the
+     * returned array (see class-level contract).
      *
      * @return the image data buffer
      */
@@ -117,12 +161,24 @@ public abstract class AbstractTask<T> implements Callable<T>, Supplier<T> {
     }
 
     /**
-     * Returns the image metadata.
+     * Returns the image metadata. Subclasses must not add or remove
+     * entries from the returned map (see class-level contract).
      *
      * @return the metadata map
      */
     public Map<Class<?>, Object> getMetadata() {
         return workImage.metadata();
+    }
+
+    private static int hashImage(ImageWrapper32 image) {
+        int hash = 1;
+        for (float[] row : image.data()) {
+            for (float v : row) {
+                hash = 31 * hash + Float.floatToIntBits(v);
+            }
+        }
+        hash = 31 * hash + image.metadata().size();
+        return hash;
     }
 
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/CoronagraphTask.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/CoronagraphTask.java
@@ -41,15 +41,17 @@ public class CoronagraphTask extends AbstractTask<ImageWrapper32> {
 
     @Override
     protected ImageWrapper32 doCall() throws Exception {
-        var buffer = getBuffer();
-        DiskFill.doFillWithGradient(fitting, buffer, 0);
+        // The disk-fill, background-removal and stretching steps below mutate
+        // their target buffer in place. The base class no longer provides a
+        // defensive copy, so we make our own owned copy here.
+        var work = workImage.copy();
+        DiskFill.doFillWithGradient(fitting, work.data(), 0);
         for (int i = 0; i < 2; i++) {
-            workImage = BackgroundRemoval.neutralizeBackground(workImage);
+            work = BackgroundRemoval.neutralizeBackground(work);
         }
-        buffer = workImage.data();
-        new ArcsinhStretchingStrategy(0, 50, 50).stretch(workImage);
-        workImage = new ImageWrapper32(width, height, buffer, workImage.metadata());
-        return workImage;
+        var buffer = work.data();
+        new ArcsinhStretchingStrategy(0, 50, 50).stretch(work);
+        return new ImageWrapper32(width, height, buffer, work.metadata());
     }
 
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/EllipseFittingTask.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/tasks/EllipseFittingTask.java
@@ -119,14 +119,19 @@ public class EllipseFittingTask extends AbstractTask<EllipseFittingTask.Result> 
         workImage = ImageWrapper32.fromImage(tmp);
         // Perform background neutralization to reduce impact of reflections,
         // particularly visible close to UV. We perform multiple iterations
-        // because some gradients are particularly difficult to remove
+        // because some gradients are particularly difficult to remove. The
+        // working buffer is allocated once and reused across all iterations
+        // — each call reads from the previous iteration's result (which lives
+        // in `bgBuffer`) and writes back into the same buffer. Was up to 17
+        // large allocations per task; now 1.
+        var bgBuffer = new float[height][width];
         double bg = Constants.MAX_PIXEL_VALUE;
-        var blindBg = BackgroundRemoval.blindBackgroundNeutralization(workImage);
+        var blindBg = BackgroundRemoval.blindBackgroundNeutralization(workImage, bgBuffer);
         workImage = blindBg.neutralized();
         int maxIterations = 16;
         while (Math.abs(bg - blindBg.averageBackground()) / Math.max(bg, blindBg.averageBackground()) > 0.02 && maxIterations-- > 0) {
             bg = blindBg.averageBackground();
-            blindBg = BackgroundRemoval.blindBackgroundNeutralization(workImage);
+            blindBg = BackgroundRemoval.blindBackgroundNeutralization(workImage, bgBuffer);
             workImage = blindBg.neutralized();
             LOGGER.debug("Background level was {}", blindBg.averageBackground());
         }
@@ -137,6 +142,7 @@ public class EllipseFittingTask extends AbstractTask<EllipseFittingTask.Result> 
     /**
      * Returns a list of points, sorted by their distance to the center of the
      * image.
+     *
      * @return
      */
     private List<Point2D> sortByDistanceToEdges(List<Point2D> points) {
@@ -149,13 +155,14 @@ public class EllipseFittingTask extends AbstractTask<EllipseFittingTask.Result> 
      * Only keeps 80% of the points, sorted by their distance to the edges.
      * This helps with eclipse images, where sample points can be found at the moon
      * limb, which are not relevant for the ellipse fitting.
+     *
      * @param points the initial list of points
      * @return the decimated list of points
      */
     private List<Point2D> decimate(List<Point2D> points) {
         return sortByDistanceToEdges(points)
                 .stream()
-                .limit((long) (0.8*points.size()))
+                .limit((long) (0.8 * points.size()))
                 .collect(Collectors.toList());
     }
 

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DefaultImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DefaultImageEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2023 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.ProcessingException;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
 
-import java.awt.Graphics2D;
+import java.awt.*;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -35,6 +35,15 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -45,27 +54,74 @@ import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectorie
 /**
  * An image emitter is a utility tool to generate
  * mono or color images with transformations.
+ *
+ * <p>Emissions are submitted asynchronously to the supplied {@link Executor}.
+ * Each emission's metadata is snapshot at submission time so concurrent
+ * emissions can't race on the input image's metadata map. Callers must
+ * invoke {@link #await()} before proceeding past the workflow boundary
+ * to ensure all submitted writes have completed (and any
+ * {@code ImageGeneratedEvent} listeners have run).
+ *
  */
 public class DefaultImageEmitter implements ImageEmitter {
+    private static final ExecutorService DEFAULT_EXECUTOR = Executors.newCachedThreadPool(r -> new Thread(r, "DefaultImageEmitter"));
+
     private final Broadcaster broadcaster;
     private final ProgressOperation operation;
     private final File outputDir;
+    private final Executor executor;
+    private final AtomicInteger outstanding = new AtomicInteger();
+    private final Lock awaitLock = new ReentrantLock();
+    private final Condition idle = awaitLock.newCondition();
+    private final AtomicReference<Throwable> firstFailure = new AtomicReference<>();
 
     public DefaultImageEmitter(Broadcaster broadcaster,
                                ProgressOperation operation,
                                File outputDir) {
+        this(broadcaster, operation, outputDir, DEFAULT_EXECUTOR);
+    }
+
+    public DefaultImageEmitter(Broadcaster broadcaster,
+                               ProgressOperation operation,
+                               File outputDir,
+                               Executor executor) {
         this.broadcaster = broadcaster;
         this.operation = operation;
         this.outputDir = outputDir;
+        this.executor = executor;
+    }
+
+    private static ImageWrapper32 snapshot(ImageWrapper32 image, GeneratedImageKind kind, String title, String name) {
+        var metadata = new HashMap<>(image.metadata());
+        metadata.put(GeneratedImageMetadata.class, new GeneratedImageMetadata(kind, title, name));
+        return new ImageWrapper32(image.width(), image.height(), image.data(), metadata);
+    }
+
+    private void submit(Runnable task) {
+        outstanding.incrementAndGet();
+        CompletableFuture.runAsync(task, executor)
+                .whenComplete((r, t) -> {
+                    if (t != null) {
+                        firstFailure.compareAndSet(null, t);
+                    }
+                    if (outstanding.decrementAndGet() == 0) {
+                        awaitLock.lock();
+                        try {
+                            idle.signalAll();
+                        } finally {
+                            awaitLock.unlock();
+                        }
+                    }
+                });
     }
 
     @Override
     public void newMonoImage(GeneratedImageKind kind, String category, String title, String name, String description, ImageWrapper32 image, Consumer<? super float[][]> bufferConsumer) {
         prepareOutput(name);
-        storeMetadata(kind, title, name, image);
-        new WriteMonoImageTask(broadcaster,
+        var snapshot = snapshot(image, kind, title, name);
+        submit(() -> new WriteMonoImageTask(broadcaster,
                 operation,
-                () -> image,
+                () -> snapshot,
                 outputDir,
                 title,
                 name,
@@ -76,11 +132,7 @@ public class DefaultImageEmitter implements ImageEmitter {
             public void transform() {
                 bufferConsumer.accept(getBuffer());
             }
-        }.get();
-    }
-
-    private static Object storeMetadata(GeneratedImageKind kind, String title, String name, ImageWrapper32 image) {
-        return image.metadata().put(GeneratedImageMetadata.class, new GeneratedImageMetadata(kind, title, name));
+        }.get());
     }
 
     private void prepareOutput(String name) {
@@ -96,83 +148,91 @@ public class DefaultImageEmitter implements ImageEmitter {
     @Override
     public void newMonoImage(GeneratedImageKind kind, String category, String title, String name, String description, ImageWrapper32 image) {
         prepareOutput(name);
-        storeMetadata(kind, title, name, image);
-        new WriteMonoImageTask(broadcaster,
+        var snapshot = snapshot(image, kind, title, name);
+        submit(() -> new WriteMonoImageTask(broadcaster,
                 operation,
-                () -> image,
+                () -> snapshot,
                 outputDir,
                 title,
                 name,
                 description,
-                kind).get();
+                kind).get());
     }
 
     @Override
     public void newColorImage(GeneratedImageKind kind, String category, String title, String name, String description, ImageWrapper32 image, Function<ImageWrapper32, float[][][]> rgbSupplier) {
         prepareOutput(name);
-        storeMetadata(kind, title, name, image);
-        new WriteColorizedImageTask(broadcaster,
+        var snapshot = snapshot(image, kind, title, name);
+        submit(() -> new WriteColorizedImageTask(broadcaster,
                 operation,
-                () -> image,
+                () -> snapshot,
                 outputDir,
                 title,
                 name,
                 description,
                 kind,
-                rgbSupplier).get();
+                rgbSupplier).get());
     }
 
     @Override
     public void newColorImage(GeneratedImageKind kind, String category, String title, String name, String description, ImageWrapper32 image, Function<ImageWrapper32, float[][][]> rgbSupplier, BiConsumer<Graphics2D, ? super ImageWrapper> painter) {
         newColorImage(kind, null, title, name, description, image, img -> {
             var rgb = rgbSupplier.apply(img);
-            var r = rgb[0];
-            var g = rgb[1];
-            var b = rgb[2];
-            var copy = new RGBImage(
-                    img.width(),
-                    img.height(),
-                    r,
-                    g,
-                    b,
-                    new HashMap<>(image.metadata())
-            );
-            var draw = new ImageDraw(Map.of(), broadcaster);
-            RGBImage color = (RGBImage) draw.drawOnImage(copy, painter);
-            return new float[][][]{color.r(), color.g(), color.b()};
+            var copy = new RGBImage(img.width(), img.height(), rgb[0], rgb[1], rgb[2], new HashMap<>(image.metadata()));
+            ImageDraw.drawOnImageInPlace(copy, painter);
+            return new float[][][]{copy.r(), copy.g(), copy.b()};
         });
     }
 
     @Override
     public void newColorImage(GeneratedImageKind kind, String category, String title, String name, String description, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][][]> rgbSupplier) {
         prepareOutput(name);
-        new WriteRGBImageTask(broadcaster,
+        // The supplier here builds the source image lazily; capture by reference.
+        var capturedMetadata = new HashMap<>(metadata);
+        capturedMetadata.put(GeneratedImageMetadata.class, new GeneratedImageMetadata(kind, title, name));
+        submit(() -> new WriteRGBImageTask(broadcaster,
                 operation,
-                () -> {
-                    var image = new ImageWrapper32(width, height, new float[height][width], new HashMap<>(metadata));
-                    storeMetadata(kind, title, name, image);
-                    return image;
-                },
+                () -> new ImageWrapper32(width, height, new float[height][width], capturedMetadata),
                 outputDir,
                 title,
                 name,
                 description,
                 kind,
-                rgbSupplier).get();
+                rgbSupplier).get());
     }
 
     @Override
     public void newGenericFile(GeneratedImageKind kind, String category, String title, String name, String description, Path file) {
         prepareOutput(name);
-
         var fileName = file.getFileName().toString();
         String extension = fileName.substring(fileName.lastIndexOf("."));
         var targetFile = outputDir.toPath().resolve(name + extension);
+        // File moves are cheap and small; keep them on the calling thread to
+        // avoid races with subsequent operations that depend on the move.
         try {
             Files.move(file, targetFile, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             throw new ProcessingException(e);
         }
         broadcaster.broadcast(FileGeneratedEvent.of(kind, title, targetFile));
+    }
+
+    @Override
+    public void await() {
+        awaitLock.lock();
+        try {
+            while (outstanding.get() > 0) {
+                idle.await();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ProcessingException(e);
+        } finally {
+            awaitLock.unlock();
+        }
+        var t = firstFailure.getAndSet(null);
+        if (t != null) {
+            throw ProcessingException.wrap(t.getCause() != null ? t.getCause() : t);
+        }
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DiscardNonRequiredImages.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DiscardNonRequiredImages.java
@@ -90,4 +90,9 @@ public class DiscardNonRequiredImages implements ImageEmitter {
         }
         delegate.newGenericFile(kind, category, title, name, description, file);
     }
+
+    @Override
+    public void await() {
+        delegate.await();
+    }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DopplerSupport.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DopplerSupport.java
@@ -108,8 +108,8 @@ public class DopplerSupport {
     }
 
     private void produceRotationCorrectedDopplerImage(ImageWrapper32 grey1, ImageWrapper32 grey2,
-                                                         int width, int height,
-                                                         Map<Class<?>, Object> metadata) {
+                                                      int width, int height,
+                                                      Map<Class<?>, Object> metadata) {
         var corrected1 = grey1.copy();
         var corrected2 = grey2.copy();
         if (!cancelRotationGradient(width, height, corrected1, corrected2)) {
@@ -148,6 +148,7 @@ public class DopplerSupport {
         var xty = new double[POLY_TERMS];
         var fitRadius = 0.97 * radius;
         var fitRadius2 = fitRadius * fitRadius;
+        var terms = new double[POLY_TERMS];
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
                 var px = x - cx;
@@ -158,7 +159,7 @@ public class DopplerSupport {
                 var dx = px / radius;
                 var dy = py / radius;
                 var diff = d1[y][x] - d2[y][x];
-                var terms = polyTerms2D(dx, dy);
+                polyTerms2DInto(dx, dy, terms);
                 for (int i = 0; i < POLY_TERMS; i++) {
                     xty[i] += terms[i] * diff;
                     for (int j = i; j < POLY_TERMS; j++) {
@@ -199,7 +200,7 @@ public class DopplerSupport {
                 }
                 var dx = px / radius;
                 var dy = py / radius;
-                var terms = polyTerms2D(dx, dy);
+                polyTerms2DInto(dx, dy, terms);
                 double surface = 0;
                 for (int i = 0; i < POLY_TERMS; i++) {
                     surface += coeffs[i] * terms[i];
@@ -212,16 +213,14 @@ public class DopplerSupport {
         return true;
     }
 
-    private static double[] polyTerms2D(double dx, double dy) {
-        var terms = new double[POLY_TERMS];
+    private static void polyTerms2DInto(double dx, double dy, double[] out) {
         int idx = 0;
         for (int d = 0; d <= POLY_DEGREE; d++) {
             for (int px = d; px >= 0; px--) {
                 int py = d - px;
-                terms[idx++] = Math.pow(dx, px) * Math.pow(dy, py);
+                out[idx++] = Math.pow(dx, px) * Math.pow(dy, py);
             }
         }
-        return terms;
     }
 
     static float[][][] toDopplerImage(int width, int height, ImageWrapper32 grey1, ImageWrapper32 grey2) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ImageEmitter.java
@@ -70,4 +70,13 @@ public interface ImageEmitter {
     void newColorImage(GeneratedImageKind kind, String category, String title, String name, String description, int width, int height, Map<Class<?>, Object> metadata, Supplier<float[][][]> rgbSupplier);
 
     void newGenericFile(GeneratedImageKind kind, String category, String title, String name, String description, Path file);
+
+    /**
+     * Awaits all pending asynchronous emissions submitted to this emitter.
+     * Implementations that emit synchronously may keep the default no-op.
+     * Wrapping emitters must override to forward to the wrapped instance.
+     */
+    default void await() {
+        // no-op for synchronous implementations
+    }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/NamingStrategyAwareImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/NamingStrategyAwareImageEmitter.java
@@ -77,4 +77,9 @@ public class NamingStrategyAwareImageEmitter implements ImageEmitter {
     public void newGenericFile(GeneratedImageKind kind, String category, String title, String name, String description, Path file) {
         delegate.newGenericFile(kind, null, title, rename(kind, name, category, null), description, file);
     }
+
+    @Override
+    public void await() {
+        delegate.await();
+    }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/ProcessingWorkflow.java
@@ -126,6 +126,18 @@ public class ProcessingWorkflow {
     }
 
     public void start() {
+        try {
+            startInternal();
+        } finally {
+            // Wait for all asynchronously-submitted image emissions to finish
+            // before returning. This is the workflow boundary: callers expect
+            // the workflow to be fully complete (including disk writes) when
+            // start() returns.
+            imagesEmitter.await();
+        }
+    }
+
+    private void startInternal() {
         emitReconImage();
         var existingFitting = state.findResult(WorkflowResults.MAIN_ELLIPSE_FITTING);
         if (existingFitting.isPresent()) {
@@ -220,31 +232,39 @@ public class ProcessingWorkflow {
             imagesEmitter.newMonoImage(GeneratedImageKind.GEOMETRY_CORRECTED_PROCESSED, null, message("processed"), processParams.contrastEnhancement().name().toLowerCase(Locale.US),
                     String.format(message("contrast.enhanced.description"), state.pixelShift(), processParams.contrastEnhancement()), stretched);
         }
+        // Each runnable below runs on a parallel worker. Many of the produce*
+        // methods stretch/smooth their input image in place, so callers must
+        // hand them a private copy — otherwise concurrent runnables racing on
+        // the same float[][] would corrupt each other's outputs.
         var runnables = new ArrayList<Runnable>();
         if (isMainShift() && shouldProduce(GeneratedImageKind.NEGATIVE)) {
-            runnables.add(() -> produceNegativeImage(enhanced));
+            runnables.add(() -> produceNegativeImage(enhanced.copy()));
         }
         if (isMainShift() && shouldProduce(GeneratedImageKind.COLORIZED)) {
-            runnables.add(() -> produceColorizedImage(blackPoint, stretched, processParams));
+            runnables.add(() -> produceColorizedImage(blackPoint, stretched.copy(), processParams));
         }
         if (isMainShift()) {
-            runnables.add(() -> produceCoronagraph(blackPoint, enhanced));
+            runnables.add(() -> produceCoronagraph(blackPoint, enhanced.copy()));
         }
         if (isMainShift() && shouldProduce(GeneratedImageKind.TECHNICAL_CARD)) {
-            produceTechnicalCard(stretched);
+            if (stretched != null) {
+                runnables.add(() ->
+                        produceTechnicalCard(stretched.copy())
+                );
+            }
         }
         if (shouldProduce(GeneratedImageKind.ACTIVE_REGIONS)) {
             if (isMainShift()) {
-                produceActiveRegionsImage(enhanced);
+                runnables.add(() -> produceActiveRegionsImage(enhanced.copy()));
             }
             if (shouldProduce(GeneratedImageKind.CONTINUUM) && state.pixelShift() == processParams.spectrumParams().continuumShift()) {
-                produceActiveRegionsImage(enhanced);
+                runnables.add(() -> produceActiveRegionsImage(enhanced.copy()));
             }
         }
         if (processParams.spectrumParams().pixelShift() == 0 && isMainShift() && shouldProduce(GeneratedImageKind.REDSHIFT)) {
             geometryFixed.findMetadata(Redshifts.class).ifPresent(redshifts -> {
                 if (!redshifts.redshifts().isEmpty()) {
-                    runnables.add(() -> produceRedshiftsImage(geometryFixed, redshifts.redshifts()));
+                    runnables.add(() -> produceRedshiftsImage(geometryFixed.copy(), redshifts.redshifts()));
                 }
             });
         }
@@ -253,7 +273,7 @@ public class ProcessingWorkflow {
             geometryFixed.findMetadata(Flares.class).ifPresent(flares -> {
                 var flareList = flares.flares();
                 if (!flareList.isEmpty()) {
-                    runnables.add(() -> produceEllermanBombsImage(geometryFixed, flareList));
+                    runnables.add(() -> produceEllermanBombsImage(geometryFixed.copy(), flareList));
                 }
             });
         }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/RenamingImageEmitter.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/RenamingImageEmitter.java
@@ -70,4 +70,9 @@ public class RenamingImageEmitter implements ImageEmitter {
     public void newGenericFile(GeneratedImageKind kind, String category, String title, String name, String description, Path file) {
         delegate.newGenericFile(kind, null, titleRenamer.apply(title), fileRenamer.apply(name), description, file);
     }
+
+    @Override
+    public void await() {
+        delegate.await();
+    }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImage.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImage.java
@@ -15,6 +15,7 @@
  */
 package me.champeau.a4j.jsolex.processing.util;
 
+import me.champeau.a4j.utilities.HeapPressure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +29,7 @@ import java.io.IOException;
 import java.lang.ref.Cleaner;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.SoftReference;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -38,11 +40,13 @@ import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BooleanSupplier;
 
 /**
  * An image wrapper where data is stored on disk instead of
@@ -62,6 +66,7 @@ public final class FileBackedImage implements ImageWrapper {
     private static final int DEFAULT_RW_BUFFER_SIZE = 65536;
     private static final ReferenceQueue<ImageWrapper> REFERENCE_QUEUE = new ReferenceQueue<>();
 
+    private static volatile BooleanSupplier underPressure = () -> HeapPressure.current() > 0.5;
 
     static {
         var flushing = new Thread(() -> {
@@ -82,23 +87,47 @@ public final class FileBackedImage implements ImageWrapper {
         var autoFlush = new Thread(() -> {
             while (true) {
                 try {
+                    System.gc();
                     Thread.sleep(AUTOFLUSH_TIMEOUT);
+                    var event = new FileBackedImageAutoFlushEvent();
+                    event.begin();
+                    var ratio = HeapPressure.current();
+                    event.pressureRatio = ratio;
+                    if (!underPressure.getAsBoolean()) {
+                        event.triggered = false;
+                        event.commit();
+                        continue;
+                    }
+                    event.triggered = true;
                     long now = System.currentTimeMillis();
+                    // Snapshot under the lock; filter and flush outside it. The
+                    // wrap path uses CACHE_LOCK as backpressure under pressure,
+                    // so we hold it as briefly as possible here to avoid
+                    // serializing wraps for non-throttle reasons.
+                    List<FileBackedImage> snapshot;
                     CACHE_LOCK.lock();
                     try {
-                        var toFlush = WRAP_CACHE.values()
-                                .stream()
+                        snapshot = new ArrayList<>(WRAP_CACHE.values());
+                    } finally {
+                        CACHE_LOCK.unlock();
+                    }
+                    try {
+                        var candidates = snapshot.stream()
                                 .filter(fbi -> fbi.unwrapped.get() != null)
+                                .toList();
+                        var toFlush = candidates.stream()
                                 .filter(fbi -> now - fbi.lastAccessTime.get() > AUTOFLUSH_TIMEOUT)
                                 .toList();
+                        event.candidateCount = candidates.size();
+                        event.flushedCount = toFlush.size();
                         if (!toFlush.isEmpty()) {
                             LOGGER.debug("Auto-flushing {} images", toFlush.size());
                             for (var fbi : toFlush) {
-                                fbi.flushToDisk(fbi.unwrapped.source);
+                                fbi.flushToDisk(fbi.unwrapped.source, "AUTOFLUSH");
                             }
                         }
                     } finally {
-                        CACHE_LOCK.unlock();
+                        event.commit();
                     }
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
@@ -118,7 +147,7 @@ public final class FileBackedImage implements ImageWrapper {
     private final Path backingFile;
     private final Map<Class<?>, Object> metadata;
     private final Object keptInMemory;
-    private ImageReference unwrapped;
+    private volatile ImageReference unwrapped;
     private final AtomicLong lastAccessTime;
 
     private FileBackedImage(int width, int height, Path backingFile, Map<Class<?>, Object> metadata, Object keptInMemory, ImageWrapper source) {
@@ -141,57 +170,80 @@ public final class FileBackedImage implements ImageWrapper {
             LOCK.unlock();
         }
         CLEANER.register(this, () -> clean(backingFile));
-        if (Runtime.getRuntime().freeMemory() < 0.1 * Runtime.getRuntime().totalMemory()) {
-            flushToDisk(source);
+        if (underPressure.getAsBoolean()) {
+            flushToDisk(source, "CONSTRUCTOR");
         }
     }
 
     public static FileBackedImage wrap(ImageWrapper wrapper) {
-        if (wrapper instanceof FileBackedImage fbi) {
-            return fbi;
-        }
-        CACHE_LOCK.lock();
-        // if memory is too close to full, flush some images to disk
-        if (Runtime.getRuntime().freeMemory() < 0.1 * Runtime.getRuntime().totalMemory()) {
-            flushImages();
-        }
+        var event = new FileBackedImageWrapEvent();
+        event.begin();
         try {
-            var cached = WRAP_CACHE.get(wrapper);
-            if (cached != null) {
-                return cached;
+            if (wrapper instanceof FileBackedImage fbi) {
+                event.cached = true;
+                return fbi;
             }
-            var width = wrapper.width();
-            var height = wrapper.height();
+            CACHE_LOCK.lock();
+            // if memory is too close to full, flush some images to disk
+            if (underPressure.getAsBoolean()) {
+                event.triggeredFlush = true;
+                flushImages();
+            }
             try {
-                var backingFile = TemporaryFolder.newTempFile("jsolex", ".img");
-                Files.delete(backingFile);
-                if (wrapper instanceof ImageWrapper32 mono) {
-                    var result = new FileBackedImage(width, height, backingFile, mono.metadata(), null, mono);
-                    WRAP_CACHE.put(wrapper, result);
-                    return result;
+                var cached = WRAP_CACHE.get(wrapper);
+                if (cached != null) {
+                    event.cached = true;
+                    return cached;
                 }
-                if (wrapper instanceof RGBImage rgb) {
-                    var fileBackedImage = new FileBackedImage(width, height, backingFile, rgb.metadata(), null, rgb);
-                    WRAP_CACHE.put(wrapper, fileBackedImage);
-                    return fileBackedImage;
+                var width = wrapper.width();
+                var height = wrapper.height();
+                try {
+                    var backingFile = TemporaryFolder.newTempFile("jsolex", ".img");
+                    Files.delete(backingFile);
+                    if (wrapper instanceof ImageWrapper32 mono) {
+                        var result = new FileBackedImage(width, height, backingFile, mono.metadata(), null, mono);
+                        WRAP_CACHE.put(wrapper, result);
+                        return result;
+                    }
+                    if (wrapper instanceof RGBImage rgb) {
+                        var fileBackedImage = new FileBackedImage(width, height, backingFile, rgb.metadata(), null, rgb);
+                        WRAP_CACHE.put(wrapper, fileBackedImage);
+                        return fileBackedImage;
+                    }
+                    throw new ProcessingException("Unexpected image type " + wrapper);
+                } catch (IOException ex) {
+                    throw new ProcessingException(ex);
                 }
-                throw new ProcessingException("Unexpected image type " + wrapper);
-            } catch (IOException ex) {
-                throw new ProcessingException(ex);
+            } finally {
+                CACHE_LOCK.unlock();
             }
         } finally {
-            CACHE_LOCK.unlock();
+            event.commit();
         }
     }
 
     public static void flushImages() {
-        CACHE_LOCK.lock();
+        // Note to future self (and AI):
+        // Usually, when you see System.gc, it's a code smell.
+        // However, here, it is not. This is by design. We are
+        // using ZGC, which performs lots of small, real time cleanups. When
+        // we reach this point in the code, we have determined that we are
+        // under pressure, and what we want is to serialize to disk images which
+        // are still in use. If we don't do a GC followed by a sleep, then
+        // we may serialize to disk images which are NOT used anymore, which
+        // is a waste of time and resources. It is particularly visible with
+        // more system memory, where we would accumulate images in memory and
+        // never cleanup, and serialize to disk. This triggers may kernel calls
+        // which are clearly visible in profiles.
+        // You may think that sleeping for half a second will increase wall
+        // clock time for processing, but it won't: this runs in a separate
+        // thread, and what is blocked is actually image wrapping, that is that
+        // we throttle image generation, which is what we want in any case,
+        // because we're running out of memory. But the threads which actually
+        // do CPU work will NOT be blocked.
+        System.gc();
         try {
-            System.gc();
-            if (Runtime.getRuntime().freeMemory() < 0.25 * Runtime.getRuntime().totalMemory()) {
-                // This helps with machines which have very low memory available
-                Thread.sleep(1_000);
-            }
+            CACHE_LOCK.lock();
             var fbiToFlush = WRAP_CACHE.values()
                     .stream()
                     .filter(fbi -> fbi.unwrapped.get() != null)
@@ -199,91 +251,118 @@ public final class FileBackedImage implements ImageWrapper {
             if (fbiToFlush.isEmpty()) {
                 return;
             }
+            var event = new FileBackedImageFlushEvent();
+            event.begin();
+            event.imageCount = fbiToFlush.size();
             LOGGER.debug("Flushing {} images to disk to free memory", fbiToFlush.size());
-            try (var executor = Executors.newFixedThreadPool(Math.max(1, Runtime.getRuntime().availableProcessors() / 2))) {
+            try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+                var semaphore = new Semaphore(4);
                 for (var fbi : fbiToFlush) {
                     executor.submit(() -> {
-                        if (Runtime.getRuntime().freeMemory() > 0.5 * Runtime.getRuntime().totalMemory()) {
+                        if (!underPressure.getAsBoolean() || fbi.unwrapped.get() == null) {
                             return;
                         }
-                        var status = fbi.status;
-                        var condition = status.newCondition();
-                        fbi.flushToDisk(fbi.unwrapped.source);
-                        status.lock().lock();
+                        semaphore.acquireUninterruptibly();
                         try {
-                            while (!status.saved().get()) {
-                                try {
-                                    condition.await();
-                                } catch (InterruptedException e) {
-                                    Thread.currentThread().interrupt();
-                                    break;
-                                }
-                            }
+                            fbi.writeToDisk(fbi.unwrapped.source, "BATCH");
                         } finally {
-                            status.lock().unlock();
+                            semaphore.release();
                         }
                     });
                 }
+            } finally {
+                event.commit();
             }
-            System.gc();
             LOGGER.debug("Flushed images");
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
         } finally {
             CACHE_LOCK.unlock();
         }
     }
 
-    private void flushToDisk(ImageWrapper source) {
+    /**
+     * Asynchronous variant: spawns a virtual thread to perform the write.
+     * Used by callers that don't want to block — the auto-flush thread, the
+     * soft-ref cleaner thread, and the constructor's pressure-triggered flush.
+     * Callers that do want to wait should use {@link #writeToDisk} directly
+     * rather than spawning-then-waiting.
+     */
+    private void flushToDisk(ImageWrapper source, String trigger) {
         if (source == null) {
             return;
         }
-        Thread.startVirtualThread(() -> {
-            status.lock().lock();
-            try {
-                if (status.saved.get() || REF_COUNT.getOrDefault(backingFile, 0) == 0) {
-                    return;
-                }
-                if (source instanceof ImageWrapper32 mono) {
-                    try (var fos = new BufferedOutputStream(new FileOutputStream(backingFile.toFile()), DEFAULT_RW_BUFFER_SIZE);
-                         var dos = new DataOutputStream(fos)) {
-                        dos.writeByte(MONO);
-                        dos.writeInt(height);
-                        dos.writeInt(width);
-                        var data = mono.data();
-                        for (int y = 0; y < height; y++) {
-                            for (int x = 0; x < width; x++) {
-                                dos.writeFloat(data[y][x]);
-                            }
-                        }
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                } else if (source instanceof RGBImage rgb) {
-                    try (var fos = new BufferedOutputStream(new FileOutputStream(backingFile.toFile()), DEFAULT_RW_BUFFER_SIZE);
-                         var dos = new DataOutputStream(fos)) {
-                        dos.writeByte(RGB);
-                        dos.writeInt(height);
-                        dos.writeInt(width);
-                        var r = rgb.r();
-                        var g = rgb.g();
-                        var b = rgb.b();
-                        for (int y = 0; y < height; y++) {
-                            for (int x = 0; x < width; x++) {
-                                dos.writeFloat(r[y][x]);
-                                dos.writeFloat(g[y][x]);
-                                dos.writeFloat(b[y][x]);
-                            }
-                        }
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            } finally {
-                fileSaved();
-                status.lock().unlock();
+        Thread.startVirtualThread(() -> writeToDisk(source, trigger));
+    }
+
+    /**
+     * Synchronous variant: writes the source to disk on the calling thread.
+     * Idempotent — subsequent calls short-circuit on {@code status.saved}.
+     * Holds {@code status.lock()} for the duration so concurrent writers of
+     * the same image serialize safely.
+     */
+    private void writeToDisk(ImageWrapper source, String trigger) {
+        if (source == null) {
+            return;
+        }
+        var event = new FileBackedImageWriteEvent();
+        event.begin();
+        event.trigger = trigger;
+        status.lock().lock();
+        try {
+            if (status.saved.get() || REF_COUNT.getOrDefault(backingFile, 0) == 0) {
+                event.skipped = true;
+                return;
             }
-        });
+            long bytes = 0;
+            if (source instanceof ImageWrapper32 mono) {
+                try (var fos = new BufferedOutputStream(new FileOutputStream(backingFile.toFile()), DEFAULT_RW_BUFFER_SIZE);
+                     var dos = new DataOutputStream(fos)) {
+                    dos.writeByte(MONO);
+                    dos.writeInt(height);
+                    dos.writeInt(width);
+                    var data = mono.data();
+                    var rowBytes = new byte[width * Float.BYTES];
+                    var rowFloats = ByteBuffer.wrap(rowBytes).asFloatBuffer();
+                    for (int y = 0; y < height; y++) {
+                        rowFloats.clear();
+                        rowFloats.put(data[y]);
+                        fos.write(rowBytes);
+                    }
+                    bytes = 1L + 8L + (long) height * rowBytes.length;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            } else if (source instanceof RGBImage rgb) {
+                try (var fos = new BufferedOutputStream(new FileOutputStream(backingFile.toFile()), DEFAULT_RW_BUFFER_SIZE);
+                     var dos = new DataOutputStream(fos)) {
+                    dos.writeByte(RGB);
+                    dos.writeInt(height);
+                    dos.writeInt(width);
+                    var r = rgb.r();
+                    var g = rgb.g();
+                    var b = rgb.b();
+                    var rowBytes = new byte[width * 3 * Float.BYTES];
+                    var rowFloats = ByteBuffer.wrap(rowBytes).asFloatBuffer();
+                    for (int y = 0; y < height; y++) {
+                        rowFloats.clear();
+                        var rRow = r[y];
+                        var gRow = g[y];
+                        var bRow = b[y];
+                        for (int x = 0; x < width; x++) {
+                            rowFloats.put(rRow[x]).put(gRow[x]).put(bRow[x]);
+                        }
+                        fos.write(rowBytes);
+                    }
+                    bytes = 1L + 8L + (long) height * rowBytes.length;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            event.bytes = bytes;
+        } finally {
+            fileSaved();
+            status.lock().unlock();
+            event.commit();
+        }
     }
 
     public ImageWrapper unwrapToMemory() {
@@ -291,6 +370,10 @@ public final class FileBackedImage implements ImageWrapper {
         var cached = unwrapped.get();
         if (cached != null) {
             return cached;
+        }
+        var stillAlive = unwrapped.source;
+        if (stillAlive != null) {
+            return stillAlive;
         }
         LOGGER.debug("Re-reading image from disk: {}", backingFile);
         status.lock().lock();
@@ -328,10 +411,12 @@ public final class FileBackedImage implements ImageWrapper {
             return switch (kind) {
                 case MONO -> {
                     float[][] data = new float[height][width];
+                    var rowBytes = new byte[width * Float.BYTES];
+                    var rowFloats = ByteBuffer.wrap(rowBytes).asFloatBuffer();
                     for (int y = 0; y < height; y++) {
-                        for (int x = 0; x < width; x++) {
-                            data[y][x] = dis.readFloat();
-                        }
+                        dis.readFully(rowBytes);
+                        rowFloats.clear();
+                        rowFloats.get(data[y]);
                     }
                     yield new ImageWrapper32(width, height, data, metadata);
                 }
@@ -339,11 +424,18 @@ public final class FileBackedImage implements ImageWrapper {
                     float[][] r = new float[height][width];
                     float[][] g = new float[height][width];
                     float[][] b = new float[height][width];
+                    var rowBytes = new byte[width * 3 * Float.BYTES];
+                    var rowFloats = ByteBuffer.wrap(rowBytes).asFloatBuffer();
                     for (int y = 0; y < height; y++) {
+                        dis.readFully(rowBytes);
+                        rowFloats.clear();
+                        var rRow = r[y];
+                        var gRow = g[y];
+                        var bRow = b[y];
                         for (int x = 0; x < width; x++) {
-                            r[y][x] = dis.readFloat();
-                            g[y][x] = dis.readFloat();
-                            b[y][x] = dis.readFloat();
+                            rRow[x] = rowFloats.get();
+                            gRow[x] = rowFloats.get();
+                            bRow[x] = rowFloats.get();
                         }
                     }
                     yield new RGBImage(width, height, r, g, b, metadata);
@@ -382,6 +474,41 @@ public final class FileBackedImage implements ImageWrapper {
         unwrapped.clear();
     }
 
+
+    /**
+     * Test-only hook: replace the heap-pressure decision used by all eviction
+     * paths. Pass {@code null} to restore the default runtime-based check.
+     */
+    static void setPressureSupplierForTesting(BooleanSupplier supplier) {
+        underPressure = supplier != null ? supplier : () -> {
+            var runtime = Runtime.getRuntime();
+            return runtime.freeMemory() < 0.1 * runtime.totalMemory();
+        };
+    }
+
+    /**
+     * Test-only hook: forces the soft reference to be cleared and enqueued,
+     * simulating a ZGC soft-reference clearing. Returns once the queue daemon
+     * has processed the reference (rearmed or flushed).
+     */
+    void clearSoftReferenceForTesting() throws InterruptedException {
+        var ref = unwrapped;
+        ref.clear();
+        ref.enqueue();
+        // Wait for the daemon to process: either a rearm (new unwrapped instance)
+        // or a flush (source becomes null).
+        long deadline = System.nanoTime() + 5_000_000_000L;
+        while (System.nanoTime() < deadline) {
+            if (unwrapped != ref) {
+                return; // rearmed
+            }
+            if (ref.source == null) {
+                return; // flushed
+            }
+            Thread.sleep(5);
+        }
+        throw new IllegalStateException("Daemon did not process the cleared soft reference within 5s");
+    }
 
     private static void clean(Path backingFile) {
         LOCK.lock();
@@ -436,7 +563,7 @@ public final class FileBackedImage implements ImageWrapper {
 
     private static class ImageReference extends SoftReference<ImageWrapper> {
         private final FileBackedImage image;
-        private ImageWrapper source;
+        private volatile ImageWrapper source;
 
         public ImageReference(ImageWrapper referent, FileBackedImage image, ReferenceQueue<ImageWrapper> queue) {
             super(referent, queue);
@@ -453,7 +580,7 @@ public final class FileBackedImage implements ImageWrapper {
         public void flushToDisk() {
             var source = this.source;
             this.source = null;
-            image.flushToDisk(source);
+            image.flushToDisk(source, "SOFTREF");
         }
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImageAutoFlushEvent.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImageAutoFlushEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.util;
+
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+/**
+ * One iteration of the {@code FileBackedImage} auto-flush daemon: System.gc()
+ * + sleep + pressure check + (optional) sweep. {@code pressureRatio} captures
+ * the value seen after the GC/sleep window; {@code triggered=false} means
+ * pressure was below threshold and no sweep ran. Otherwise {@code candidateCount}
+ * is the number of in-memory FBIs scanned and {@code flushedCount} is how many
+ * met the idle-time threshold and were enqueued for write.
+ */
+@Name("me.champeau.a4j.jsolex.processing.util.FileBackedImageAutoFlush")
+@Label("FileBackedImage auto-flush sweep")
+@Category({"jsolex", "Memory"})
+@StackTrace(false)
+public class FileBackedImageAutoFlushEvent extends Event {
+    @Label("Pressure ratio")
+    public double pressureRatio;
+
+    @Label("Triggered")
+    public boolean triggered;
+
+    @Label("Candidate count")
+    public int candidateCount;
+
+    @Label("Flushed count")
+    public int flushedCount;
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImageFlushEvent.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImageFlushEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.util;
+
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+
+/**
+ * Wraps a {@link FileBackedImage#flushImages()} call. Duration covers the
+ * full operation including the synchronous wait for all writes to complete.
+ * {@code imageCount} is the size of the dirty-list snapshot taken under
+ * {@code CACHE_LOCK} — zero means the call was a no-op (nothing to flush).
+ *
+ * <p>Stack trace is left enabled (default) so callers — {@code wrap()}'s
+ * pressure path vs the explicit per-batch invocation in {@code SolexVideoProcessor}
+ * — are distinguishable in the JFR.
+ */
+@Name("me.champeau.a4j.jsolex.processing.util.FileBackedImageFlush")
+@Label("FileBackedImage flush batch")
+@Category({"jsolex", "Memory"})
+public class FileBackedImageFlushEvent extends Event {
+    @Label("Image count")
+    public int imageCount;
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImageWrapEvent.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImageWrapEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.util;
+
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+/**
+ * Per-call event for {@link FileBackedImage#wrap(ImageWrapper)}. Captures
+ * whether the wrapper was reused from the cache and whether this call
+ * triggered an in-line {@code flushImages()} because the heap was under
+ * pressure. Stack trace disabled — we don't need the call site, just
+ * counts and rates.
+ */
+@Name("me.champeau.a4j.jsolex.processing.util.FileBackedImageWrap")
+@Label("FileBackedImage wrap")
+@Category({"jsolex", "Memory"})
+@StackTrace(false)
+public class FileBackedImageWrapEvent extends Event {
+    @Label("Cached")
+    public boolean cached;
+
+    @Label("Triggered flush")
+    public boolean triggeredFlush;
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImageWriteEvent.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/FileBackedImageWriteEvent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.util;
+
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+
+/**
+ * Per-image disk write triggered by {@code FileBackedImage}. {@code trigger}
+ * names the caller path: {@code CONSTRUCTOR} (FBI created under pressure),
+ * {@code AUTOFLUSH} (the periodic daemon picked an idle FBI), {@code SOFTREF}
+ * (the soft-ref cleaner observed a cleared reference), {@code BATCH} (the
+ * mass {@link FileBackedImage#flushImages()} call), or {@code RECONSTRUCT_END}
+ * (end-of-reconstruction explicit flush). {@code skipped=true} means the call
+ * short-circuited because the image was already on disk.
+ */
+@Name("me.champeau.a4j.jsolex.processing.util.FileBackedImageWrite")
+@Label("FileBackedImage write")
+@Category({"jsolex", "Memory"})
+public class FileBackedImageWriteEvent extends Event {
+    @Label("Trigger")
+    public String trigger;
+
+    @Label("Bytes written")
+    public long bytes;
+
+    @Label("Skipped")
+    public boolean skipped;
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ImageSaver.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ImageSaver.java
@@ -20,6 +20,7 @@ import me.champeau.a4j.jsolex.processing.stretching.StretchingStrategy;
 import me.champeau.a4j.jsolex.processing.sun.ImageUtils;
 
 import java.io.File;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -46,7 +47,8 @@ public class ImageSaver {
             image = fbi.unwrapToMemory();
         }
         if (image instanceof ImageWrapper32 mono) {
-            var stretched = stretch(mono);
+            var buf = new float[mono.height()][mono.width()];
+            var stretched = stretchInto(mono, buf);
             files = ImageUtils.writeMonoImage(image.width(), image.height(), stretched.data(), target, imageFormats);
             if (imageFormats.contains(ImageFormat.FITS)) {
                 var fits = toFits(target);
@@ -54,7 +56,8 @@ public class ImageSaver {
                 FitsUtils.writeFitsFile(stretched, fits, processParams);
             }
         } else if (image instanceof RGBImage rgb) {
-            var stretched = stretch(rgb);
+            var bufs = new float[3][rgb.height()][rgb.width()];
+            var stretched = stretchInto(rgb, bufs);
             var r = stretched.r();
             var g = stretched.g();
             var b = stretched.b();
@@ -68,16 +71,26 @@ public class ImageSaver {
         return files;
     }
 
-    private ImageWrapper32 stretch(ImageWrapper32 image) {
-        var copy = image.copy();
-        stretchingStrategy.stretch(copy);
-        return copy;
+    private ImageWrapper32 stretchInto(ImageWrapper32 image, float[][] buf) {
+        copyInto(image.data(), buf);
+        var stretched = new ImageWrapper32(image.width(), image.height(), buf, new LinkedHashMap<>(image.metadata()));
+        stretchingStrategy.stretch(stretched);
+        return stretched;
     }
 
-    private RGBImage stretch(RGBImage image) {
-        var copy = image.copy();
-        stretchingStrategy.stretch(copy);
-        return copy;
+    private RGBImage stretchInto(RGBImage image, float[][][] bufs) {
+        copyInto(image.r(), bufs[0]);
+        copyInto(image.g(), bufs[1]);
+        copyInto(image.b(), bufs[2]);
+        var stretched = new RGBImage(image.width(), image.height(), bufs[0], bufs[1], bufs[2], new LinkedHashMap<>(image.metadata()));
+        stretchingStrategy.stretch(stretched);
+        return stretched;
+    }
+
+    private static void copyInto(float[][] src, float[][] dst) {
+        for (int y = 0; y < src.length; y++) {
+            System.arraycopy(src[y], 0, dst[y], 0, src[y].length);
+        }
     }
 
     private File toFits(File target) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ImageWrapper.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ImageWrapper.java
@@ -15,6 +15,7 @@
  */
 package me.champeau.a4j.jsolex.processing.util;
 
+
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/MemoryAwareStreams.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/MemoryAwareStreams.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.util;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Helpers to opt streams into parallel execution only when the heap
+ * has enough headroom. Use these on streams whose per-element body
+ * allocates large intermediate buffers (e.g. full-image float[][]).
+ * <p>
+ * Under heap pressure (free heap below 20% of total committed heap)
+ * the returned stream is sequential, avoiding the multiplicative
+ * memory cost of parallel allocation when it can't be afforded.
+ */
+public final class MemoryAwareStreams {
+
+    private static final double PRESSURE_THRESHOLD = 0.2;
+
+    private MemoryAwareStreams() {
+    }
+
+    public static IntStream maybeParallel(IntStream stream) {
+        return underPressure() ? stream : stream.parallel();
+    }
+
+    public static <T> Stream<T> maybeParallel(Stream<T> stream) {
+        return underPressure() ? stream : stream.parallel();
+    }
+
+    private static boolean underPressure() {
+        var runtime = Runtime.getRuntime();
+        return runtime.freeMemory() < PRESSURE_THRESHOLD * runtime.totalMemory();
+    }
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ThumbnailGenerator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/ThumbnailGenerator.java
@@ -15,6 +15,7 @@
  */
 package me.champeau.a4j.jsolex.processing.util;
 
+
 public class ThumbnailGenerator {
     public static ImageWrapper generateThumbnail(ImageWrapper source, int maxWidth, int maxHeight) {
         if (source instanceof FileBackedImage fbi) {

--- a/jsolex-core/src/main/java/module-info.java
+++ b/jsolex-core/src/main/java/module-info.java
@@ -36,6 +36,7 @@ module me.champeau.a4j.jsolex.core {
     requires org.apache.arrow.memory.unsafe;
     requires org.apache.arrow.vector;
     requires org.apache.arrow.c;
+    requires jdk.jfr;
     uses org.apache.arrow.memory.AllocationManager.Factory;
     exports me.champeau.a4j.jsolex.expr;
     exports me.champeau.a4j.jsolex.processing.expr.python;

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/util/FileBackedImageTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/util/FileBackedImageTest.groovy
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.util
+
+import spock.lang.Specification
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.function.BooleanSupplier
+
+class FileBackedImageTest extends Specification {
+
+    def cleanup() {
+        FileBackedImage.setPressureSupplierForTesting(null)
+    }
+
+    def "round-trip preserves mono pixel data exactly through forced flush"() {
+        given: "a real FITS image loaded from test resources"
+        def src = new File(getClass().getResource("/average/Ha/14_38_01.ser-average.fits").file)
+        def original = (ImageWrapper32) FitsUtils.readFitsFile(src)
+        def originalCopy = copyMonoData(original.data())
+
+        and: "an FBI in pressure mode so the constructor flushes immediately"
+        FileBackedImage.setPressureSupplierForTesting({ true } as BooleanSupplier)
+        def fbi = FileBackedImage.wrap(original)
+
+        when: "the soft reference is cleared (data should already be on disk)"
+        fbi.clearSoftReferenceForTesting()
+        def recovered = (ImageWrapper32) fbi.unwrapToMemory()
+
+        then: "every pixel matches"
+        recovered.width() == original.width()
+        recovered.height() == original.height()
+        floatArraysEqual(recovered.data(), originalCopy)
+    }
+
+    def "round-trip preserves RGB pixel data exactly through forced flush"() {
+        given: "a synthetic RGB image with deterministic per-channel values"
+        def width = 320
+        def height = 240
+        def r = synthesise(width, height, 0)
+        def g = synthesise(width, height, 1000)
+        def b = synthesise(width, height, 2000)
+        def metadata = [:] as Map<Class<?>, Object>
+        def rgb = new RGBImage(width, height, r, g, b, metadata)
+        def rCopy = copyMonoData(r)
+        def gCopy = copyMonoData(g)
+        def bCopy = copyMonoData(b)
+
+        and: "an FBI under pressure"
+        FileBackedImage.setPressureSupplierForTesting({ true } as BooleanSupplier)
+        def fbi = FileBackedImage.wrap(rgb)
+
+        when:
+        fbi.clearSoftReferenceForTesting()
+        def recovered = (RGBImage) fbi.unwrapToMemory()
+
+        then: "all three channels match the originals"
+        recovered.width() == width
+        recovered.height() == height
+        floatArraysEqual(recovered.r(), rCopy)
+        floatArraysEqual(recovered.g(), gCopy)
+        floatArraysEqual(recovered.b(), bCopy)
+    }
+
+    def "comfortable heap keeps data in memory: unwrap returns the in-memory copy without writing to disk"() {
+        given: "an FBI built under comfortable heap (no constructor flush)"
+        FileBackedImage.setPressureSupplierForTesting({ false } as BooleanSupplier)
+        def width = 200
+        def height = 150
+        def data = synthesise(width, height, 42)
+        def img = new ImageWrapper32(width, height, data, [:] as Map<Class<?>, Object>)
+        def fbi = FileBackedImage.wrap(img)
+
+        when: "data is unwrapped without forcing eviction"
+        def recovered = (ImageWrapper32) fbi.unwrapToMemory()
+
+        then: "data is recovered from memory"
+        floatArraysEqual(recovered.data(), data)
+
+        and: "no disk write happened — comfortable heap means we keep things in RAM"
+        !statusSaved(fbi)
+    }
+
+    def "repeated unwrap calls under comfortable heap stay in memory"() {
+        given: "an FBI under comfortable heap"
+        FileBackedImage.setPressureSupplierForTesting({ false } as BooleanSupplier)
+        def width = 100
+        def height = 80
+        def data = synthesise(width, height, 7)
+        def img = new ImageWrapper32(width, height, data, [:] as Map<Class<?>, Object>)
+        def fbi = FileBackedImage.wrap(img)
+
+        when: "unwrapToMemory is invoked repeatedly"
+        ImageWrapper32 recovered = null
+        for (int i = 0; i < 10; i++) {
+            recovered = (ImageWrapper32) fbi.unwrapToMemory()
+        }
+
+        then: "data is still intact"
+        floatArraysEqual(recovered.data(), data)
+
+        and: "no disk write ever happened"
+        !statusSaved(fbi)
+    }
+
+    def "pressure flip from comfortable to tight evicts to disk on next soft-reference clear"() {
+        given: "an FBI built comfortable (no flush in constructor)"
+        FileBackedImage.setPressureSupplierForTesting({ false } as BooleanSupplier)
+        def width = 150
+        def height = 120
+        def data = synthesise(width, height, 99)
+        def img = new ImageWrapper32(width, height, data, [:] as Map<Class<?>, Object>)
+        def fbi = FileBackedImage.wrap(img)
+        assert !statusSaved(fbi)
+
+        when: "pressure flips to tight and the soft ref is cleared"
+        FileBackedImage.setPressureSupplierForTesting({ true } as BooleanSupplier)
+        fbi.clearSoftReferenceForTesting()
+        def recovered = (ImageWrapper32) fbi.unwrapToMemory()
+
+        then: "the file was written and the recovery returns identical data"
+        statusSaved(fbi)
+        floatArraysEqual(recovered.data(), data)
+    }
+
+    def "concurrent unwrapToMemory after flush returns equivalent data"() {
+        given: "an FBI flushed to disk"
+        FileBackedImage.setPressureSupplierForTesting({ true } as BooleanSupplier)
+        def width = 256
+        def height = 256
+        def data = synthesise(width, height, 17)
+        def img = new ImageWrapper32(width, height, data, [:] as Map<Class<?>, Object>)
+        def fbi = FileBackedImage.wrap(img)
+        fbi.clearSoftReferenceForTesting()
+
+        when: "many threads concurrently unwrap"
+        def threads = 8
+        def latch = new CountDownLatch(threads)
+        def start = new CountDownLatch(1)
+        def results = Collections.synchronizedList(new ArrayList<float[][]>())
+        def errors = Collections.synchronizedList(new ArrayList<Throwable>())
+        def pool = Executors.newFixedThreadPool(threads)
+        threads.times {
+            pool.submit({
+                try {
+                    start.await()
+                    def r = (ImageWrapper32) fbi.unwrapToMemory()
+                    results.add(r.data())
+                } catch (Throwable t) {
+                    errors.add(t)
+                } finally {
+                    latch.countDown()
+                }
+            })
+        }
+        start.countDown()
+        latch.await(10, TimeUnit.SECONDS)
+        pool.shutdownNow()
+
+        then: "no errors, every result matches the original"
+        errors.isEmpty()
+        results.size() == threads
+        results.every { floatArraysEqual(it, data) }
+    }
+
+    private static boolean statusSaved(FileBackedImage fbi) {
+        // Reach into the package-private status indirectly: unwrapToMemory's
+        // disk-read path waits on status.saved(). We use a side-effect:
+        // if the file exists with non-zero size, a flush completed.
+        def field = FileBackedImage.class.getDeclaredField("backingFile")
+        field.setAccessible(true)
+        def path = (java.nio.file.Path) field.get(fbi)
+        return java.nio.file.Files.exists(path) && java.nio.file.Files.size(path) > 0
+    }
+
+    private static float[][] synthesise(int width, int height, int seed) {
+        def random = new Random(seed)
+        def data = new float[height][width]
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                data[y][x] = 1000.0f + random.nextFloat() * 60000.0f
+            }
+        }
+        return data
+    }
+
+    private static float[][] copyMonoData(float[][] src) {
+        def copy = new float[src.length][src[0].length]
+        for (int y = 0; y < src.length; y++) {
+            System.arraycopy(src[y], 0, copy[y], 0, src[y].length)
+        }
+        return copy
+    }
+
+    private static boolean floatArraysEqual(float[][] a, float[][] b) {
+        if (a.length != b.length) {
+            return false
+        }
+        for (int y = 0; y < a.length; y++) {
+            if (!Arrays.equals(a[y], b[y])) {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/jsolex/build.gradle.kts
+++ b/jsolex/build.gradle.kts
@@ -131,8 +131,12 @@ tasks.withType<JavaCompile>().configureEach {
 tasks.named<JavaExec>("run") {
     doFirst {
         jvmArgs(
-//            listOf("--module-path", classpath.asPath, "-XX:StartFlightRecording=filename=/tmp/batch.jfr,settings=profile,duration=300s")
-            listOf("--module-path", classpath.asPath)
+            listOf(
+                "--module-path",
+                classpath.asPath,
+                "-XX:StartFlightRecording=filename=/tmp/batch.jfr,settings=profile,duration=300s"
+            )
+//            listOf("--module-path", classpath.asPath)
         )
         classpath = files()
     }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
@@ -68,7 +68,6 @@ import javafx.stage.Stage;
 import javafx.util.Duration;
 import javafx.util.StringConverter;
 import javafx.util.converter.IntegerStringConverter;
-import me.champeau.a4j.jsolex.app.AlertFactory;
 import me.champeau.a4j.jsolex.app.jfx.AdvancedParamsController;
 import me.champeau.a4j.jsolex.app.jfx.ApplyUserRotation;
 import me.champeau.a4j.jsolex.app.jfx.AssistedEllipseFittingController;
@@ -79,8 +78,6 @@ import me.champeau.a4j.jsolex.app.jfx.EmbeddedServerController;
 import me.champeau.a4j.jsolex.app.jfx.ExposureCalculator;
 import me.champeau.a4j.jsolex.app.jfx.I18N;
 import me.champeau.a4j.jsolex.app.jfx.ImageMathEditor;
-import me.champeau.a4j.jsolex.app.jfx.ime.HighlightingMode;
-import me.champeau.a4j.jsolex.app.jfx.ScriptErrorDialog;
 import me.champeau.a4j.jsolex.app.jfx.ImageViewer;
 import me.champeau.a4j.jsolex.app.jfx.MetadataEditor;
 import me.champeau.a4j.jsolex.app.jfx.MultipleImagesViewer;
@@ -101,9 +98,9 @@ import me.champeau.a4j.jsolex.app.jfx.SpectroHeliographEditor;
 import me.champeau.a4j.jsolex.app.jfx.SpectrumBrowser;
 import me.champeau.a4j.jsolex.app.jfx.StandaloneImagesLoader;
 import me.champeau.a4j.jsolex.app.jfx.bass2000.Bass2000SubmissionController;
+import me.champeau.a4j.jsolex.app.jfx.ime.ImageMathTextArea;
 import me.champeau.a4j.jsolex.app.jfx.spectrosolhub.SpectroSolHubLoginPane;
 import me.champeau.a4j.jsolex.app.jfx.spectrosolhub.SpectroSolHubSubmissionController;
-import me.champeau.a4j.jsolex.app.jfx.ime.ImageMathTextArea;
 import me.champeau.a4j.jsolex.app.jfx.stacking.StackingAndMosaicController;
 import me.champeau.a4j.jsolex.app.listeners.BatchModeEventListener;
 import me.champeau.a4j.jsolex.app.listeners.BatchProcessingContext;
@@ -124,14 +121,15 @@ import me.champeau.a4j.jsolex.processing.expr.ImageMathScriptResult;
 import me.champeau.a4j.jsolex.processing.expr.InvalidExpression;
 import me.champeau.a4j.jsolex.processing.expr.ScriptExecutionContext;
 import me.champeau.a4j.jsolex.processing.file.FileNamingStrategy;
-import me.champeau.a4j.jsolex.processing.params.ScriptParameterExtractor;
 import me.champeau.a4j.jsolex.processing.params.ImageMathParams;
 import me.champeau.a4j.jsolex.processing.params.NumberParameter;
 import me.champeau.a4j.jsolex.processing.params.ProcessParams;
 import me.champeau.a4j.jsolex.processing.params.ProcessParamsIO;
 import me.champeau.a4j.jsolex.processing.params.RotationKind;
 import me.champeau.a4j.jsolex.processing.params.ScriptParameter;
+import me.champeau.a4j.jsolex.processing.params.ScriptParameterExtractor;
 import me.champeau.a4j.jsolex.processing.params.SpectralRay;
+import me.champeau.a4j.jsolex.processing.spectrum.ReferenceIntensities;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.CaptureSoftwareMetadataHelper;
 import me.champeau.a4j.jsolex.processing.sun.SolexVideoProcessor;
@@ -143,18 +141,17 @@ import me.champeau.a4j.jsolex.processing.util.BackgroundOperations;
 import me.champeau.a4j.jsolex.processing.util.Bass2000ConfigService;
 import me.champeau.a4j.jsolex.processing.util.Constants;
 import me.champeau.a4j.jsolex.processing.util.DurationFormatter;
-import me.champeau.a4j.jsolex.processing.util.SpectroSolHubClient;
-import me.champeau.a4j.jsolex.processing.util.spectrosolhub.SpectroSolHubException;
 import me.champeau.a4j.jsolex.processing.util.FilesUtils;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.LiveSessionManager;
 import me.champeau.a4j.jsolex.processing.util.LocaleUtils;
 import me.champeau.a4j.jsolex.processing.util.LoggingSupport;
-import me.champeau.a4j.jsolex.processing.util.MutableMap;
 import me.champeau.a4j.jsolex.processing.util.NativeLibrariesUtils;
 import me.champeau.a4j.jsolex.processing.util.ProcessingException;
+import me.champeau.a4j.jsolex.processing.util.SpectroSolHubClient;
 import me.champeau.a4j.jsolex.processing.util.TemporaryFolder;
 import me.champeau.a4j.jsolex.processing.util.VersionUtil;
+import me.champeau.a4j.jsolex.processing.util.spectrosolhub.SpectroSolHubException;
 import me.champeau.a4j.math.VectorApiSupport;
 import me.champeau.a4j.math.opencl.OpenCLSupport;
 import me.champeau.a4j.math.regression.Ellipse;
@@ -540,7 +537,11 @@ public class JSolEx implements JSolExInterface, BatchProcessingHelper.BatchConte
             });
             startWatcherThread();
             repositoryUpdateService.checkAtStartup();
-            Thread.startVirtualThread(() -> UpdateChecker.findLatestRelease().ifPresent(this::maybeWarnAboutNewRelease));
+            Thread.startVirtualThread(() -> {
+                // pre-load reference intensities in background to avoid blocking the UI later on when they're first needed
+                var _ = ReferenceIntensities.INSTANCE;
+                UpdateChecker.findLatestRelease().ifPresent(this::maybeWarnAboutNewRelease);
+            });
             LOGGER.info(message("java.runtime.version"), System.getProperty("java.version"));
             LOGGER.info(message("vector.api.support"), VectorApiSupport.isPresent() ? message("vector.api.available") : message("vector.api.missing"),
                     VectorApiSupport.isEnabled() ? message("vector.api.enabled") + MessageFormat.format(message("vector.api.enabled.disable.hint"), VectorApiSupport.VECTOR_API_ENV_VAR) : message("vector.api.disabled"));
@@ -653,8 +654,8 @@ public class JSolEx implements JSolExInterface, BatchProcessingHelper.BatchConte
     /**
      * Creates a new scene with the JSolEx stylesheet applied.
      *
-     * @param root the root node
-     * @param width the scene width
+     * @param root   the root node
+     * @param width  the scene width
      * @param height the scene height
      * @return the configured scene
      */
@@ -827,13 +828,13 @@ public class JSolEx implements JSolExInterface, BatchProcessingHelper.BatchConte
         alert.showAndWait().ifPresent(button -> {
             if (button == retry) {
                 OpenGLAvailability.retryCheck().thenAccept(available ->
-                    Platform.runLater(() -> {
-                        if (available) {
-                            AlertFactory.info(message("opengl.crash.retry.success")).showAndWait();
-                        } else {
-                            AlertFactory.warning(message("opengl.crash.retry.failure")).showAndWait();
-                        }
-                    })
+                        Platform.runLater(() -> {
+                            if (available) {
+                                AlertFactory.info(message("opengl.crash.retry.success")).showAndWait();
+                            } else {
+                                AlertFactory.warning(message("opengl.crash.retry.failure")).showAndWait();
+                            }
+                        })
                 );
             } else if (button == deactivate) {
                 OpenGLAvailability.disableOpenGL();
@@ -1092,8 +1093,8 @@ public class JSolEx implements JSolExInterface, BatchProcessingHelper.BatchConte
                     executor.putVariable(entry.getKey(), entry.getValue());
                 }
                 var result = isPythonScript()
-                    ? executor.executePythonScript(text, section)
-                    : executor.execute(text, section);
+                        ? executor.executePythonScript(text, section)
+                        : executor.execute(text, section);
                 // Python scripts handle batch mode via explicit batch() function, not automatic "both sections"
                 if (shouldRunBothSections && !isPythonScript()) {
                     var previousVariables = new HashMap<String, Object>();
@@ -1135,9 +1136,9 @@ public class JSolEx implements JSolExInterface, BatchProcessingHelper.BatchConte
             var fileChooser = new FileChooser();
             config.findLastOpenDirectory(Configuration.DirectoryKind.IMAGE_MATH).ifPresent(dir -> fileChooser.setInitialDirectory(dir.toFile()));
             fileChooser.getExtensionFilters().addAll(
-                ImageMathEditor.ALL_SCRIPTS_EXTENSION_FILTER,
-                ImageMathEditor.MATH_SCRIPT_EXTENSION_FILTER,
-                ImageMathEditor.PY_SCRIPT_EXTENSION_FILTER
+                    ImageMathEditor.ALL_SCRIPTS_EXTENSION_FILTER,
+                    ImageMathEditor.MATH_SCRIPT_EXTENSION_FILTER,
+                    ImageMathEditor.PY_SCRIPT_EXTENSION_FILTER
             );
             var file = fileChooser.showOpenDialog(rootStage);
             loadImageMathScriptFrom(file);
@@ -1154,13 +1155,13 @@ public class JSolEx implements JSolExInterface, BatchProcessingHelper.BatchConte
             var selectedLanguage = scriptLanguageChoice.getValue();
             if (selectedLanguage == ImageMathEditor.ScriptLanguage.PYTHON) {
                 fileChooser.getExtensionFilters().addAll(
-                    ImageMathEditor.PY_SCRIPT_EXTENSION_FILTER,
-                    ImageMathEditor.MATH_SCRIPT_EXTENSION_FILTER
+                        ImageMathEditor.PY_SCRIPT_EXTENSION_FILTER,
+                        ImageMathEditor.MATH_SCRIPT_EXTENSION_FILTER
                 );
             } else {
                 fileChooser.getExtensionFilters().addAll(
-                    ImageMathEditor.MATH_SCRIPT_EXTENSION_FILTER,
-                    ImageMathEditor.PY_SCRIPT_EXTENSION_FILTER
+                        ImageMathEditor.MATH_SCRIPT_EXTENSION_FILTER,
+                        ImageMathEditor.PY_SCRIPT_EXTENSION_FILTER
                 );
             }
             var file = fileChooser.showSaveDialog(rootStage);
@@ -1989,7 +1990,8 @@ public class JSolEx implements JSolExInterface, BatchProcessingHelper.BatchConte
         var rootOperation = createRootOperation(selectedFile.getName());
         Platform.runLater(() -> imageMathRun.setDisable(true));
         var processingThread =
-                new Thread(() -> processSingleFile(params, rootOperation, selectedFile, false, 0, selectedFile, firstHeader, () -> {}, () -> Platform.runLater(() -> {
+                new Thread(() -> processSingleFile(params, rootOperation, selectedFile, false, 0, selectedFile, firstHeader, () -> {
+                }, () -> Platform.runLater(() -> {
                     workButtons.getChildren().remove(interruptButton);
                     imageMathRun.setDisable(false);
                 })));
@@ -2298,7 +2300,8 @@ public class JSolEx implements JSolExInterface, BatchProcessingHelper.BatchConte
         }
         var appender = LogbackConfigurer.createContextualFileAppender(sequenceNumber, logFile);
         LoggingSupport.LOGGER.info(message("output.dir.set"), outputDirectory);
-        var processorContext = Map.<Class<?>, Object>of(AnimationFormat.class, config.getAnimationFormats());
+        var processorContext = new HashMap<Class<?>, Object>();
+        processorContext.put(AnimationFormat.class, config.getAnimationFormats());
         var processor = new SolexVideoProcessor(selectedFile, outputDirectory.toPath(), sequenceNumber, params, processingDate, batchMode, batchMode ? config.getBatchParallelism() : 1, config.getMemoryRestrictionMultiplier(), operation, processorContext);
         processor.setOnReconstructionComplete(onReconstructionComplete);
         var listener = createListener(operation, baseName, params, batchMode, sequenceNumber, context);

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/BatchProcessingHelper.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/BatchProcessingHelper.java
@@ -92,19 +92,19 @@ public final class BatchProcessingHelper {
     /**
      * Starts batch processing with full UI orchestration.
      *
-     * @param context the batch context providing callbacks
-     * @param header the SER file header
+     * @param context           the batch context providing callbacks
+     * @param header            the SER file header
      * @param progressOperation the root progress operation
-     * @param params the processing parameters
-     * @param selectedFiles the files to process
-     * @param autoTrimSerFile whether to auto-trim SER files
+     * @param params            the processing parameters
+     * @param selectedFiles     the files to process
+     * @param autoTrimSerFile   whether to auto-trim SER files
      */
     public void startBatchProcess(BatchContext context,
-                                   Header header,
-                                   ProgressOperation progressOperation,
-                                   ProcessParams params,
-                                   List<File> selectedFiles,
-                                   boolean autoTrimSerFile) {
+                                  Header header,
+                                  ProgressOperation progressOperation,
+                                  ProcessParams params,
+                                  List<File> selectedFiles,
+                                  boolean autoTrimSerFile) {
         context.newSession();
         LOGGER.info(message("batch.mode.info"));
 
@@ -172,8 +172,8 @@ public final class BatchProcessingHelper {
     }
 
     private BatchProcessingContext createBatchContext(List<BatchItem> batchItems,
-                                                       File outputDirectory,
-                                                       Header header) {
+                                                      File outputDirectory,
+                                                      Header header) {
         return new BatchProcessingContext(
                 batchItems,
                 new HashSet<>(),
@@ -196,20 +196,20 @@ public final class BatchProcessingHelper {
     }
 
     private Thread runBatchProcessing(List<File> selectedFiles,
-                                       BatchProcessingContext batchContext,
-                                       ProcessParams params,
-                                       ProgressOperation progressOperation,
-                                       Header header,
-                                       BatchContext context,
-                                       AtomicBoolean interrupted,
-                                       boolean autoTrimSerFile,
-                                       Runnable onComplete) {
+                                      BatchProcessingContext batchContext,
+                                      ProcessParams params,
+                                      ProgressOperation progressOperation,
+                                      Header header,
+                                      BatchContext context,
+                                      AtomicBoolean interrupted,
+                                      boolean autoTrimSerFile,
+                                      Runnable onComplete) {
         var batchThread = new Thread(() -> {
             // Eagerly initialize ReferenceIntensities to avoid virtual thread
             // pinning when all batch threads trigger class loading simultaneously
             var unused = ReferenceIntensities.INSTANCE;
             try {
-                var parallelism = Configuration.getInstance().getBatchParallelism();
+                var parallelism = capParallelismForMemory(Configuration.getInstance().getBatchParallelism());
                 var reconstructionSemaphore = new Semaphore(parallelism);
                 var totalInFlightSemaphore = new Semaphore(parallelism + 1);
                 try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
@@ -273,15 +273,15 @@ public final class BatchProcessingHelper {
     }
 
     private void processFile(BatchContext context,
-                              ProcessParams params,
-                              ProgressOperation operation,
-                              File selectedFile,
-                              int sequenceNumber,
-                              BatchProcessingContext batchContext,
-                              Header header,
-                              AtomicBoolean interrupted,
-                              boolean autoTrimSerFile,
-                              Runnable onReconstructionComplete) {
+                             ProcessParams params,
+                             ProgressOperation operation,
+                             File selectedFile,
+                             int sequenceNumber,
+                             BatchProcessingContext batchContext,
+                             Header header,
+                             AtomicBoolean interrupted,
+                             boolean autoTrimSerFile,
+                             Runnable onReconstructionComplete) {
         context.processSingleFile(params, operation, selectedFile, sequenceNumber, batchContext, header, onReconstructionComplete, () -> {
             if (autoTrimSerFile && !interrupted.get()) {
                 var trimmingParams = context.getTrimmingParameters();
@@ -304,5 +304,27 @@ public final class BatchProcessingHelper {
                 }
             }
         });
+    }
+
+    /**
+     * Caps batch parallelism to at most one worker per 4 GB of JVM heap, with
+     * a floor of 1. The cap exists because each parallel file processing
+     * holds a substantial in-flight working set (raw frames, reconstructed
+     * images, async writers) — running more files concurrently than the
+     * heap can comfortably hold leads to thrashing and OOMs regardless of
+     * the per-process throttling we apply elsewhere. If the user-configured
+     * parallelism exceeds the memory-derived cap we log a warning and use
+     * the cap; otherwise the user's setting wins.
+     */
+    private static int capParallelismForMemory(int configured) {
+        long maxHeapBytes = Runtime.getRuntime().maxMemory();
+        long bytesPerWorker = 4L * 1024 * 1024 * 1024;
+        int memoryCap = (int) Math.max(1, maxHeapBytes / bytesPerWorker);
+        if (configured > memoryCap) {
+            long heapGb = maxHeapBytes / (1024 * 1024 * 1024);
+            LOGGER.warn(message("batch.parallelism.capped"), configured, memoryCap, heapGb);
+            return memoryCap;
+        }
+        return configured;
     }
 }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ImageViewer.java
@@ -36,6 +36,7 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.Slider;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.BorderPane;
@@ -122,6 +123,9 @@ public class ImageViewer implements WithRootNode {
     @FXML
     private StackPane imageContainer;
 
+    @FXML
+    private ProgressIndicator loadingIndicator;
+
     private CheckBox correctAngleP;
     private Button saveButton;
     private String title;
@@ -170,16 +174,16 @@ public class ImageViewer implements WithRootNode {
      * Configures the image viewer.
      *
      * @param broadcaster the event broadcaster
-     * @param operation the progress operation
-     * @param title the title
-     * @param baseName the base name
-     * @param kind the generated image kind
+     * @param operation   the progress operation
+     * @param title       the title
+     * @param baseName    the base name
+     * @param kind        the generated image kind
      * @param description the description
-     * @param image the image
-     * @param imageName the image file name
-     * @param params the process parameters
-     * @param popupViews the popup views
-     * @param siblings the sibling viewers
+     * @param image       the image
+     * @param imageName   the image file name
+     * @param params      the process parameters
+     * @param popupViews  the popup views
+     * @param siblings    the sibling viewers
      */
     public void setup(ProcessingEventListener broadcaster,
                       ProgressOperation operation,
@@ -381,7 +385,8 @@ public class ImageViewer implements WithRootNode {
     private StretchingStrategy determineStrategy() {
         return switch (stretchingMode) {
             case NO_STRETCH -> CutoffStretchingStrategy.DEFAULT;
-            case LINEAR -> new StretchingChain(RangeExpansionStrategy.DEFAULT, contrastAdjustStrategy, RangeExpansionStrategy.DEFAULT);
+            case LINEAR ->
+                    new StretchingChain(RangeExpansionStrategy.DEFAULT, contrastAdjustStrategy, RangeExpansionStrategy.DEFAULT);
             case CURVE -> curveTransformStrategy;
         };
     }
@@ -673,7 +678,14 @@ public class ImageViewer implements WithRootNode {
 
     void display() {
         if (image != null && firstShow) {
-            BackgroundOperations.async(() -> stretchAndDisplay(true));
+            showLoadingIndicator();
+            BackgroundOperations.async(() -> {
+                try {
+                    stretchAndDisplay(true);
+                } finally {
+                    Platform.runLater(this::hideLoadingIndicator);
+                }
+            });
             firstShow = false;
         } else if (image != null) {
             BackgroundOperations.async(() -> {
@@ -683,6 +695,22 @@ public class ImageViewer implements WithRootNode {
                     onStretchedImageUpdate.accept(currentStretchedImage.unwrapToMemory());
                 }
             });
+        }
+    }
+
+    private void showLoadingIndicator() {
+        if (loadingIndicator != null) {
+            if (Platform.isFxApplicationThread()) {
+                loadingIndicator.setVisible(true);
+            } else {
+                Platform.runLater(() -> loadingIndicator.setVisible(true));
+            }
+        }
+    }
+
+    private void hideLoadingIndicator() {
+        if (loadingIndicator != null) {
+            loadingIndicator.setVisible(false);
         }
     }
 
@@ -796,9 +824,9 @@ public class ImageViewer implements WithRootNode {
      * Updates the displayed image.
      *
      * @param baseName the base name
-     * @param params the process parameters
-     * @param image the image
-     * @param path the image path
+     * @param params   the process parameters
+     * @param image    the image
+     * @param path     the image path
      */
     public synchronized void setImage(String baseName, ProcessParams params, ImageWrapper image, Path path) {
         this.processParams = params;

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ReconstructionView.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ReconstructionView.java
@@ -50,20 +50,26 @@ public class ReconstructionView extends BorderPane implements WithRootNode {
     private final Semaphore lock = new Semaphore(1);
 
     private final byte[] solarImageData;
+    private final int solarImageWidth;
+    private final int solarImageHeight;
     private Image spectrumImage;
 
     /**
      * Creates a reconstruction view with synchronized spectrum and solar image displays.
      *
-     * @param solarView the zoomable solar image view
-     * @param solarImageData the raw solar image data
+     * @param solarView        the zoomable solar image view
+     * @param solarImageData   the raw BGRA solar image data ({@code 4 * width * height} bytes)
+     * @param solarImageWidth  the width in pixels of the solar buffer
+     * @param solarImageHeight the height in pixels of the solar buffer
      */
-    public ReconstructionView(ZoomableImageView solarView, byte[] solarImageData) {
+    public ReconstructionView(ZoomableImageView solarView, byte[] solarImageData, int solarImageWidth, int solarImageHeight) {
         this.spectrumView = new ImageView();
         this.solarView = solarView;
         this.spectrumViewOverlay = new Canvas();
         this.solarViewOverlay = new Canvas();
         this.solarImageData = solarImageData;
+        this.solarImageWidth = solarImageWidth;
+        this.solarImageHeight = solarImageHeight;
         spectrumView.setPreserveRatio(true);
         var solarViewStack = new StackPane(solarView, solarViewOverlay);
         var spectrumScrollPane = new ScrollPane(spectrumView);
@@ -141,6 +147,20 @@ public class ReconstructionView extends BorderPane implements WithRootNode {
      */
     public byte[] getSolarImageData() {
         return solarImageData;
+    }
+
+    /**
+     * Returns the pixel width of the solar buffer (and matching {@code WritableImage}).
+     */
+    public int getSolarImageWidth() {
+        return solarImageWidth;
+    }
+
+    /**
+     * Returns the pixel height of the solar buffer (and matching {@code WritableImage}).
+     */
+    public int getSolarImageHeight() {
+        return solarImageHeight;
     }
 
     /**

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/BatchImageCollector.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/BatchImageCollector.java
@@ -16,6 +16,7 @@
 package me.champeau.a4j.jsolex.app.listeners;
 
 import me.champeau.a4j.jsolex.app.jfx.CandidateImageDescriptor;
+import me.champeau.a4j.jsolex.processing.util.FileBackedImage;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
 
 import java.io.File;
@@ -92,12 +93,15 @@ final class BatchImageCollector {
     }
 
     /**
-     * Adds an image wrapper by label.
+     * Adds an image wrapper by label. The image is wrapped via {@link FileBackedImage}
+     * so its pixel data can spill to disk under memory pressure — batch-scoped retention
+     * across many files would otherwise pin every output image in heap.
      */
     void addImageByLabel(String label, ImageWrapper image) {
+        var backed = FileBackedImage.wrap(image);
         dataLock.writeLock().lock();
         try {
-            imagesByLabel.computeIfAbsent(label, unused -> new ArrayList<>()).add(image);
+            imagesByLabel.computeIfAbsent(label, unused -> new ArrayList<>()).add(backed);
         } finally {
             dataLock.writeLock().unlock();
         }
@@ -116,12 +120,15 @@ final class BatchImageCollector {
     }
 
     /**
-     * Adds an image wrapper by sequence number.
+     * Adds an image wrapper by sequence number. The image is wrapped via {@link FileBackedImage}
+     * so its pixel data can spill to disk under memory pressure — batch-scoped retention
+     * across many files would otherwise pin every output image in heap.
      */
     void addImageByIndex(int sequenceNumber, ImageWrapper image) {
+        var backed = FileBackedImage.wrap(image);
         dataLock.writeLock().lock();
         try {
-            imageWrappersByIndex.computeIfAbsent(sequenceNumber, unused -> new ArrayList<>()).add(image);
+            imageWrappersByIndex.computeIfAbsent(sequenceNumber, unused -> new ArrayList<>()).add(backed);
         } finally {
             dataLock.writeLock().unlock();
         }

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SingleModeProcessingEventListener.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SingleModeProcessingEventListener.java
@@ -161,6 +161,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -171,7 +172,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static me.champeau.a4j.jsolex.app.JSolEx.message;
-import static me.champeau.a4j.jsolex.app.jfx.BatchOperations.blockingUntilResultAvailable;
 import static me.champeau.a4j.jsolex.app.jfx.FXUtils.newModalStage;
 import static me.champeau.a4j.jsolex.processing.sun.CaptureSoftwareMetadataHelper.computeSerFileBasename;
 
@@ -217,10 +217,13 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
     private static final DopplerMeasurementMethod ROTATION_PROFILE_DOPPLER_METHOD = DopplerMeasurementMethod.VOIGT_FIT;
 
     // Record to hold velocity measurement with its position data for weighted averaging
-    private record VelocityMeasurement(double velocity, double longitudeFraction) {}
+    private record VelocityMeasurement(double velocity, double longitudeFraction) {
+    }
 
     private final Map<SuggestionEvent.SuggestionKind, String> suggestions = Collections.synchronizedMap(new LinkedHashMap<>());
     private final Map<Double, ReconstructionView> imageViews;
+    private final Map<Double, byte[]> solarImageBuffers = new ConcurrentHashMap<>();
+    private final Set<Double> pendingViewCreation = ConcurrentHashMap.newKeySet();
     private final JSolExInterface owner;
     private final ProgressOperation rootOperation;
     private final String baseName;
@@ -309,7 +312,7 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
         this.shiftImages = new HashMap<>();
         this.processingDate = processingDate;
         this.spectral3DHelper = new Spectral3DVisualizationHelper(this);
-        imageViews = new HashMap<>();
+        imageViews = new ConcurrentHashMap<>();
         sd = 0;
         width = 0;
         height = 0;
@@ -409,24 +412,24 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
         height = event.getHeight();
     }
 
-    private ReconstructionView createImageView(double pixelShift) {
-        var buffer = new byte[3 * width * height];
-        var reconstructionView = blockingUntilResultAvailable(() -> owner.getImagesViewer().addImage(this,
+    private ReconstructionView createImageViewOnFx(double pixelShift, byte[] buffer, int bufferWidth, int bufferHeight,
+                                                   int spectrumWidth, int spectrumHeight) {
+        var reconstructionView = owner.getImagesViewer().addImage(this,
                 rootOperation,
                 message("image.reconstruction"), baseName,
                 GeneratedImageKind.RECONSTRUCTION, null, null, null, params, popupViews, new PixelShift(pixelShift),
                 viewer -> {
                     var parentWidth = owner.getImagesViewer().widthProperty();
                     viewer.getImageView().getScrollPane().maxWidthProperty().bind(parentWidth);
-                    return new ReconstructionView(viewer.getImageView(), buffer);
+                    return new ReconstructionView(viewer.getImageView(), buffer, bufferWidth, bufferHeight);
                 },
                 viewer -> {
 
-                }));
+                });
         var imageView = reconstructionView.getSolarView();
-        var image = new WritableImage(width, height);
-        imageView.setImage(image);
+        imageView.setImage(new WritableImage(bufferWidth, bufferHeight));
         imageView.resetZoom();
+        reconstructionView.getSpectrumView().setImage(new WritableImage(spectrumWidth, spectrumHeight));
         return reconstructionView;
     }
 
@@ -446,31 +449,52 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
             return;
         }
 
-        var reconstructionView = getOrCreateImageView(event);
-        var imageView = reconstructionView.getSolarView();
-        imageView.resetZoom();
-        var image = (WritableImage) imageView.getImage();
+        var pixelShift = payload.pixelShift();
         var line = payload.data();
-        var rgb = reconstructionView.getSolarImageData();
+        var lineWidth = line.length;
+        var bufferHeight = totalLines;
+        var rgb = solarImageBuffers.computeIfAbsent(pixelShift, k -> {
+            var buf = new byte[4 * lineWidth * bufferHeight];
+            for (int i = 3; i < buf.length; i += 4) {
+                buf[i] = (byte) 0xFF;
+            }
+            return buf;
+        });
 
-        // Update the current row in the rgb buffer.
-        for (var x = 0; x < line.length; x++) {
+        // Update the current row in the BGRA buffer (alpha already 0xFF from initialization).
+        for (var x = 0; x < lineWidth; x++) {
             var v = (int) Math.round(line[x]);
             var c = (byte) (v >> 8);
-            var offset = 3 * (y * width + x);
+            var offset = 4 * (y * lineWidth + x);
             rgb[offset] = c;
             rgb[offset + 1] = c;
             rgb[offset + 2] = c;
         }
 
-        // Ensure the spectrum image is ready.
         var spectrum = payload.spectrum();
-        var pixelformat = PixelFormat.getByteRgbInstance();
-        var spectrumView = reconstructionView.getSpectrumView();
-        if (spectrumView.getImage() == null) {
-            spectrumView.setImage(new WritableImage(spectrum.width(), spectrum.height()));
+        var spectrumWidth = spectrum.width();
+        var spectrumHeight = spectrum.height();
+        var reconstructionView = imageViews.get(pixelShift);
+        if (reconstructionView == null) {
+            // View not ready yet — schedule async creation and skip this UI flush.
+            // The rgb buffer is already up to date; the next periodic flush (or the
+            // final flush in onReconstructionDone) will pick up everything.
+            if (pendingViewCreation.add(pixelShift)) {
+                Platform.runLater(() -> {
+                    try {
+                        imageViews.put(pixelShift, createImageViewOnFx(pixelShift, rgb, lineWidth, bufferHeight, spectrumWidth, spectrumHeight));
+                    } finally {
+                        pendingViewCreation.remove(pixelShift);
+                    }
+                });
+            }
+            return;
         }
-        var spectrumImage = (WritableImage) spectrumView.getImage();
+        var imageView = reconstructionView.getSolarView();
+        imageView.resetZoom();
+        var image = (WritableImage) imageView.getImage();
+        var pixelformat = PixelFormat.getByteBgraPreInstance();
+        var spectrumImage = (WritableImage) reconstructionView.getSpectrumView().getImage();
 
         var currentTime = System.currentTimeMillis();
         var lastUpdate = lastUIUpdateTime.get();
@@ -489,15 +513,15 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
                                         pixelformat,
                                         spectrumBuffer,
                                         0,
-                                        3 * spectrum.width()
+                                        4 * spectrum.width()
                                 );
                                 image.getPixelWriter().setPixels(
                                         0, 0,
-                                        width, y + 1,
+                                        lineWidth, y + 1,
                                         pixelformat,
                                         rgb,
                                         0,
-                                        3 * width
+                                        4 * lineWidth
                                 );
                             } finally {
                                 lock.release();
@@ -511,38 +535,36 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
 
     private void forceFinalUIUpdate(ReconstructionView reconstructionView) {
         var lock = reconstructionView.getLock();
-        if (lock.tryAcquire()) {
-            Thread.startVirtualThread(() -> {
-                Platform.runLater(() -> {
-                    try {
-                        var solarView = reconstructionView.getSolarView();
-                        var solarImage = (WritableImage) solarView.getImage();
-                        var spectrumView = reconstructionView.getSpectrumView();
-                        var spectrumImage = (WritableImage) spectrumView.getImage();
-
-                        if (solarImage != null && spectrumImage != null) {
-                            var rgb = reconstructionView.getSolarImageData();
-                            var pixelformat = PixelFormat.getByteRgbInstance();
-                            var imageWidth = (int) solarImage.getWidth();
-                            var imageHeight = (int) solarImage.getHeight();
-                            var expectedSize = 3 * imageWidth * imageHeight;
-                            if (rgb.length == expectedSize) {
-                                solarImage.getPixelWriter().setPixels(
-                                        0, 0,
-                                        imageWidth, imageHeight,
-                                        pixelformat,
-                                        rgb,
-                                        0,
-                                        3 * imageWidth
-                                );
-                            }
-                        }
-                    } finally {
-                        lock.release();
+        Thread.startVirtualThread(() -> {
+            try {
+                lock.acquire();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            Platform.runLater(() -> {
+                try {
+                    var solarView = reconstructionView.getSolarView();
+                    var solarImage = (WritableImage) solarView.getImage();
+                    if (solarImage == null) {
+                        return;
                     }
-                });
+                    var rgb = reconstructionView.getSolarImageData();
+                    var bufferWidth = reconstructionView.getSolarImageWidth();
+                    var bufferHeight = reconstructionView.getSolarImageHeight();
+                    solarImage.getPixelWriter().setPixels(
+                            0, 0,
+                            bufferWidth, bufferHeight,
+                            PixelFormat.getByteBgraPreInstance(),
+                            rgb,
+                            0,
+                            4 * bufferWidth
+                    );
+                } finally {
+                    lock.release();
+                }
             });
-        }
+        });
     }
 
     @Override
@@ -550,21 +572,28 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
         var serFileReader = e.getPayload().reader();
         var frameCount = serFileReader.header().frameCount();
         var converter = ImageUtils.createImageConverter(params.videoParams().colorMode(), params.geometryParams().isSpectrumVFlip());
-        var pixelformat = PixelFormat.getByteRgbInstance();
+        var pixelformat = PixelFormat.getByteBgraPreInstance();
         if (reconstructionProgress != null) {
             onProgress(ProgressEvent.of(reconstructionProgress.complete()));
         }
         reconstructionProgress = null;
 
-        // Force final UI updates for all reconstruction views to ensure complete display
-        imageViews.entrySet().forEach(entry -> {
-            var view = entry.getValue();
-            forceFinalUIUpdate(view);
-        });
+        // Force final UI updates for all reconstruction views to ensure complete display.
+        // Iterate the rgb buffers (populated synchronously) rather than imageViews, then
+        // defer to the FX thread so any pending view-creation tasks have completed first.
+        var pixelShifts = List.copyOf(solarImageBuffers.keySet());
+        Platform.runLater(() -> pixelShifts.forEach(pixelShift -> {
+            var view = imageViews.get(pixelShift);
+            if (view != null) {
+                forceFinalUIUpdate(view);
+            }
+        }));
 
-        imageViews.entrySet().forEach(entry -> {
-            var pixelShift = entry.getKey();
-            var view = entry.getValue();
+        Platform.runLater(() -> pixelShifts.forEach(pixelShift -> {
+            var view = imageViews.get(pixelShift);
+            if (view == null) {
+                return;
+            }
             var solarViewOverlay = view.getSolarViewOverlay();
             var solarView = view.getSolarView();
             stretchReconstructionView(solarView);
@@ -609,7 +638,7 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
                     view.setSpectrumImage(spectrum);
                     Platform.runLater(() -> {
                         var pixelWriter = ((WritableImage) view.getSpectrumView().getImage()).getPixelWriter();
-                        pixelWriter.setPixels(0, 0, geometry.width(), geometry.height(), pixelformat, imageBytes, 0, 3 * geometry.width());
+                        pixelWriter.setPixels(0, 0, geometry.width(), geometry.height(), pixelformat, imageBytes, 0, 4 * geometry.width());
                     });
                     if (polynomial != null) {
                         // Store the clicked column and update the profile tab (detailed mode)
@@ -636,7 +665,7 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
                     });
                 }
             });
-        });
+        }));
     }
 
     private void stretchReconstructionView(ZoomableImageView solarView) {
@@ -669,10 +698,6 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
         });
     }
 
-
-    private synchronized ReconstructionView getOrCreateImageView(PartialReconstructionEvent event) {
-        return imageViews.computeIfAbsent(event.getPayload().pixelShift(), this::createImageView);
-    }
 
     @Override
     public void onImageGenerated(ImageGeneratedEvent event) {
@@ -953,7 +978,7 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
 
 
     private void generateRotationProfileChart(AverageImageComputedEvent.AverageImage payload,
-                                               ReferenceCoords refCoords, Ellipse ellipse, SolarParameters solarParams) {
+                                              ReferenceCoords refCoords, Ellipse ellipse, SolarParameters solarParams) {
         var params = payload.adjustedParams();
         var lambda0 = params.spectrumParams().ray().wavelength();
         var binning = params.observationDetails().binning();
@@ -984,9 +1009,9 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
 
         // Check for HFLIP/VFLIP to determine actual image orientation
         var hasHFlip = refCoords.operations().stream()
-            .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.HFLIP);
+                .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.HFLIP);
         var hasVFlip = refCoords.operations().stream()
-            .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.VFLIP);
+                .anyMatch(op -> op.kind() == ReferenceCoords.OperationKind.VFLIP);
 
         // Longitude sign convention: East limb = negative longitude, West limb = positive
         // After LEFT_ROTATION without HFLIP: orientation is mirrored, so signs swap
@@ -1012,10 +1037,10 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
         var config = differentialRotationConfig;
         Thread.startVirtualThread(() -> {
             var velocityData = computeRotationProfile(
-                refCoords, range, polynomial, start, end, height,
-                lambda0, dispersion, centerX, centerY, radius, b0, angleP, eastLonSign, latSign,
-                config,
-                progress -> Platform.runLater(() -> progressBar.setProgress(progress))
+                    refCoords, range, polynomial, start, end, height,
+                    lambda0, dispersion, centerX, centerY, radius, b0, angleP, eastLonSign, latSign,
+                    config,
+                    progress -> Platform.runLater(() -> progressBar.setProgress(progress))
             );
 
             Platform.runLater(() -> {
@@ -1028,13 +1053,13 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
     }
 
     private List<double[]> computeRotationProfile(ReferenceCoords refCoords,
-                                                   PixelShiftRange range, DoubleUnaryOperator polynomial,
-                                                   int start, int end, int height,
-                                                   Wavelen lambda0, Dispersion dispersion,
-                                                   double centerX, double centerY, double radius,
-                                                   double b0, double angleP, int eastLonSign, int latSign,
-                                                   DifferentialRotationConfig config,
-                                                   DoubleConsumer progressCallback) {
+                                                  PixelShiftRange range, DoubleUnaryOperator polynomial,
+                                                  int start, int end, int height,
+                                                  Wavelen lambda0, Dispersion dispersion,
+                                                  double centerX, double centerY, double radius,
+                                                  double b0, double angleP, int eastLonSign, int latSign,
+                                                  DifferentialRotationConfig config,
+                                                  DoubleConsumer progressCallback) {
         var velocityData = new ArrayList<double[]>();
         int totalPoints = 0;
 
@@ -1120,7 +1145,7 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
                             // longitudeFraction: 0 at limb (best accuracy), 1 at meridian (worst)
                             var longitudeFraction = 1.0 - Math.abs(lonDeg) / limbLongitude;
                             measurementsByLat.computeIfAbsent(latBin, k -> new ArrayList<>())
-                                .add(new VelocityMeasurement(equatorialVelocity, longitudeFraction));
+                                    .add(new VelocityMeasurement(equatorialVelocity, longitudeFraction));
                         }
                     }
                 }
@@ -1139,8 +1164,8 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
             var velocities = measurements.stream().map(VelocityMeasurement::velocity).toList();
             // For weighted average: weight = 1 - longitudeFraction (higher weight at limb)
             var weights = measurements.stream()
-                .map(m -> 1.0 - m.longitudeFraction())
-                .toList();
+                    .map(m -> 1.0 - m.longitudeFraction())
+                    .toList();
             // Apply sample rejection before aggregation
             var filtered = sampleRejection.filter(velocities, weights);
             var result = noiseReduction.aggregate(filtered.velocities(), filtered.weights());
@@ -1156,10 +1181,9 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
     }
 
 
-
     private static List<double[]> applyLatitudeSmoothingFilter(List<double[]> velocityData,
-                                                                double windowDeg,
-                                                                NoiseReductionMethod noiseReduction) {
+                                                               double windowDeg,
+                                                               NoiseReductionMethod noiseReduction) {
         var filtered = new ArrayList<double[]>();
         var halfWindow = windowDeg / 2.0;
         for (int i = 0; i < velocityData.size(); i++) {
@@ -1245,9 +1269,9 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
                 var theoreticalVEq = snodgrassVelocity(latDeg);
                 var fitVEq = fittedCoeffs.tangentialVelocity(latDeg) / cosLat; // Convert back to equatorial
                 writer.printf(Locale.US, "%.2f;%.4f;%.4f;%.4f;%.4f;%.4f;%.4f;%.4f;%.4f%n",
-                    latDeg, vEq * cosLat, madEq * cosLat, theoreticalVEq * cosLat, fittedCoeffs.tangentialVelocity(latDeg),
-                    velocityToAngularVelocity(vEq), velocityToAngularVelocity(madEq),
-                    snodgrassAngularVelocity(latDeg), fittedCoeffs.angularVelocity(latDeg));
+                        latDeg, vEq * cosLat, madEq * cosLat, theoreticalVEq * cosLat, fittedCoeffs.tangentialVelocity(latDeg),
+                        velocityToAngularVelocity(vEq), velocityToAngularVelocity(madEq),
+                        snodgrassAngularVelocity(latDeg), fittedCoeffs.angularVelocity(latDeg));
             }
             // Add fitted coefficients as a comment at the end
             writer.printf(Locale.US, "%n# Fitted coefficients: A=%.4f, B=%.4f, C=%.4f%n", fittedCoeffs.a(), fittedCoeffs.b(), fittedCoeffs.c());
@@ -1259,9 +1283,9 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
             return createDualRotationLayout(chartTitle, vc, ac, fittedCoeffs);
         };
         registerSaveChartAction(new GraphData.DifferentialVelocityData(
-            velocityChart, dualLayoutFactory, csvWriter));
+                velocityChart, dualLayoutFactory, csvWriter));
         registerSaveChartAction(new GraphData.DifferentialVelocityData(
-            angularChart, dualLayoutFactory, csvWriter));
+                angularChart, dualLayoutFactory, csvWriter));
 
         // Display in a new window
         var stage = new Stage();
@@ -1304,9 +1328,9 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
 
         // Display fitted coefficients compared to reference (Snodgrass & Ulrich 1990)
         var coeffsLabel = new Label(String.format(Locale.US,
-            "Fitted: ω(φ) = %.3f %+.3f·sin²φ %+.3f·sin⁴φ  |  Snodgrass & Ulrich (1990): ω(φ) = %.3f %+.3f·sin²φ %+.3f·sin⁴φ  (deg/day)",
-            fittedCoeffs.a(), fittedCoeffs.b(), fittedCoeffs.c(),
-            SNODGRASS_A, SNODGRASS_B, SNODGRASS_C));
+                "Fitted: ω(φ) = %.3f %+.3f·sin²φ %+.3f·sin⁴φ  |  Snodgrass & Ulrich (1990): ω(φ) = %.3f %+.3f·sin²φ %+.3f·sin⁴φ  (deg/day)",
+                fittedCoeffs.a(), fittedCoeffs.b(), fittedCoeffs.c(),
+                SNODGRASS_A, SNODGRASS_B, SNODGRASS_C));
         coeffsLabel.setStyle("-fx-font-size: 12px; -fx-font-family: monospace;");
         coeffsLabel.setMaxWidth(Double.MAX_VALUE);
         coeffsLabel.setAlignment(Pos.CENTER);
@@ -1319,7 +1343,8 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
         return vbox;
     }
 
-    private record ErrorBarParts(Line stem, Line topCap, Line bottomCap, double mad) {}
+    private record ErrorBarParts(Line stem, Line topCap, Line bottomCap, double mad) {
+    }
 
     private static void addErrorBarsToChart(LineChart<Number, Number> chart, List<double[]> velocityData, boolean angularVelocity) {
         var yAxis = (NumberAxis) chart.getYAxis();
@@ -1800,14 +1825,14 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
 
     private ScriptExecutionContext prepareExecutionContext(ProcessingDoneEvent.Outcome payload) {
         return ScriptExecutionContext.forProcessing(payload.processParams(), serFile.toPath(), payload.pixelShiftRange(), header)
-            .ellipse(payload.ellipse())
-            .imageStats(payload.imageStats())
-            .imageEmitter(payload.customImageEmitter())
-            .animationFormats(Configuration.getInstance().getAnimationFormats())
-            .progressOperation(rootOperation)
-            .serFileReader(payload.serFileReader())
-            .spectralLinePolynomial(payload.polynomialCoefficients() != null ? new SpectralLinePolynomial(payload.polynomialCoefficients()) : null)
-            .build();
+                .ellipse(payload.ellipse())
+                .imageStats(payload.imageStats())
+                .imageEmitter(payload.customImageEmitter())
+                .animationFormats(Configuration.getInstance().getAnimationFormats())
+                .progressOperation(rootOperation)
+                .serFileReader(payload.serFileReader())
+                .spectralLinePolynomial(payload.polynomialCoefficients() != null ? new SpectralLinePolynomial(payload.polynomialCoefficients()) : null)
+                .build();
     }
 
     @Override
@@ -2355,9 +2380,9 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
         // Helper to run the measurement
         Runnable runMeasurement = () -> {
             var referenceImage = shiftImages.entrySet().stream()
-                .min(Comparator.comparingDouble(e2 -> Math.abs(e2.getKey().pixelShift())))
-                .map(Map.Entry::getValue)
-                .orElse(null);
+                    .min(Comparator.comparingDouble(e2 -> Math.abs(e2.getKey().pixelShift())))
+                    .map(Map.Entry::getValue)
+                    .orElse(null);
             if (referenceImage == null) {
                 return;
             }
@@ -2382,8 +2407,8 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
         customMeasurementButton.setDisable(true);
         customMeasurementButton.setOnAction(evt -> {
             var result = DifferentialRotationConfigDialog.show(
-                measureVelocityButton.getScene().getWindow(),
-                differentialRotationConfig
+                    measureVelocityButton.getScene().getWindow(),
+                    differentialRotationConfig
             );
             result.ifPresent(config -> {
                 differentialRotationConfig = config;
@@ -2967,7 +2992,7 @@ public class SingleModeProcessingEventListener implements ProcessingEventListene
             var outputFile = new File(outputDirectory.toFile(), name);
             var image = entry.getValue();
             image.metadata().put(SpectroSolHubImageKind.class,
-                new SpectroSolHubImageKind(OutputMetadata.computeSpectroSolHubImageKind(label, metadata)));
+                    new SpectroSolHubImageKind(OutputMetadata.computeSpectroSolHubImageKind(label, metadata)));
             onImageGenerated(new ImageGeneratedEvent(
                     new GeneratedImage(GeneratedImageKind.IMAGE_MATH, label, outputFile.toPath(), image, description, displayTitle)
             ));

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SpectrumImageConverter.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/listeners/SpectrumImageConverter.java
@@ -28,16 +28,21 @@ final class SpectrumImageConverter {
     }
 
     /**
-     * Converts a spectrum image to an RGB byte array for display.
-     * Applies normalization and contrast stretching.
+     * Converts a spectrum image to a BGRA byte array for display.
+     * BGRA matches JavaFX's native pixel format so {@code WritableImage.setPixels}
+     * skips the on-FX-thread {@code ToByteBgrfConv} conversion. Output layout
+     * is {@code [B, G, R, A=0xFF]} per pixel; with greyscale data the three
+     * colour bytes are identical so the order doesn't matter, but the alpha
+     * byte must still be written. Caller passes
+     * {@link javafx.scene.image.PixelFormat#getByteBgraPreInstance()}.
      *
      * @param spectrum the spectrum image to convert
-     * @return RGB byte array suitable for display
+     * @return BGRA byte array suitable for display, sized {@code 4 * width * height}
      */
     static byte[] convertSpectrumImage(Image spectrum) {
         var width = spectrum.width();
         var height = spectrum.height();
-        var spectrumBuffer = new byte[3 * width * height];
+        var spectrumBuffer = new byte[4 * width * height];
 
         // Single pass: find max and store normalized values
         var max = 0;
@@ -56,14 +61,15 @@ final class SpectrumImageConverter {
             }
         }
 
-        // Second pass: apply stretching and convert to RGB bytes
+        // Second pass: apply stretching and convert to BGRA bytes
         var maxInverse = max > 0 ? 255.0 / max : 0.0;
         for (var i = 0; i < normalizedValues.length; i++) {
             var s = (byte) (normalizedValues[i] * maxInverse);
-            var offset = 3 * i;
+            var offset = 4 * i;
             spectrumBuffer[offset] = s;
             spectrumBuffer[offset + 1] = s;
             spectrumBuffer[offset + 2] = s;
+            spectrumBuffer[offset + 3] = (byte) 0xFF;
         }
 
         return spectrumBuffer;
@@ -73,7 +79,7 @@ final class SpectrumImageConverter {
      * Stretches pixel values to fill the full 0-255 range.
      *
      * @param pixels the ARGB pixel array to stretch
-     * @param width image width
+     * @param width  image width
      * @param height image height
      * @return stretched pixel array
      */

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/imageview.fxml
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/imageview.fxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.scene.control.ProgressIndicator?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.StackPane?>
 <?import me.champeau.a4j.jsolex.app.jfx.ZoomableImageView?>
@@ -13,6 +14,7 @@
     <center>
         <StackPane fx:id="imageContainer">
             <ZoomableImageView fx:id="imageView"/>
+            <ProgressIndicator fx:id="loadingIndicator" maxWidth="80" maxHeight="80" visible="false" mouseTransparent="true"/>
         </StackPane>
     </center>
 </BorderPane>

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages.properties
@@ -19,6 +19,7 @@ filename=File
 image.reconstruction=Reconstruction
 images=Generated images
 batch.mode.info=Entering batch mode: images will automatically be saved and date set to SER file date.
+batch.parallelism.capped=Batch parallelism reduced from {} to {} because the JVM heap is too small ({} GB). Increase the JVM heap to run more files in parallel.
 status=Status
 batch.started=Started
 batch.ok=Finished

--- a/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages_fr.properties
+++ b/jsolex/src/main/resources/me/champeau/a4j/jsolex/app/messages_fr.properties
@@ -19,6 +19,7 @@ filename=Fichier
 image.reconstruction=Reconstruction
 images=Images générées
 batch.mode.info=Entrée en mode batch. Les images seront automatiquement sauvegardées et la date remplacée par celle des fichiers SER.
+batch.parallelism.capped=Parallélisme batch réduit de {} à {} car le tas JVM est trop petit ({} Go). Augmentez la mémoire JVM pour traiter plus de fichiers en parallèle.
 status=Status
 batch.started=Démarré
 batch.ok=Terminé

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -2,6 +2,7 @@
 
 ## What's New in Version 5.1.3
 
+- Faster SER file processing thanks to reduced memory copies when reading frames.
 - Fixed custom color curves being silently lost after upgrading from a previous version.
 - Added a "Trust SER file bit depth" option in the advanced process parameters to bypass automatic bit depth detection when it produces an incorrect result.
 - Fixed the 3D viewers (single image 3D view and spherical tomography, both shell and smooth modes) failing to render on macOS.

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -2,6 +2,7 @@
 
 ## Nouveautés de la version 5.1.3
 
+- Traitement des fichiers SER plus rapide grâce à la réduction des copies mémoire lors de la lecture des images.
 - Correction des courbes de couleur personnalisées silencieusement perdues lors d'une mise à jour depuis une version antérieure.
 - Ajout d'une option « Faire confiance à la profondeur de bits déclarée » dans les paramètres de traitement avancés pour contourner la détection automatique lorsqu'elle donne un résultat incorrect.
 - Correction des vues 3D (image 3D et tomographie sphérique, modes coquilles et lissé) qui ne s'affichaient pas sur macOS.

--- a/math/build.gradle.kts
+++ b/math/build.gradle.kts
@@ -12,7 +12,9 @@ astro4j {
 }
 
 dependencies {
+    api(projects.utilities)
     implementation(libs.commons.math)
+    implementation(libs.slf4j.api)
 
     implementation(libs.lwjgl)
     implementation(libs.lwjgl.opencl)

--- a/math/src/main/java/me/champeau/a4j/math/correlation/CorrelationTools.java
+++ b/math/src/main/java/me/champeau/a4j/math/correlation/CorrelationTools.java
@@ -16,14 +16,16 @@
 package me.champeau.a4j.math.correlation;
 
 import me.champeau.a4j.math.fft.FFTSupport;
+import me.champeau.a4j.math.opencl.GpuOp;
 import me.champeau.a4j.math.opencl.OpenCLContext;
 import me.champeau.a4j.math.opencl.OpenCLSupport;
-import org.lwjgl.system.MemoryStack;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.lwjgl.opencl.CL10.*;
+import static org.lwjgl.opencl.CL10.CL_MEM_READ_ONLY;
+import static org.lwjgl.opencl.CL10.CL_MEM_WRITE_ONLY;
+import static org.lwjgl.opencl.CL10.CL_MEM_READ_WRITE;
 
 /**
  * Batched correlation for tile-based image alignment.
@@ -70,9 +72,7 @@ public class CorrelationTools {
         var context = OpenCLSupport.getContext();
         if (context != null && OpenCLSupport.isEnabled() && numTiles >= MIN_TILES_FOR_GPU) {
             try {
-                return context.tryExecuteWithLock(
-                        () -> batchedCorrelationGPU(context, refTiles, targetTiles, normalize),
-                        () -> batchedCorrelationCPU(refTiles, targetTiles, normalize));
+                return batchedCorrelationGPU(context, refTiles, targetTiles, normalize);
             } catch (Exception e) {
                 context.recordError("Correlation.batchedCorrelation", e);
             }
@@ -112,52 +112,25 @@ public class CorrelationTools {
         var targetFlat = flatten3D(targetTiles);
         var gpuResults = new float[numTiles * 3];
 
-        return context.executeWithLock(() -> {
-            long refBuffer = 0;
-            long targetBuffer = 0;
-            long resultBuffer = 0;
-            try {
-                refBuffer = context.allocateBuffer(refFlat.length * Float.BYTES, CL_MEM_READ_ONLY);
-                targetBuffer = context.allocateBuffer(targetFlat.length * Float.BYTES, CL_MEM_READ_ONLY);
-                resultBuffer = context.allocateBuffer(gpuResults.length * Float.BYTES, CL_MEM_WRITE_ONLY);
+        return context.runOp(op -> {
+            var refBuffer = op.allocateBuffer(refFlat.length * Float.BYTES, CL_MEM_READ_ONLY);
+            var targetBuffer = op.allocateBuffer(targetFlat.length * Float.BYTES, CL_MEM_READ_ONLY);
+            var resultBuffer = op.allocateBuffer(gpuResults.length * Float.BYTES, CL_MEM_WRITE_ONLY);
+            op.write(refBuffer, refFlat);
+            op.write(targetBuffer, targetFlat);
 
-                context.writeBuffer(refBuffer, refFlat);
-                context.writeBuffer(targetBuffer, targetFlat);
+            op.kernel("correlation", "batched_correlation_32")
+                    .arg(refBuffer)
+                    .arg(targetBuffer)
+                    .arg(resultBuffer)
+                    .arg(numTiles)
+                    .arg(normalize ? 1 : 0)
+                    .global((long) numTiles * 32, 32)
+                    .local(32, 32)
+                    .run();
 
-                var kernel = context.getKernelManager().getKernel("correlation", "batched_correlation_32");
-
-                try (var stack = MemoryStack.stackPush()) {
-                    clSetKernelArg(kernel, 0, stack.pointers(refBuffer));
-                    clSetKernelArg(kernel, 1, stack.pointers(targetBuffer));
-                    clSetKernelArg(kernel, 2, stack.pointers(resultBuffer));
-                    clSetKernelArg(kernel, 3, stack.ints(numTiles));
-                    clSetKernelArg(kernel, 4, stack.ints(normalize ? 1 : 0));
-
-                    var globalSize = stack.pointers((long) numTiles * 32, 32);
-                    var localSize = stack.pointers(32, 32);
-
-                    int err = clEnqueueNDRangeKernel(
-                            context.getCommandQueue(),
-                            kernel,
-                            2,
-                            null,
-                            globalSize,
-                            localSize,
-                            null,
-                            null
-                    );
-                    if (err != 0) {
-                        throw new RuntimeException("Failed to enqueue kernel: " + err);
-                    }
-                }
-
-                context.finish();
-                context.readBufferNoSync(resultBuffer, gpuResults);
-
-                return unpackGpuResults(gpuResults, numTiles);
-            } finally {
-                safeRelease(context, refBuffer, targetBuffer, resultBuffer);
-            }
+            op.read(resultBuffer, gpuResults);
+            return unpackGpuResults(gpuResults, numTiles);
         });
     }
 
@@ -170,109 +143,82 @@ public class CorrelationTools {
         var targetFlat = flatten3D(targetTiles);
         var gpuResults = new float[numTiles * 3];
 
-        return context.executeWithLock(() -> {
-            long refInputBuffer = 0;
-            long targetInputBuffer = 0;
-            long refComplexBuffer = 0;
-            long targetComplexBuffer = 0;
-            long tempBuffer = 0;
-            long realBuffer = 0;
-            long resultBuffer = 0;
+        int complexSize = numTiles * tileElements * 2 * Float.BYTES;
+        int realSize = numTiles * tileElements * Float.BYTES;
 
-            try {
-                int complexSize = numTiles * tileElements * 2 * Float.BYTES;
-                int realSize = numTiles * tileElements * Float.BYTES;
+        return context.runOp(op -> {
+            var refInputBuffer = op.allocateBuffer(realSize, CL_MEM_READ_ONLY);
+            var targetInputBuffer = op.allocateBuffer(realSize, CL_MEM_READ_ONLY);
+            var refComplexBuffer = op.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
+            var targetComplexBuffer = op.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
+            var tempBuffer = op.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
+            var realBuffer = op.allocateBuffer(realSize, CL_MEM_READ_WRITE);
+            var resultBuffer = op.allocateBuffer(gpuResults.length * Float.BYTES, CL_MEM_WRITE_ONLY);
 
-                refInputBuffer = context.allocateBuffer(realSize, CL_MEM_READ_ONLY);
-                targetInputBuffer = context.allocateBuffer(realSize, CL_MEM_READ_ONLY);
-                refComplexBuffer = context.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
-                targetComplexBuffer = context.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
-                tempBuffer = context.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
-                realBuffer = context.allocateBuffer(realSize, CL_MEM_READ_WRITE);
-                resultBuffer = context.allocateBuffer(gpuResults.length * Float.BYTES, CL_MEM_WRITE_ONLY);
+            op.write(refInputBuffer, refFlat);
+            op.write(targetInputBuffer, targetFlat);
 
-                context.writeBuffer(refInputBuffer, refFlat);
-                context.writeBuffer(targetInputBuffer, targetFlat);
+            // 1. Hann window for both ref and target
+            applyHann(op, refInputBuffer, refComplexBuffer, tileSize, numTiles);
+            applyHann(op, targetInputBuffer, targetComplexBuffer, tileSize, numTiles);
 
-                var km = context.getKernelManager();
-                var applyHannKernel = km.getKernel("correlation", "apply_hann_window");
-                var fftRowsKernel = km.getKernel("correlation", "fft_rows");
-                var transposeKernel = km.getKernel("correlation", "transpose");
-                var crossPowerKernel = km.getKernel("correlation", "cross_power_spectrum");
-                var scaleIfftKernel = km.getKernel("correlation", "scale_ifft");
-                var fftShiftKernel = km.getKernel("correlation", "fft_shift_real");
-                var findPeaksKernel = km.getKernel("correlation", "find_peaks");
+            // 2-3. Forward 2D FFT for reference and target
+            fft2D(op, refComplexBuffer, tempBuffer, tileSize, logTileSize, numTiles, -1);
+            fft2D(op, targetComplexBuffer, tempBuffer, tileSize, logTileSize, numTiles, -1);
 
-                try (var stack = MemoryStack.stackPush()) {
-                    var queue = context.getCommandQueue();
+            // 4. Cross-power spectrum
+            op.kernel("correlation", "cross_power_spectrum")
+                    .arg(refComplexBuffer)
+                    .arg(targetComplexBuffer)
+                    .arg(tileSize)
+                    .arg(numTiles)
+                    .arg(normalize ? 1 : 0)
+                    .global(tileSize, tileSize, numTiles)
+                    .run();
 
-                    // 1. Apply Hann window to both ref and target
-                    clSetKernelArg(applyHannKernel, 0, stack.pointers(refInputBuffer));
-                    clSetKernelArg(applyHannKernel, 1, stack.pointers(refComplexBuffer));
-                    clSetKernelArg(applyHannKernel, 2, stack.ints(tileSize));
-                    clSetKernelArg(applyHannKernel, 3, stack.ints(numTiles));
-                    enqueue3D(queue, applyHannKernel, tileSize, tileSize, numTiles, stack);
+            // 5. Inverse 2D FFT
+            fft2D(op, refComplexBuffer, tempBuffer, tileSize, logTileSize, numTiles, +1);
 
-                    clSetKernelArg(applyHannKernel, 0, stack.pointers(targetInputBuffer));
-                    clSetKernelArg(applyHannKernel, 1, stack.pointers(targetComplexBuffer));
-                    enqueue3D(queue, applyHannKernel, tileSize, tileSize, numTiles, stack);
+            // 6. Scale by 1/N^2
+            op.kernel("correlation", "scale_ifft")
+                    .arg(refComplexBuffer)
+                    .arg(tileSize)
+                    .arg(numTiles)
+                    .global(tileSize, tileSize, numTiles)
+                    .run();
 
-                    // 2. Forward 2D FFT for reference: rows -> transpose -> rows -> transpose
-                    fft2D(queue, fftRowsKernel, transposeKernel, refComplexBuffer, tempBuffer,
-                            tileSize, logTileSize, numTiles, -1, stack);
+            // 7. FFT shift + extract real part
+            op.kernel("correlation", "fft_shift_real")
+                    .arg(refComplexBuffer)
+                    .arg(realBuffer)
+                    .arg(tileSize)
+                    .arg(numTiles)
+                    .global(tileSize, tileSize, numTiles)
+                    .run();
 
-                    // 3. Forward 2D FFT for target
-                    fft2D(queue, fftRowsKernel, transposeKernel, targetComplexBuffer, tempBuffer,
-                            tileSize, logTileSize, numTiles, -1, stack);
+            // 8. Find peaks
+            op.kernel("correlation", "find_peaks")
+                    .arg(realBuffer)
+                    .arg(resultBuffer)
+                    .arg(tileSize)
+                    .arg(numTiles)
+                    .global(numTiles * 256L)
+                    .local(256)
+                    .run();
 
-                    // 4. Cross-power spectrum (with optional normalization)
-                    clSetKernelArg(crossPowerKernel, 0, stack.pointers(refComplexBuffer));
-                    clSetKernelArg(crossPowerKernel, 1, stack.pointers(targetComplexBuffer));
-                    clSetKernelArg(crossPowerKernel, 2, stack.ints(tileSize));
-                    clSetKernelArg(crossPowerKernel, 3, stack.ints(numTiles));
-                    clSetKernelArg(crossPowerKernel, 4, stack.ints(normalize ? 1 : 0));
-                    enqueue3D(queue, crossPowerKernel, tileSize, tileSize, numTiles, stack);
-
-                    // 5. Inverse 2D FFT
-                    fft2D(queue, fftRowsKernel, transposeKernel, refComplexBuffer, tempBuffer,
-                            tileSize, logTileSize, numTiles, +1, stack);
-
-                    // 6. Scale by 1/N^2
-                    clSetKernelArg(scaleIfftKernel, 0, stack.pointers(refComplexBuffer));
-                    clSetKernelArg(scaleIfftKernel, 1, stack.ints(tileSize));
-                    clSetKernelArg(scaleIfftKernel, 2, stack.ints(numTiles));
-                    enqueue3D(queue, scaleIfftKernel, tileSize, tileSize, numTiles, stack);
-
-                    // 7. FFT shift and extract real part
-                    clSetKernelArg(fftShiftKernel, 0, stack.pointers(refComplexBuffer));
-                    clSetKernelArg(fftShiftKernel, 1, stack.pointers(realBuffer));
-                    clSetKernelArg(fftShiftKernel, 2, stack.ints(tileSize));
-                    clSetKernelArg(fftShiftKernel, 3, stack.ints(numTiles));
-                    enqueue3D(queue, fftShiftKernel, tileSize, tileSize, numTiles, stack);
-
-                    // 8. Find peaks
-                    clSetKernelArg(findPeaksKernel, 0, stack.pointers(realBuffer));
-                    clSetKernelArg(findPeaksKernel, 1, stack.pointers(resultBuffer));
-                    clSetKernelArg(findPeaksKernel, 2, stack.ints(tileSize));
-                    clSetKernelArg(findPeaksKernel, 3, stack.ints(numTiles));
-
-                    var globalSize = stack.pointers(numTiles * 256L);
-                    var localSize = stack.pointers(256);
-                    int err = clEnqueueNDRangeKernel(queue, findPeaksKernel, 1, null, globalSize, localSize, null, null);
-                    if (err != 0) {
-                        throw new RuntimeException("Failed to enqueue find_peaks kernel: " + err);
-                    }
-                }
-
-                context.finish();
-                context.readBufferNoSync(resultBuffer, gpuResults);
-
-                return unpackGpuResults(gpuResults, numTiles);
-            } finally {
-                safeRelease(context, refInputBuffer, targetInputBuffer, refComplexBuffer,
-                        targetComplexBuffer, tempBuffer, realBuffer, resultBuffer);
-            }
+            op.read(resultBuffer, gpuResults);
+            return unpackGpuResults(gpuResults, numTiles);
         });
+    }
+
+    private static void applyHann(GpuOp op, long inputBuffer, long outputComplex, int tileSize, int numTiles) {
+        op.kernel("correlation", "apply_hann_window")
+                .arg(inputBuffer)
+                .arg(outputComplex)
+                .arg(tileSize)
+                .arg(numTiles)
+                .global(tileSize, tileSize, numTiles)
+                .run();
     }
 
     private static float[][] unpackGpuResults(float[] gpuResults, int numTiles) {
@@ -286,94 +232,45 @@ public class CorrelationTools {
         return results;
     }
 
-    private static void safeRelease(OpenCLContext context, long... buffers) {
-        for (long buffer : buffers) {
-            if (buffer != 0) {
-                try {
-                    context.releaseBuffer(buffer);
-                } catch (Exception e) {
-                    System.err.println("[PhaseCorrelation] Failed to release GPU buffer");
-                    e.printStackTrace();
-                }
-            }
-        }
+    private static void fft2D(GpuOp op,
+                              long dataBuffer,
+                              long tempBuffer,
+                              int tileSize,
+                              int logTileSize,
+                              int numTiles,
+                              int direction) {
+        enqueueFFTRows(op, dataBuffer, tileSize, logTileSize, numTiles, direction);
+        enqueueTranspose(op, dataBuffer, tempBuffer, tileSize, numTiles);
+        enqueueFFTRows(op, tempBuffer, tileSize, logTileSize, numTiles, direction);
+        enqueueTranspose(op, tempBuffer, dataBuffer, tileSize, numTiles);
     }
 
-    private void fft2D(long queue,
-                       long fftRowsKernel,
-                       long transposeKernel,
-                       long dataBuffer,
-                       long tempBuffer,
-                       int tileSize,
-                       int logTileSize,
-                       int numTiles,
-                       int direction,
-                       MemoryStack stack) {
-        enqueueFFTRows(queue, fftRowsKernel, dataBuffer, tileSize, logTileSize, numTiles, direction, stack);
-        enqueueTranspose(queue, transposeKernel, dataBuffer, tempBuffer, tileSize, numTiles, stack);
-        enqueueFFTRows(queue, fftRowsKernel, tempBuffer, tileSize, logTileSize, numTiles, direction, stack);
-        enqueueTranspose(queue, transposeKernel, tempBuffer, dataBuffer, tileSize, numTiles, stack);
-    }
-
-    private static void enqueueFFTRows(long queue,
-                                       long kernel,
-                                       long buffer,
-                                       int tileSize,
-                                       int logTileSize,
-                                       int numTiles,
-                                       int direction,
-                                       MemoryStack stack) {
-        clSetKernelArg(kernel, 0, stack.pointers(buffer));
-        clSetKernelArg(kernel, 1, stack.ints(tileSize));
-        clSetKernelArg(kernel, 2, stack.ints(logTileSize));
-        clSetKernelArg(kernel, 3, stack.ints(direction));
-
-        var globalSize = stack.pointers(tileSize, (long) numTiles * tileSize);
-        var localSize = stack.pointers(tileSize, 1);
-        int err = clEnqueueNDRangeKernel(queue, kernel, 2, null, globalSize, localSize, null, null);
-        if (err != 0) {
-            throw new RuntimeException("Failed to enqueue fft_rows kernel: " + err);
-        }
+    private static void enqueueFFTRows(GpuOp op, long buffer, int tileSize, int logTileSize, int numTiles, int direction) {
+        op.kernel("correlation", "fft_rows")
+                .arg(buffer)
+                .arg(tileSize)
+                .arg(logTileSize)
+                .arg(direction)
+                .global(tileSize, (long) numTiles * tileSize)
+                .local(tileSize, 1)
+                .run();
     }
 
     private static final int TRANSPOSE_BLOCK_SIZE = 16;
 
-    private static void enqueueTranspose(long queue,
-                                         long kernel,
-                                         long src,
-                                         long dst,
-                                         int tileSize,
-                                         int numTiles,
-                                         MemoryStack stack) {
-        clSetKernelArg(kernel, 0, stack.pointers(src));
-        clSetKernelArg(kernel, 1, stack.pointers(dst));
-        clSetKernelArg(kernel, 2, stack.ints(tileSize));
-        clSetKernelArg(kernel, 3, stack.ints(numTiles));
-
+    private static void enqueueTranspose(GpuOp op, long src, long dst, int tileSize, int numTiles) {
         // Round up global size to multiple of block size for local memory blocking
-        int globalX = ((tileSize + TRANSPOSE_BLOCK_SIZE - 1) / TRANSPOSE_BLOCK_SIZE) * TRANSPOSE_BLOCK_SIZE;
-        int globalY = ((tileSize + TRANSPOSE_BLOCK_SIZE - 1) / TRANSPOSE_BLOCK_SIZE) * TRANSPOSE_BLOCK_SIZE;
-
-        var globalSize = stack.pointers(globalX, globalY, numTiles);
-        var localSize = stack.pointers(TRANSPOSE_BLOCK_SIZE, TRANSPOSE_BLOCK_SIZE, 1);
-        int err = clEnqueueNDRangeKernel(queue, kernel, 3, null, globalSize, localSize, null, null);
-        if (err != 0) {
-            throw new RuntimeException("Failed to enqueue transpose kernel: " + err);
-        }
+        int globalXY = ((tileSize + TRANSPOSE_BLOCK_SIZE - 1) / TRANSPOSE_BLOCK_SIZE) * TRANSPOSE_BLOCK_SIZE;
+        op.kernel("correlation", "transpose")
+                .arg(src)
+                .arg(dst)
+                .arg(tileSize)
+                .arg(numTiles)
+                .global(globalXY, globalXY, numTiles)
+                .local(TRANSPOSE_BLOCK_SIZE, TRANSPOSE_BLOCK_SIZE, 1)
+                .run();
     }
 
-    private static void enqueue3D(long queue,
-                                  long kernel,
-                                  int sizeX,
-                                  int sizeY,
-                                  int sizeZ,
-                                  MemoryStack stack) {
-        var globalSize = stack.pointers(sizeX, sizeY, sizeZ);
-        int err = clEnqueueNDRangeKernel(queue, kernel, 3, null, globalSize, null, null, null);
-        if (err != 0) {
-            throw new RuntimeException("Failed to enqueue 3D kernel: " + err);
-        }
-    }
 
     private static float[] flatten3D(float[][][] data) {
         int n = data.length;
@@ -449,9 +346,7 @@ public class CorrelationTools {
         var context = OpenCLSupport.getContext();
         if (context != null && OpenCLSupport.isEnabled() && numTiles >= MIN_TILES_FOR_GPU) {
             try {
-                return context.tryExecuteWithLock(
-                        () -> batchedNCCGPU(context, refTiles, targetTiles),
-                        () -> batchedNCCCPU(refTiles, targetTiles));
+                return batchedNCCGPU(context, refTiles, targetTiles);
             } catch (Exception e) {
                 context.recordError("Correlation.batchedNCC", e);
             }
@@ -491,51 +386,21 @@ public class CorrelationTools {
         var targetFlat = flatten3D(targetTiles);
         var gpuResults = new float[numTiles * 3];
 
-        return context.executeWithLock(() -> {
-            long refBuffer = 0;
-            long targetBuffer = 0;
-            long resultBuffer = 0;
-            try {
-                refBuffer = context.allocateBuffer(refFlat.length * Float.BYTES, CL_MEM_READ_ONLY);
-                targetBuffer = context.allocateBuffer(targetFlat.length * Float.BYTES, CL_MEM_READ_ONLY);
-                resultBuffer = context.allocateBuffer(gpuResults.length * Float.BYTES, CL_MEM_WRITE_ONLY);
+        return context.runOp(op -> {
+            var refBuffer = op.allocateBuffer(refFlat.length * Float.BYTES, CL_MEM_READ_ONLY);
+            var targetBuffer = op.allocateBuffer(targetFlat.length * Float.BYTES, CL_MEM_READ_ONLY);
+            var resultBuffer = op.allocateBuffer(gpuResults.length * Float.BYTES, CL_MEM_WRITE_ONLY);
+            op.write(refBuffer, refFlat);
+            op.write(targetBuffer, targetFlat);
 
-                context.writeBuffer(refBuffer, refFlat);
-                context.writeBuffer(targetBuffer, targetFlat);
+            op.kernel("correlation", "batched_ncc_32")
+                    .arg(refBuffer).arg(targetBuffer).arg(resultBuffer).arg(numTiles)
+                    .global((long) numTiles * 32, 32)
+                    .local(32, 32)
+                    .run();
 
-                var kernel = context.getKernelManager().getKernel("correlation", "batched_ncc_32");
-
-                try (var stack = MemoryStack.stackPush()) {
-                    clSetKernelArg(kernel, 0, stack.pointers(refBuffer));
-                    clSetKernelArg(kernel, 1, stack.pointers(targetBuffer));
-                    clSetKernelArg(kernel, 2, stack.pointers(resultBuffer));
-                    clSetKernelArg(kernel, 3, stack.ints(numTiles));
-
-                    var globalSize = stack.pointers((long) numTiles * 32, 32);
-                    var localSize = stack.pointers(32, 32);
-
-                    int err = clEnqueueNDRangeKernel(
-                            context.getCommandQueue(),
-                            kernel,
-                            2,
-                            null,
-                            globalSize,
-                            localSize,
-                            null,
-                            null
-                    );
-                    if (err != 0) {
-                        throw new RuntimeException("Failed to enqueue NCC kernel: " + err);
-                    }
-                }
-
-                context.finish();
-                context.readBufferNoSync(resultBuffer, gpuResults);
-
-                return unpackGpuResults(gpuResults, numTiles);
-            } finally {
-                safeRelease(context, refBuffer, targetBuffer, resultBuffer);
-            }
+            op.read(resultBuffer, gpuResults);
+            return unpackGpuResults(gpuResults, numTiles);
         });
     }
 
@@ -548,130 +413,71 @@ public class CorrelationTools {
         var targetFlat = flatten3D(targetTiles);
         var gpuResults = new float[numTiles * 3];
 
-        return context.executeWithLock(() -> {
-            long refInputBuffer = 0;
-            long targetInputBuffer = 0;
-            long refComplexBuffer = 0;
-            long targetComplexBuffer = 0;
-            long tempBuffer = 0;
-            long realBuffer = 0;
-            long resultBuffer = 0;
-            long statsBuffer = 0;
+        int complexSize = numTiles * tileElements * 2 * Float.BYTES;
+        int realSize = numTiles * tileElements * Float.BYTES;
+        int statsSize = numTiles * 3 * Float.BYTES;  // normFactor, meanRef, meanTarget per tile
 
-            try {
-                int complexSize = numTiles * tileElements * 2 * Float.BYTES;
-                int realSize = numTiles * tileElements * Float.BYTES;
-                int statsSize = numTiles * 3 * Float.BYTES;  // normFactor, meanRef, meanTarget per tile
+        return context.runOp(op -> {
+            var refInputBuffer = op.allocateBuffer(realSize, CL_MEM_READ_ONLY);
+            var targetInputBuffer = op.allocateBuffer(realSize, CL_MEM_READ_ONLY);
+            var refComplexBuffer = op.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
+            var targetComplexBuffer = op.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
+            var tempBuffer = op.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
+            var realBuffer = op.allocateBuffer(realSize, CL_MEM_READ_WRITE);
+            var resultBuffer = op.allocateBuffer(gpuResults.length * Float.BYTES, CL_MEM_WRITE_ONLY);
+            var statsBuffer = op.allocateBuffer(statsSize, CL_MEM_READ_WRITE);
 
-                refInputBuffer = context.allocateBuffer(realSize, CL_MEM_READ_ONLY);
-                targetInputBuffer = context.allocateBuffer(realSize, CL_MEM_READ_ONLY);
-                refComplexBuffer = context.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
-                targetComplexBuffer = context.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
-                tempBuffer = context.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
-                realBuffer = context.allocateBuffer(realSize, CL_MEM_READ_WRITE);
-                resultBuffer = context.allocateBuffer(gpuResults.length * Float.BYTES, CL_MEM_WRITE_ONLY);
-                statsBuffer = context.allocateBuffer(statsSize, CL_MEM_READ_WRITE);
+            op.write(refInputBuffer, refFlat);
+            op.write(targetInputBuffer, targetFlat);
 
-                context.writeBuffer(refInputBuffer, refFlat);
-                context.writeBuffer(targetInputBuffer, targetFlat);
+            // 1. Compute per-tile statistics
+            op.kernel("correlation", "compute_tile_stats")
+                    .arg(refInputBuffer).arg(targetInputBuffer).arg(statsBuffer)
+                    .arg(tileSize).arg(numTiles)
+                    .global(numTiles * 256L).local(256)
+                    .run();
 
-                var km = context.getKernelManager();
-                var computeStatsKernel = km.getKernel("correlation", "compute_tile_stats");
-                var zeroMeanAndHannKernel = km.getKernel("correlation", "zero_mean_and_hann");
-                var fftRowsKernel = km.getKernel("correlation", "fft_rows");
-                var transposeKernel = km.getKernel("correlation", "transpose");
-                var crossPowerKernel = km.getKernel("correlation", "cross_power_spectrum");
-                var scaleIfftKernel = km.getKernel("correlation", "scale_ifft");
-                var fftShiftKernel = km.getKernel("correlation", "fft_shift_real");
-                var findPeaksNCCKernel = km.getKernel("correlation", "find_peaks_ncc");
+            // 2. Zero-mean + Hann window for ref and target
+            op.kernel("correlation", "zero_mean_and_hann")
+                    .arg(refInputBuffer).arg(refComplexBuffer).arg(statsBuffer)
+                    .arg(tileSize).arg(numTiles).arg(0)
+                    .global(tileSize, tileSize, numTiles).run();
+            op.kernel("correlation", "zero_mean_and_hann")
+                    .arg(targetInputBuffer).arg(targetComplexBuffer).arg(statsBuffer)
+                    .arg(tileSize).arg(numTiles).arg(1)
+                    .global(tileSize, tileSize, numTiles).run();
 
-                try (var stack = MemoryStack.stackPush()) {
-                    var queue = context.getCommandQueue();
+            // 3-4. Forward 2D FFT for ref and target
+            fft2D(op, refComplexBuffer, tempBuffer, tileSize, logTileSize, numTiles, -1);
+            fft2D(op, targetComplexBuffer, tempBuffer, tileSize, logTileSize, numTiles, -1);
 
-                    // 1. Compute statistics (mean and sum of squared deviations) for both tiles
-                    clSetKernelArg(computeStatsKernel, 0, stack.pointers(refInputBuffer));
-                    clSetKernelArg(computeStatsKernel, 1, stack.pointers(targetInputBuffer));
-                    clSetKernelArg(computeStatsKernel, 2, stack.pointers(statsBuffer));
-                    clSetKernelArg(computeStatsKernel, 3, stack.ints(tileSize));
-                    clSetKernelArg(computeStatsKernel, 4, stack.ints(numTiles));
+            // 5. Cross-power spectrum (no normalization for NCC)
+            op.kernel("correlation", "cross_power_spectrum")
+                    .arg(refComplexBuffer).arg(targetComplexBuffer)
+                    .arg(tileSize).arg(numTiles).arg(0)
+                    .global(tileSize, tileSize, numTiles).run();
 
-                    var globalSizeStats = stack.pointers(numTiles * 256L);
-                    var localSizeStats = stack.pointers(256);
-                    int err = clEnqueueNDRangeKernel(queue, computeStatsKernel, 1, null, globalSizeStats, localSizeStats, null, null);
-                    if (err != 0) {
-                        throw new RuntimeException("Failed to enqueue compute_tile_stats kernel: " + err);
-                    }
+            // 6. Inverse 2D FFT
+            fft2D(op, refComplexBuffer, tempBuffer, tileSize, logTileSize, numTiles, +1);
 
-                    // 2. Apply zero-mean and Hann window to both ref and target
-                    clSetKernelArg(zeroMeanAndHannKernel, 0, stack.pointers(refInputBuffer));
-                    clSetKernelArg(zeroMeanAndHannKernel, 1, stack.pointers(refComplexBuffer));
-                    clSetKernelArg(zeroMeanAndHannKernel, 2, stack.pointers(statsBuffer));
-                    clSetKernelArg(zeroMeanAndHannKernel, 3, stack.ints(tileSize));
-                    clSetKernelArg(zeroMeanAndHannKernel, 4, stack.ints(numTiles));
-                    clSetKernelArg(zeroMeanAndHannKernel, 5, stack.ints(0));
-                    enqueue3D(queue, zeroMeanAndHannKernel, tileSize, tileSize, numTiles, stack);
+            // 7. Scale by 1/N^2
+            op.kernel("correlation", "scale_ifft")
+                    .arg(refComplexBuffer).arg(tileSize).arg(numTiles)
+                    .global(tileSize, tileSize, numTiles).run();
 
-                    clSetKernelArg(zeroMeanAndHannKernel, 0, stack.pointers(targetInputBuffer));
-                    clSetKernelArg(zeroMeanAndHannKernel, 1, stack.pointers(targetComplexBuffer));
-                    clSetKernelArg(zeroMeanAndHannKernel, 5, stack.ints(1));
-                    enqueue3D(queue, zeroMeanAndHannKernel, tileSize, tileSize, numTiles, stack);
+            // 8. FFT shift + extract real part
+            op.kernel("correlation", "fft_shift_real")
+                    .arg(refComplexBuffer).arg(realBuffer).arg(tileSize).arg(numTiles)
+                    .global(tileSize, tileSize, numTiles).run();
 
-                    // 3. Forward 2D FFT for reference
-                    fft2D(queue, fftRowsKernel, transposeKernel, refComplexBuffer, tempBuffer,
-                            tileSize, logTileSize, numTiles, -1, stack);
+            // 9. Find peaks with NCC normalization
+            op.kernel("correlation", "find_peaks_ncc")
+                    .arg(realBuffer).arg(statsBuffer).arg(resultBuffer)
+                    .arg(tileSize).arg(numTiles)
+                    .global(numTiles * 256L).local(256).run();
 
-                    // 4. Forward 2D FFT for target
-                    fft2D(queue, fftRowsKernel, transposeKernel, targetComplexBuffer, tempBuffer,
-                            tileSize, logTileSize, numTiles, -1, stack);
-
-                    // 5. Cross-power spectrum (no normalization for NCC)
-                    clSetKernelArg(crossPowerKernel, 0, stack.pointers(refComplexBuffer));
-                    clSetKernelArg(crossPowerKernel, 1, stack.pointers(targetComplexBuffer));
-                    clSetKernelArg(crossPowerKernel, 2, stack.ints(tileSize));
-                    clSetKernelArg(crossPowerKernel, 3, stack.ints(numTiles));
-                    clSetKernelArg(crossPowerKernel, 4, stack.ints(0));
-                    enqueue3D(queue, crossPowerKernel, tileSize, tileSize, numTiles, stack);
-
-                    // 6. Inverse 2D FFT
-                    fft2D(queue, fftRowsKernel, transposeKernel, refComplexBuffer, tempBuffer,
-                            tileSize, logTileSize, numTiles, +1, stack);
-
-                    // 7. Scale by 1/N^2
-                    clSetKernelArg(scaleIfftKernel, 0, stack.pointers(refComplexBuffer));
-                    clSetKernelArg(scaleIfftKernel, 1, stack.ints(tileSize));
-                    clSetKernelArg(scaleIfftKernel, 2, stack.ints(numTiles));
-                    enqueue3D(queue, scaleIfftKernel, tileSize, tileSize, numTiles, stack);
-
-                    // 8. FFT shift and extract real part
-                    clSetKernelArg(fftShiftKernel, 0, stack.pointers(refComplexBuffer));
-                    clSetKernelArg(fftShiftKernel, 1, stack.pointers(realBuffer));
-                    clSetKernelArg(fftShiftKernel, 2, stack.ints(tileSize));
-                    clSetKernelArg(fftShiftKernel, 3, stack.ints(numTiles));
-                    enqueue3D(queue, fftShiftKernel, tileSize, tileSize, numTiles, stack);
-
-                    // 9. Find peaks with NCC normalization
-                    clSetKernelArg(findPeaksNCCKernel, 0, stack.pointers(realBuffer));
-                    clSetKernelArg(findPeaksNCCKernel, 1, stack.pointers(statsBuffer));
-                    clSetKernelArg(findPeaksNCCKernel, 2, stack.pointers(resultBuffer));
-                    clSetKernelArg(findPeaksNCCKernel, 3, stack.ints(tileSize));
-                    clSetKernelArg(findPeaksNCCKernel, 4, stack.ints(numTiles));
-
-                    var globalSize = stack.pointers(numTiles * 256L);
-                    var localSize = stack.pointers(256);
-                    err = clEnqueueNDRangeKernel(queue, findPeaksNCCKernel, 1, null, globalSize, localSize, null, null);
-                    if (err != 0) {
-                        throw new RuntimeException("Failed to enqueue find_peaks_ncc kernel: " + err);
-                    }
-                }
-
-                context.finish();
-                context.readBufferNoSync(resultBuffer, gpuResults);
-
-                return unpackGpuResults(gpuResults, numTiles);
-            } finally {
-                safeRelease(context, refInputBuffer, targetInputBuffer, refComplexBuffer,
-                        targetComplexBuffer, tempBuffer, realBuffer, resultBuffer, statsBuffer);
-            }
+            op.read(resultBuffer, gpuResults);
+            return unpackGpuResults(gpuResults, numTiles);
         });
     }
 
@@ -701,7 +507,6 @@ public class CorrelationTools {
         float meanRef = (float) (sumRef / count);
         float meanDef = (float) (sumDef / count);
 
-        // 2. Zero-mean and compute variances
         var zeroMeanRef = new float[size][size];
         var zeroMeanDef = new float[size][size];
         double sumSqRef = 0, sumSqDef = 0;
@@ -717,18 +522,15 @@ public class CorrelationTools {
             }
         }
 
-        // 3. Normalization factor
         double normFactor = Math.sqrt(sumSqRef * sumSqDef);
         if (normFactor < 1e-10) {
             return new ShiftResult(0, 0, 0);
         }
 
-        // 4. Apply Hann window
         var window = getOrCreateHannWindow(size);
         var windowedRef = applyWindowCopy(zeroMeanRef, window);
         var windowedDef = applyWindowCopy(zeroMeanDef, window);
 
-        // 5. FFT cross-correlation (no normalization)
         var fftRef = FFTSupport.fft2Float(windowedRef);
         var fftDef = FFTSupport.fft2Float(windowedDef);
 
@@ -736,7 +538,6 @@ public class CorrelationTools {
         var cols = fftRef.real[0].length;
         var realResult = new float[rows][cols];
         var imagResult = new float[rows][cols];
-
         for (var i = 0; i < rows; i++) {
             for (var j = 0; j < cols; j++) {
                 var refR = fftRef.real[i][j];
@@ -748,10 +549,8 @@ public class CorrelationTools {
                 imagResult[i][j] = refI * defR - refR * defI;
             }
         }
-
         var crossCorr = fftShift(FFTSupport.ifft2Float(new FFTSupport.FloatFFT2DResult(realResult, imagResult)));
 
-        // 6. Find peak and compute NCC value
         var maxIdx = findMaxIndex(crossCorr);
         var center = new double[]{crossCorr.real.length / 2d, crossCorr.real[0].length / 2d};
         var shifts = new double[]{maxIdx[0] - center[0], maxIdx[1] - center[1]};
@@ -760,11 +559,8 @@ public class CorrelationTools {
         shifts[0] += subpixelOffset[0];
         shifts[1] += subpixelOffset[1];
 
-        // 7. NCC confidence = peak value / normalization factor
         double peakValue = crossCorr.real[maxIdx[0]][maxIdx[1]];
         double nccValue = peakValue / normFactor;
-
-        // Clamp to [0, 1] - negative correlations indicate mismatch
         double confidence = Math.max(0, Math.min(1, nccValue));
 
         return new ShiftResult(shifts[0], shifts[1], confidence);
@@ -793,7 +589,6 @@ public class CorrelationTools {
         var cols = fftRef.real[0].length;
         var realResult = new float[rows][cols];
         var imagResult = new float[rows][cols];
-
         for (var i = 0; i < rows; i++) {
             for (var j = 0; j < cols; j++) {
                 var refR = fftRef.real[i][j];
@@ -972,10 +767,8 @@ public class CorrelationTools {
      * This method eliminates tile transfer overhead by extracting tiles directly
      * from images that are already on the GPU. This is significantly faster when
      * processing multiple image pairs, as images only need to be uploaded once.
-     * <p>
-     * Must be called within {@link OpenCLContext#executeWithLock}.
      *
-     * @param context           the OpenCL context (must hold GPU lock)
+     * @param context           the OpenCL context
      * @param refImageBuffer    GPU buffer handle for reference image
      * @param targetImageBuffer GPU buffer handle for target image
      * @param imageWidth        image width in pixels
@@ -984,11 +777,11 @@ public class CorrelationTools {
      * @return displacements [N][3] containing (dx, dy, confidence) per tile
      */
     public float[][] correlateResidentImagesNCC32(OpenCLContext context,
-                                                   long refImageBuffer,
-                                                   long targetImageBuffer,
-                                                   int imageWidth,
-                                                   int imageHeight,
-                                                   int[][] tilePositions) {
+                                                  long refImageBuffer,
+                                                  long targetImageBuffer,
+                                                  int imageWidth,
+                                                  int imageHeight,
+                                                  int[][] tilePositions) {
         int numTiles = tilePositions.length;
         if (numTiles == 0) {
             return new float[0][3];
@@ -1003,50 +796,22 @@ public class CorrelationTools {
 
         var gpuResults = new float[numTiles * 3];
 
-        long positionsBuffer = 0;
-        long resultBuffer = 0;
-        try {
-            positionsBuffer = context.allocateBuffer(positionsFlat.length * Integer.BYTES, CL_MEM_READ_ONLY);
-            resultBuffer = context.allocateBuffer(gpuResults.length * Float.BYTES, CL_MEM_WRITE_ONLY);
+        return context.runOp(op -> {
+            var positionsBuffer = op.allocateBuffer(positionsFlat.length * Integer.BYTES, CL_MEM_READ_ONLY);
+            var resultBuffer = op.allocateBuffer(gpuResults.length * Float.BYTES, CL_MEM_WRITE_ONLY);
+            op.writeInts(positionsBuffer, positionsFlat);
 
-            context.writeBufferInt(positionsBuffer, positionsFlat);
+            op.kernel("correlation", "correlate_resident_ncc_32")
+                    .arg(refImageBuffer).arg(targetImageBuffer)
+                    .arg(imageWidth).arg(imageHeight)
+                    .arg(positionsBuffer).arg(resultBuffer).arg(numTiles)
+                    .global((long) numTiles * 32, 32)
+                    .local(32, 32)
+                    .run();
 
-            var kernel = context.getKernelManager().getKernel("correlation", "correlate_resident_ncc_32");
-
-            try (var stack = MemoryStack.stackPush()) {
-                clSetKernelArg(kernel, 0, stack.pointers(refImageBuffer));
-                clSetKernelArg(kernel, 1, stack.pointers(targetImageBuffer));
-                clSetKernelArg(kernel, 2, stack.ints(imageWidth));
-                clSetKernelArg(kernel, 3, stack.ints(imageHeight));
-                clSetKernelArg(kernel, 4, stack.pointers(positionsBuffer));
-                clSetKernelArg(kernel, 5, stack.pointers(resultBuffer));
-                clSetKernelArg(kernel, 6, stack.ints(numTiles));
-
-                var globalSize = stack.pointers((long) numTiles * 32, 32);
-                var localSize = stack.pointers(32, 32);
-
-                int err = clEnqueueNDRangeKernel(
-                        context.getCommandQueue(),
-                        kernel,
-                        2,
-                        null,
-                        globalSize,
-                        localSize,
-                        null,
-                        null
-                );
-                if (err != 0) {
-                    throw new RuntimeException("Failed to enqueue correlate_resident_ncc_32 kernel: " + err);
-                }
-            }
-
-            context.finish();
-            context.readBufferNoSync(resultBuffer, gpuResults);
-
+            op.read(resultBuffer, gpuResults);
             return unpackGpuResults(gpuResults, numTiles);
-        } finally {
-            safeRelease(context, positionsBuffer, resultBuffer);
-        }
+        });
     }
 
     /**
@@ -1055,10 +820,8 @@ public class CorrelationTools {
      * This method extracts tiles directly from GPU-resident images, eliminating
      * the overhead of CPU-GPU tile transfers. It uses the same FFT pipeline as
      * the regular batch NCC method.
-     * <p>
-     * Must be called within {@link OpenCLContext#executeWithLock}.
      *
-     * @param context           the OpenCL context (must hold GPU lock)
+     * @param context           the OpenCL context
      * @param refImageBuffer    GPU buffer handle for reference image
      * @param targetImageBuffer GPU buffer handle for target image
      * @param imageWidth        image width in pixels
@@ -1068,12 +831,12 @@ public class CorrelationTools {
      * @return displacements [N][3] containing (dx, dy, confidence) per tile
      */
     public float[][] correlateResidentImagesNCCLarge(OpenCLContext context,
-                                                      long refImageBuffer,
-                                                      long targetImageBuffer,
-                                                      int imageWidth,
-                                                      int imageHeight,
-                                                      int[][] tilePositions,
-                                                      int tileSize) {
+                                                     long refImageBuffer,
+                                                     long targetImageBuffer,
+                                                     int imageWidth,
+                                                     int imageHeight,
+                                                     int[][] tilePositions,
+                                                     int tileSize) {
         int numTiles = tilePositions.length;
         if (numTiles == 0) {
             return new float[0][3];
@@ -1091,161 +854,84 @@ public class CorrelationTools {
 
         var gpuResults = new float[numTiles * 3];
 
-        long positionsBuffer = 0;
-        long refMeansBuffer = 0;
-        long targetMeansBuffer = 0;
-        long refSumSqBuffer = 0;
-        long targetSumSqBuffer = 0;
-        long refComplexBuffer = 0;
-        long targetComplexBuffer = 0;
-        long tempBuffer = 0;
-        long realBuffer = 0;
-        long resultBuffer = 0;
-        long statsBuffer = 0;
+        int complexSize = numTiles * tileElements * 2 * Float.BYTES;
+        int realSize = numTiles * tileElements * Float.BYTES;
+        int statsSize = numTiles * 3 * Float.BYTES;
+        int meansSize = numTiles * Float.BYTES;
 
-        try {
-            int complexSize = numTiles * tileElements * 2 * Float.BYTES;
-            int realSize = numTiles * tileElements * Float.BYTES;
-            int statsSize = numTiles * 3 * Float.BYTES;  // normFactor per tile (plus padding)
-            int meansSize = numTiles * Float.BYTES;
+        return context.runOp(op -> {
+            var positionsBuffer = op.allocateBuffer(positionsFlat.length * Integer.BYTES, CL_MEM_READ_ONLY);
+            var refMeansBuffer = op.allocateBuffer(meansSize, CL_MEM_READ_WRITE);
+            var targetMeansBuffer = op.allocateBuffer(meansSize, CL_MEM_READ_WRITE);
+            var refSumSqBuffer = op.allocateBuffer(meansSize, CL_MEM_READ_WRITE);
+            var targetSumSqBuffer = op.allocateBuffer(meansSize, CL_MEM_READ_WRITE);
+            var refComplexBuffer = op.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
+            var targetComplexBuffer = op.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
+            var tempBuffer = op.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
+            var realBuffer = op.allocateBuffer(realSize, CL_MEM_READ_WRITE);
+            var resultBuffer = op.allocateBuffer(gpuResults.length * Float.BYTES, CL_MEM_WRITE_ONLY);
+            var statsBuffer = op.allocateBuffer(statsSize, CL_MEM_READ_WRITE);
 
-            positionsBuffer = context.allocateBuffer(positionsFlat.length * Integer.BYTES, CL_MEM_READ_ONLY);
-            refMeansBuffer = context.allocateBuffer(meansSize, CL_MEM_READ_WRITE);
-            targetMeansBuffer = context.allocateBuffer(meansSize, CL_MEM_READ_WRITE);
-            refSumSqBuffer = context.allocateBuffer(meansSize, CL_MEM_READ_WRITE);
-            targetSumSqBuffer = context.allocateBuffer(meansSize, CL_MEM_READ_WRITE);
-            refComplexBuffer = context.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
-            targetComplexBuffer = context.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
-            tempBuffer = context.allocateBuffer(complexSize, CL_MEM_READ_WRITE);
-            realBuffer = context.allocateBuffer(realSize, CL_MEM_READ_WRITE);
-            resultBuffer = context.allocateBuffer(gpuResults.length * Float.BYTES, CL_MEM_WRITE_ONLY);
-            statsBuffer = context.allocateBuffer(statsSize, CL_MEM_READ_WRITE);
+            op.writeInts(positionsBuffer, positionsFlat);
 
-            context.writeBufferInt(positionsBuffer, positionsFlat);
+            // 1. Per-tile stats for ref image
+            op.kernel("correlation", "compute_tile_stats_from_images")
+                    .arg(refImageBuffer).arg(imageWidth).arg(imageHeight).arg(positionsBuffer)
+                    .arg(refMeansBuffer).arg(refSumSqBuffer).arg(tileSize).arg(numTiles)
+                    .global(256, numTiles).local(256, 1).run();
 
-            var km = context.getKernelManager();
-            var computeStatsFromImagesKernel = km.getKernel("correlation", "compute_tile_stats_from_images");
-            var extractTilesZeroMeanKernel = km.getKernel("correlation", "extract_tiles_zero_mean");
-            var fftRowsKernel = km.getKernel("correlation", "fft_rows");
-            var transposeKernel = km.getKernel("correlation", "transpose");
-            var crossPowerKernel = km.getKernel("correlation", "cross_power_spectrum");
-            var scaleIfftKernel = km.getKernel("correlation", "scale_ifft");
-            var fftShiftKernel = km.getKernel("correlation", "fft_shift_real");
-            var findPeaksNCCKernel = km.getKernel("correlation", "find_peaks_ncc");
+            // 2. Per-tile stats for target image
+            op.kernel("correlation", "compute_tile_stats_from_images")
+                    .arg(targetImageBuffer).arg(imageWidth).arg(imageHeight).arg(positionsBuffer)
+                    .arg(targetMeansBuffer).arg(targetSumSqBuffer).arg(tileSize).arg(numTiles)
+                    .global(256, numTiles).local(256, 1).run();
 
-            try (var stack = MemoryStack.stackPush()) {
-                var queue = context.getCommandQueue();
+            // 3. Extract tiles with zero-mean and Hann window
+            op.kernel("correlation", "extract_tiles_zero_mean")
+                    .arg(refImageBuffer).arg(targetImageBuffer)
+                    .arg(imageWidth).arg(imageHeight).arg(positionsBuffer)
+                    .arg(refMeansBuffer).arg(targetMeansBuffer)
+                    .arg(refComplexBuffer).arg(targetComplexBuffer)
+                    .arg(tileSize).arg(numTiles)
+                    .global(tileSize, tileSize, numTiles).run();
 
-                // 1. Compute statistics (mean and sumSqDev) for ref image tiles
-                clSetKernelArg(computeStatsFromImagesKernel, 0, stack.pointers(refImageBuffer));
-                clSetKernelArg(computeStatsFromImagesKernel, 1, stack.ints(imageWidth));
-                clSetKernelArg(computeStatsFromImagesKernel, 2, stack.ints(imageHeight));
-                clSetKernelArg(computeStatsFromImagesKernel, 3, stack.pointers(positionsBuffer));
-                clSetKernelArg(computeStatsFromImagesKernel, 4, stack.pointers(refMeansBuffer));
-                clSetKernelArg(computeStatsFromImagesKernel, 5, stack.pointers(refSumSqBuffer));
-                clSetKernelArg(computeStatsFromImagesKernel, 6, stack.ints(tileSize));
-                clSetKernelArg(computeStatsFromImagesKernel, 7, stack.ints(numTiles));
+            // 4. NCC normalization factors
+            op.kernel("correlation", "compute_ncc_norm_factors")
+                    .arg(refSumSqBuffer).arg(targetSumSqBuffer).arg(statsBuffer).arg(numTiles)
+                    .global(numTiles).run();
 
-                var globalSizeStats = stack.pointers(256, numTiles);
-                var localSizeStats = stack.pointers(256, 1);
-                int err = clEnqueueNDRangeKernel(queue, computeStatsFromImagesKernel, 2, null, globalSizeStats, localSizeStats, null, null);
-                if (err != 0) {
-                    throw new RuntimeException("Failed to enqueue compute_tile_stats_from_images kernel (ref): " + err);
-                }
+            // 5-6. Forward 2D FFT for ref and target
+            fft2D(op, refComplexBuffer, tempBuffer, tileSize, logTileSize, numTiles, -1);
+            fft2D(op, targetComplexBuffer, tempBuffer, tileSize, logTileSize, numTiles, -1);
 
-                // 2. Compute statistics for target image tiles
-                clSetKernelArg(computeStatsFromImagesKernel, 0, stack.pointers(targetImageBuffer));
-                clSetKernelArg(computeStatsFromImagesKernel, 4, stack.pointers(targetMeansBuffer));
-                clSetKernelArg(computeStatsFromImagesKernel, 5, stack.pointers(targetSumSqBuffer));
-                err = clEnqueueNDRangeKernel(queue, computeStatsFromImagesKernel, 2, null, globalSizeStats, localSizeStats, null, null);
-                if (err != 0) {
-                    throw new RuntimeException("Failed to enqueue compute_tile_stats_from_images kernel (target): " + err);
-                }
+            // 7. Cross-power spectrum (no normalization for NCC)
+            op.kernel("correlation", "cross_power_spectrum")
+                    .arg(refComplexBuffer).arg(targetComplexBuffer)
+                    .arg(tileSize).arg(numTiles).arg(0)
+                    .global(tileSize, tileSize, numTiles).run();
 
-                // 3. Extract tiles with zero-mean and Hann window from images
-                clSetKernelArg(extractTilesZeroMeanKernel, 0, stack.pointers(refImageBuffer));
-                clSetKernelArg(extractTilesZeroMeanKernel, 1, stack.pointers(targetImageBuffer));
-                clSetKernelArg(extractTilesZeroMeanKernel, 2, stack.ints(imageWidth));
-                clSetKernelArg(extractTilesZeroMeanKernel, 3, stack.ints(imageHeight));
-                clSetKernelArg(extractTilesZeroMeanKernel, 4, stack.pointers(positionsBuffer));
-                clSetKernelArg(extractTilesZeroMeanKernel, 5, stack.pointers(refMeansBuffer));
-                clSetKernelArg(extractTilesZeroMeanKernel, 6, stack.pointers(targetMeansBuffer));
-                clSetKernelArg(extractTilesZeroMeanKernel, 7, stack.pointers(refComplexBuffer));
-                clSetKernelArg(extractTilesZeroMeanKernel, 8, stack.pointers(targetComplexBuffer));
-                clSetKernelArg(extractTilesZeroMeanKernel, 9, stack.ints(tileSize));
-                clSetKernelArg(extractTilesZeroMeanKernel, 10, stack.ints(numTiles));
-                enqueue3D(queue, extractTilesZeroMeanKernel, tileSize, tileSize, numTiles, stack);
+            // 8. Inverse 2D FFT
+            fft2D(op, refComplexBuffer, tempBuffer, tileSize, logTileSize, numTiles, +1);
 
-                // 4. Compute normalization factors on GPU: normFactor = sqrt(refSumSq * targetSumSq)
-                var computeNormFactorsKernel = km.getKernel("correlation", "compute_ncc_norm_factors");
-                clSetKernelArg(computeNormFactorsKernel, 0, stack.pointers(refSumSqBuffer));
-                clSetKernelArg(computeNormFactorsKernel, 1, stack.pointers(targetSumSqBuffer));
-                clSetKernelArg(computeNormFactorsKernel, 2, stack.pointers(statsBuffer));
-                clSetKernelArg(computeNormFactorsKernel, 3, stack.ints(numTiles));
+            // 9. Scale by 1/N^2
+            op.kernel("correlation", "scale_ifft")
+                    .arg(refComplexBuffer).arg(tileSize).arg(numTiles)
+                    .global(tileSize, tileSize, numTiles).run();
 
-                var globalSizeNorm = stack.pointers(numTiles);
-                err = clEnqueueNDRangeKernel(queue, computeNormFactorsKernel, 1, null, globalSizeNorm, null, null, null);
-                if (err != 0) {
-                    throw new RuntimeException("Failed to enqueue compute_ncc_norm_factors kernel: " + err);
-                }
+            // 10. FFT shift + extract real part
+            op.kernel("correlation", "fft_shift_real")
+                    .arg(refComplexBuffer).arg(realBuffer).arg(tileSize).arg(numTiles)
+                    .global(tileSize, tileSize, numTiles).run();
 
-                // 5. Forward 2D FFT for reference
-                fft2D(queue, fftRowsKernel, transposeKernel, refComplexBuffer, tempBuffer,
-                        tileSize, logTileSize, numTiles, -1, stack);
+            // 11. Find peaks with NCC normalization
+            op.kernel("correlation", "find_peaks_ncc")
+                    .arg(realBuffer).arg(statsBuffer).arg(resultBuffer)
+                    .arg(tileSize).arg(numTiles)
+                    .global(numTiles * 256L).local(256).run();
 
-                // 6. Forward 2D FFT for target
-                fft2D(queue, fftRowsKernel, transposeKernel, targetComplexBuffer, tempBuffer,
-                        tileSize, logTileSize, numTiles, -1, stack);
-
-                // 7. Cross-power spectrum (no normalization for NCC)
-                clSetKernelArg(crossPowerKernel, 0, stack.pointers(refComplexBuffer));
-                clSetKernelArg(crossPowerKernel, 1, stack.pointers(targetComplexBuffer));
-                clSetKernelArg(crossPowerKernel, 2, stack.ints(tileSize));
-                clSetKernelArg(crossPowerKernel, 3, stack.ints(numTiles));
-                clSetKernelArg(crossPowerKernel, 4, stack.ints(0));
-                enqueue3D(queue, crossPowerKernel, tileSize, tileSize, numTiles, stack);
-
-                // 8. Inverse 2D FFT
-                fft2D(queue, fftRowsKernel, transposeKernel, refComplexBuffer, tempBuffer,
-                        tileSize, logTileSize, numTiles, +1, stack);
-
-                // 9. Scale by 1/N^2
-                clSetKernelArg(scaleIfftKernel, 0, stack.pointers(refComplexBuffer));
-                clSetKernelArg(scaleIfftKernel, 1, stack.ints(tileSize));
-                clSetKernelArg(scaleIfftKernel, 2, stack.ints(numTiles));
-                enqueue3D(queue, scaleIfftKernel, tileSize, tileSize, numTiles, stack);
-
-                // 10. FFT shift and extract real part
-                clSetKernelArg(fftShiftKernel, 0, stack.pointers(refComplexBuffer));
-                clSetKernelArg(fftShiftKernel, 1, stack.pointers(realBuffer));
-                clSetKernelArg(fftShiftKernel, 2, stack.ints(tileSize));
-                clSetKernelArg(fftShiftKernel, 3, stack.ints(numTiles));
-                enqueue3D(queue, fftShiftKernel, tileSize, tileSize, numTiles, stack);
-
-                // 11. Find peaks with NCC normalization
-                clSetKernelArg(findPeaksNCCKernel, 0, stack.pointers(realBuffer));
-                clSetKernelArg(findPeaksNCCKernel, 1, stack.pointers(statsBuffer));
-                clSetKernelArg(findPeaksNCCKernel, 2, stack.pointers(resultBuffer));
-                clSetKernelArg(findPeaksNCCKernel, 3, stack.ints(tileSize));
-                clSetKernelArg(findPeaksNCCKernel, 4, stack.ints(numTiles));
-
-                var globalSize = stack.pointers(numTiles * 256L);
-                var localSize = stack.pointers(256);
-                err = clEnqueueNDRangeKernel(queue, findPeaksNCCKernel, 1, null, globalSize, localSize, null, null);
-                if (err != 0) {
-                    throw new RuntimeException("Failed to enqueue find_peaks_ncc kernel: " + err);
-                }
-            }
-
-            context.finish();
-            context.readBufferNoSync(resultBuffer, gpuResults);
-
+            op.read(resultBuffer, gpuResults);
             return unpackGpuResults(gpuResults, numTiles);
-        } finally {
-            safeRelease(context, positionsBuffer, refMeansBuffer, targetMeansBuffer,
-                    refSumSqBuffer, targetSumSqBuffer, refComplexBuffer, targetComplexBuffer,
-                    tempBuffer, realBuffer, resultBuffer, statsBuffer);
-        }
+        });
     }
 
     /**
@@ -1388,10 +1074,8 @@ public class CorrelationTools {
     /**
      * Performs NCC correlation directly from GPU-resident images.
      * Automatically selects the appropriate implementation based on tile size.
-     * <p>
-     * Must be called within {@link OpenCLContext#executeWithLock}.
      *
-     * @param context           the OpenCL context (must hold GPU lock)
+     * @param context           the OpenCL context
      * @param refImageBuffer    GPU buffer handle for reference image
      * @param targetImageBuffer GPU buffer handle for target image
      * @param imageWidth        image width in pixels
@@ -1402,12 +1086,12 @@ public class CorrelationTools {
      * @throws UnsupportedOperationException if the device does not support the required work group size
      */
     public float[][] correlateResidentImagesNCC(OpenCLContext context,
-                                                 long refImageBuffer,
-                                                 long targetImageBuffer,
-                                                 int imageWidth,
-                                                 int imageHeight,
-                                                 int[][] tilePositions,
-                                                 int tileSize) {
+                                                long refImageBuffer,
+                                                long targetImageBuffer,
+                                                int imageWidth,
+                                                int imageHeight,
+                                                int[][] tilePositions,
+                                                int tileSize) {
         if (!isGpuResidentCorrelationSupported(context, tileSize)) {
             long maxWorkGroupSize = context.getCapabilities().maxWorkGroupSize();
             long required = requiredWorkGroupSize(tileSize);

--- a/math/src/main/java/me/champeau/a4j/math/fft/FFTSupport.java
+++ b/math/src/main/java/me/champeau/a4j/math/fft/FFTSupport.java
@@ -15,7 +15,9 @@
  */
 package me.champeau.a4j.math.fft;
 
-/** Utility class providing support functions for FFT operations. */
+/**
+ * Utility class providing support functions for FFT operations.
+ */
 public class FFTSupport {
     private FFTSupport() {
 
@@ -23,6 +25,7 @@ public class FFTSupport {
 
     /**
      * Checks if a number is a power of 2.
+     *
      * @param number the number to check
      * @return true if the number is a power of 2, false otherwise
      */
@@ -32,6 +35,7 @@ public class FFTSupport {
 
     /**
      * Computes the next power of 2 greater than or equal to the given number.
+     *
      * @param number the input number
      * @return the next power of 2
      */
@@ -49,16 +53,23 @@ public class FFTSupport {
         return x + 1;
     }
 
-    /** Result container for 2D FFT operations with double precision. */
+    /**
+     * Result container for 2D FFT operations with double precision.
+     */
     public static class FFT2DResult {
-        /** Real component of the FFT result. */
+        /**
+         * Real component of the FFT result.
+         */
         public final double[][] real;
-        /** Imaginary component of the FFT result. */
+        /**
+         * Imaginary component of the FFT result.
+         */
         public final double[][] imaginary;
 
         /**
          * Creates a new FFT2D result.
-         * @param real the real component
+         *
+         * @param real      the real component
          * @param imaginary the imaginary component
          */
         public FFT2DResult(double[][] real, double[][] imaginary) {
@@ -68,10 +79,11 @@ public class FFTSupport {
 
         /**
          * Zeros out frequencies in the specified region.
+         *
          * @param rowStart starting row index
-         * @param rowEnd ending row index
+         * @param rowEnd   ending row index
          * @param colStart starting column index
-         * @param colEnd ending column index
+         * @param colEnd   ending column index
          */
         public void zeroFrequencies(int rowStart, int rowEnd, int colStart, int colEnd) {
             for (var y = rowStart; y < rowEnd; y++) {
@@ -83,16 +95,23 @@ public class FFTSupport {
         }
     }
 
-    /** Result container for 2D FFT operations with float precision. */
+    /**
+     * Result container for 2D FFT operations with float precision.
+     */
     public static class FloatFFT2DResult {
-        /** Real component of the FFT result. */
+        /**
+         * Real component of the FFT result.
+         */
         public final float[][] real;
-        /** Imaginary component of the FFT result. */
+        /**
+         * Imaginary component of the FFT result.
+         */
         public final float[][] imaginary;
 
         /**
          * Creates a new float FFT2D result.
-         * @param real the real component
+         *
+         * @param real      the real component
          * @param imaginary the imaginary component
          */
         public FloatFFT2DResult(float[][] real, float[][] imaginary) {
@@ -102,10 +121,11 @@ public class FFTSupport {
 
         /**
          * Zeros out frequencies in the specified region.
+         *
          * @param rowStart starting row index
-         * @param rowEnd ending row index
+         * @param rowEnd   ending row index
          * @param colStart starting column index
-         * @param colEnd ending column index
+         * @param colEnd   ending column index
          */
         public void zeroFrequencies(int rowStart, int rowEnd, int colStart, int colEnd) {
             for (var y = rowStart; y < rowEnd; y++) {
@@ -119,6 +139,7 @@ public class FFTSupport {
 
     /**
      * Performs a 2D FFT on float data.
+     *
      * @param data the input data
      * @return the FFT result
      */
@@ -154,6 +175,7 @@ public class FFTSupport {
 
     /**
      * Performs a 2D FFT on double data.
+     *
      * @param data the input data
      * @return the FFT result
      */
@@ -187,6 +209,7 @@ public class FFTSupport {
 
     /**
      * Performs an inverse 2D FFT.
+     *
      * @param frequencyDomain the frequency domain data
      * @return the spatial domain result
      */
@@ -225,6 +248,7 @@ public class FFTSupport {
 
     /**
      * Computes the cross-correlation of two FFT results.
+     *
      * @param fftRef the reference FFT
      * @param fftDef the deformed FFT
      * @return the cross-correlation result
@@ -271,8 +295,9 @@ public class FFTSupport {
 
     /**
      * Pads double array data to the next power of 2 dimensions.
-     * @param data the input data
-     * @param width the current width
+     *
+     * @param data   the input data
+     * @param width  the current width
      * @param height the current height
      * @return the padded data
      */
@@ -289,8 +314,9 @@ public class FFTSupport {
 
     /**
      * Pads float array data to the next power of 2 dimensions and converts to double.
-     * @param data the input data
-     * @param width the current width
+     *
+     * @param data   the input data
+     * @param width  the current width
      * @param height the current height
      * @return the padded data as double array
      */
@@ -309,8 +335,9 @@ public class FFTSupport {
 
     /**
      * Pads float array data to the next power of 2 dimensions.
-     * @param data the input data
-     * @param width the current width
+     *
+     * @param data   the input data
+     * @param width  the current width
      * @param height the current height
      * @return the padded float data
      */
@@ -327,6 +354,7 @@ public class FFTSupport {
 
     /**
      * Performs a 2D FFT on float data returning float results.
+     *
      * @param data the input data
      * @return the float FFT result
      */
@@ -373,6 +401,7 @@ public class FFTSupport {
 
     /**
      * Performs an inverse 2D FFT on float data.
+     *
      * @param frequencyDomain the frequency domain data
      * @return the spatial domain result
      */
@@ -413,6 +442,7 @@ public class FFTSupport {
 
     /**
      * FFT2 for complex input (when both real and imaginary parts are non-zero).
+     *
      * @param complexInput the complex input data
      * @return the FFT result
      */
@@ -454,12 +484,12 @@ public class FFTSupport {
                 imag2D[i][j] = imagCols[j][i];
             }
         }
-
         return new FloatFFT2DResult(real2D, imag2D);
     }
 
     /**
      * Computes the cross-correlation of two float FFT results.
+     *
      * @param fftRef the reference FFT
      * @param fftDef the deformed FFT
      * @return the cross-correlation result

--- a/math/src/main/java/me/champeau/a4j/math/image/Image.java
+++ b/math/src/main/java/me/champeau/a4j/math/image/Image.java
@@ -15,26 +15,29 @@
  */
 package me.champeau.a4j.math.image;
 
+
 import java.util.Arrays;
 
 /**
  * Represents a 2D image with floating-point pixel values.
  *
- * @param width the width of the image
+ * @param width  the width of the image
  * @param height the height of the image
- * @param data the pixel data organized as [y][x]
+ * @param data   the pixel data organized as [y][x]
  */
 public record Image(int width, int height, float[][] data) {
 
     /**
-     * Creates a new image with different pixel data but same dimensions.
+     * Creates a new image that adopts the given pixel data array. The caller
+     * transfers ownership: the array must not be modified after this call,
+     * since the returned {@code Image} aliases it directly. Use {@link #copy()}
+     * if a defensive snapshot is needed.
      *
-     * @param newData the new pixel data
-     * @return a new image with the updated data
+     * @param newData the new pixel data (ownership transferred)
+     * @return a new image backed by the given array
      */
     public Image withData(float[][] newData) {
-        var copyData = deepCopy(newData);
-        return new Image(width, height, copyData);
+        return new Image(width, height, newData);
     }
 
     /**
@@ -48,14 +51,14 @@ public record Image(int width, int height, float[][] data) {
     }
 
     private float[][] deepCopy(float[][] original) {
-        if (original.length==0) {
+        if (original.length == 0) {
             return new float[0][];
         }
-        var copy = new float[original.length][];
-        for (int i = 0; i < original.length; i++) {
-            var length = original[i].length;
-            copy[i] = new float[length];
-            System.arraycopy(original[i], 0, copy[i], 0, length);
+        int height = original.length;
+        int width = original[0].length;
+        var copy = new float[height][width];
+        for (int i = 0; i < height; i++) {
+            System.arraycopy(original[i], 0, copy[i], 0, width);
         }
         return copy;
     }

--- a/math/src/main/java/me/champeau/a4j/math/image/ImageMath.java
+++ b/math/src/main/java/me/champeau/a4j/math/image/ImageMath.java
@@ -123,7 +123,7 @@ public interface ImageMath {
     /**
      * Computes the average value of a specific row in the image.
      *
-     * @param image the source image
+     * @param image  the source image
      * @param lineNb the row number
      * @return the average value of the row
      */
@@ -175,7 +175,7 @@ public interface ImageMath {
      *
      * @param current the current data values
      * @param average the running average (modified in place)
-     * @param n the count of values including this one
+     * @param n       the count of values including this one
      */
     default void incrementalAverage(float[][] current, float[][] average, int n) {
         for (int j = 0; j < current.length; j++) {
@@ -190,11 +190,11 @@ public interface ImageMath {
     /**
      * Rotates and scales an image in one operation.
      *
-     * @param image the source image
-     * @param angle the rotation angle in radians
+     * @param image      the source image
+     * @param angle      the rotation angle in radians
      * @param blackpoint the value to use for pixels outside the source
-     * @param scaleX the horizontal scale factor
-     * @param scaleY the vertical scale factor
+     * @param scaleX     the horizontal scale factor
+     * @param scaleY     the vertical scale factor
      * @return the transformed image
      */
     default Image rotateAndScale(Image image, double angle, float blackpoint, double scaleX, double scaleY) {
@@ -245,10 +245,10 @@ public interface ImageMath {
     /**
      * Rotates an image by an arbitrary angle with optional resizing.
      *
-     * @param image the source image
-     * @param angle the rotation angle in radians
+     * @param image      the source image
+     * @param angle      the rotation angle in radians
      * @param blackpoint the value to use for pixels outside the source (negative for adaptive)
-     * @param resize if true, resize output to fit entire rotated image
+     * @param resize     if true, resize output to fit entire rotated image
      * @return the rotated image
      */
     default Image rotate(Image image, double angle, float blackpoint, boolean resize) {
@@ -326,8 +326,8 @@ public interface ImageMath {
     /**
      * Rescales an image to new dimensions using bilinear interpolation.
      *
-     * @param image the source image
-     * @param newWidth the target width
+     * @param image     the source image
+     * @param newWidth  the target width
      * @param newHeight the target height
      * @return the rescaled image
      */
@@ -374,9 +374,9 @@ public interface ImageMath {
     /**
      * Mirrors an image horizontally and/or vertically.
      *
-     * @param source the source image
+     * @param source           the source image
      * @param horizontalMirror if true, mirror horizontally
-     * @param verticalMirror if true, mirror vertically
+     * @param verticalMirror   if true, mirror vertically
      * @return the mirrored image
      */
     default Image mirror(Image source, boolean horizontalMirror, boolean verticalMirror) {
@@ -442,10 +442,10 @@ public interface ImageMath {
      * Computes the sum of pixel values in a rectangular area using an integral image.
      *
      * @param integralImage the precomputed integral image
-     * @param x the left coordinate of the area
-     * @param y the top coordinate of the area
-     * @param width the width of the area
-     * @param height the height of the area
+     * @param x             the left coordinate of the area
+     * @param y             the top coordinate of the area
+     * @param width         the width of the area
+     * @param height        the height of the area
      * @return the sum of values in the area
      */
     default float areaSum(Image integralImage, int x, int y, int width, int height) {
@@ -475,10 +475,10 @@ public interface ImageMath {
      * Computes the average pixel value in a rectangular area using an integral image.
      *
      * @param integralImage the precomputed integral image
-     * @param x the left coordinate of the area
-     * @param y the top coordinate of the area
-     * @param width the width of the area
-     * @param height the height of the area
+     * @param x             the left coordinate of the area
+     * @param y             the top coordinate of the area
+     * @param width         the width of the area
+     * @param height        the height of the area
      * @return the average value in the area
      */
     default float areaAverage(Image integralImage, int x, int y, int width, int height) {
@@ -488,7 +488,7 @@ public interface ImageMath {
     /**
      * Applies a box blur using a sliding window in two separable passes.
      *
-     * @param image the source image
+     * @param image      the source image
      * @param kernelSize the blur kernel size (must be odd)
      * @return the blurred image
      */
@@ -499,7 +499,6 @@ public interface ImageMath {
         var halfK = kernelSize / 2;
         float invN2 = 1f / ((float) kernelSize * kernelSize);
 
-        // Horizontal pass: sliding window across each row
         var hPass = new float[height][width];
         for (int y = 0; y < height; y++) {
             var srcRow = source[y];
@@ -516,7 +515,6 @@ public interface ImageMath {
             }
         }
 
-        // Vertical pass: sliding window down columns, row-by-row for cache locality
         var result = new float[height][width];
         var colSums = new float[width];
         for (int ky = -halfK; ky <= halfK; ky++) {
@@ -544,15 +542,31 @@ public interface ImageMath {
     /**
      * Applies a convolution kernel to an image.
      *
-     * @param image the source image
+     * @param image  the source image
      * @param kernel the convolution kernel
      * @return the convolved image
      */
     default Image convolve(Image image, Kernel kernel) {
+        var output = new float[image.height()][image.width()];
+        convolve(image, kernel, output);
+        return image.withData(output);
+    }
+
+    /**
+     * Applies a convolution kernel to an image, writing the result to a
+     * caller-supplied output buffer. The buffer must have the same dimensions
+     * as the image. Use this overload when reusing a pooled buffer to avoid
+     * per-call allocation.
+     *
+     * @param image  the source image
+     * @param kernel the convolution kernel
+     * @param output the output buffer ({@code float[height][width]})
+     * @return the {@code output} buffer, populated with the convolved data
+     */
+    default float[][] convolve(Image image, Kernel kernel, float[][] output) {
         var source = image.data();
         var height = image.height();
         var width = image.width();
-        var convolved = new float[height][width];
 
         var krows = kernel.kernel();
         var kHeight = krows.length;
@@ -577,11 +591,11 @@ public interface ImageMath {
                 }
 
                 var val = sum * factor;
-                convolved[y][x] = Math.clamp(val, 0, MAX_VALUE);
+                output[y][x] = Math.clamp(val, 0, MAX_VALUE);
             }
         }
 
-        return image.withData(convolved);
+        return output;
     }
 
     /**
@@ -642,7 +656,7 @@ public interface ImageMath {
      * Multiplies all pixel values by a scalar.
      *
      * @param source the source image
-     * @param f the multiplication factor
+     * @param f      the multiplication factor
      * @return the result image
      */
     default Image multiply(Image source, float f) {
@@ -662,7 +676,7 @@ public interface ImageMath {
      * Adds a scalar to all pixel values.
      *
      * @param source the source image
-     * @param f the value to add
+     * @param f      the value to add
      * @return the result image
      */
     default Image add(Image source, float f) {
@@ -681,7 +695,7 @@ public interface ImageMath {
     /**
      * Divides corresponding pixels of two images.
      *
-     * @param first the numerator image
+     * @param first  the numerator image
      * @param second the denominator image
      * @return the result image
      */
@@ -702,7 +716,7 @@ public interface ImageMath {
     /**
      * Multiplies corresponding pixels of two images.
      *
-     * @param first the first image
+     * @param first  the first image
      * @param second the second image
      * @return the result image
      */
@@ -759,7 +773,6 @@ public interface ImageMath {
         var width = image.width();
         var sum = new float[height][width];
         for (int y = 0; y < height; y++) {
-            sum[y] = new float[width];
             for (int x = 0; x < width; x++) {
                 sum[y][x] = a[y][x] + b[y][x];
             }
@@ -772,10 +785,10 @@ public interface ImageMath {
      * The distortion grid is a sparse representation of dx/dy displacements
      * sampled at regular intervals (gridStep).
      *
-     * @param source the source image to warp
-     * @param gridDx the x-displacement grid (gridHeight x gridWidth)
-     * @param gridDy the y-displacement grid (gridHeight x gridWidth)
-     * @param gridStep the step size between grid samples in pixels
+     * @param source     the source image to warp
+     * @param gridDx     the x-displacement grid (gridHeight x gridWidth)
+     * @param gridDy     the y-displacement grid (gridHeight x gridWidth)
+     * @param gridStep   the step size between grid samples in pixels
      * @param useLanczos if true, use Lanczos-3 interpolation; otherwise use bilinear
      * @return the warped image
      */
@@ -889,7 +902,7 @@ public interface ImageMath {
     /**
      * Applies a median filter to an image.
      *
-     * @param image the source image
+     * @param image  the source image
      * @param radius the filter radius (kernel size = 2*radius+1)
      * @return the filtered image
      */

--- a/math/src/main/java/me/champeau/a4j/math/image/OpenCLImageMath.java
+++ b/math/src/main/java/me/champeau/a4j/math/image/OpenCLImageMath.java
@@ -85,32 +85,19 @@ class OpenCLImageMath extends VectorApiImageMath {
         var n = width * height;
         var flatData = flatten(source.data(), width, height);
 
-        return context.executeWithLock(() -> {
-            long inputBuffer = 0;
-            long outputBuffer = 0;
-            try {
-                inputBuffer = context.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
-                outputBuffer = context.allocateBuffer(n * Float.BYTES, CL_MEM_WRITE_ONLY);
-
-                context.writeBuffer(inputBuffer, flatData);
-
-                var kernel = context.getKernelManager().getKernel("arithmetic", "add_scalar");
-                setKernelArgs(kernel, inputBuffer, scalar, outputBuffer, n);
-
-                executeKernel(kernel, n);
-
-                var result = new float[n];
-                context.readBuffer(outputBuffer, result);
-
-                return new Image(width, height, unflatten(result, width, height));
-            } finally {
-                if (inputBuffer != 0) {
-                    context.releaseBuffer(inputBuffer);
-                }
-                if (outputBuffer != 0) {
-                    context.releaseBuffer(outputBuffer);
-                }
-            }
+        return context.runOp(op -> {
+            var inputBuffer = op.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
+            var outputBuffer = op.allocateBuffer(n * Float.BYTES, CL_MEM_WRITE_ONLY);
+            op.write(inputBuffer, flatData);
+            op.kernel("arithmetic", "add_scalar")
+                    .arg(inputBuffer)
+                    .arg(scalar)
+                    .arg(outputBuffer)
+                    .arg(n)
+                    .run(n);
+            var result = new float[n];
+            op.read(outputBuffer, result);
+            return new Image(width, height, unflatten(result, width, height));
         });
     }
 
@@ -138,32 +125,19 @@ class OpenCLImageMath extends VectorApiImageMath {
         var n = width * height;
         var flatData = flatten(source.data(), width, height);
 
-        return context.executeWithLock(() -> {
-            long inputBuffer = 0;
-            long outputBuffer = 0;
-            try {
-                inputBuffer = context.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
-                outputBuffer = context.allocateBuffer(n * Float.BYTES, CL_MEM_WRITE_ONLY);
-
-                context.writeBuffer(inputBuffer, flatData);
-
-                var kernel = context.getKernelManager().getKernel("arithmetic", "multiply_scalar");
-                setKernelArgs(kernel, inputBuffer, scalar, outputBuffer, n);
-
-                executeKernel(kernel, n);
-
-                var result = new float[n];
-                context.readBuffer(outputBuffer, result);
-
-                return new Image(width, height, unflatten(result, width, height));
-            } finally {
-                if (inputBuffer != 0) {
-                    context.releaseBuffer(inputBuffer);
-                }
-                if (outputBuffer != 0) {
-                    context.releaseBuffer(outputBuffer);
-                }
-            }
+        return context.runOp(op -> {
+            var inputBuffer = op.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
+            var outputBuffer = op.allocateBuffer(n * Float.BYTES, CL_MEM_WRITE_ONLY);
+            op.write(inputBuffer, flatData);
+            op.kernel("arithmetic", "multiply_scalar")
+                    .arg(inputBuffer)
+                    .arg(scalar)
+                    .arg(outputBuffer)
+                    .arg(n)
+                    .run(n);
+            var result = new float[n];
+            op.read(outputBuffer, result);
+            return new Image(width, height, unflatten(result, width, height));
         });
     }
 
@@ -192,38 +166,21 @@ class OpenCLImageMath extends VectorApiImageMath {
         var flatFirst = flatten(first.data(), width, height);
         var flatSecond = flatten(second.data(), width, height);
 
-        return context.executeWithLock(() -> {
-            long bufferA = 0;
-            long bufferB = 0;
-            long outputBuffer = 0;
-            try {
-                bufferA = context.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
-                bufferB = context.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
-                outputBuffer = context.allocateBuffer(n * Float.BYTES, CL_MEM_WRITE_ONLY);
-
-                context.writeBuffer(bufferA, flatFirst);
-                context.writeBuffer(bufferB, flatSecond);
-
-                var kernel = context.getKernelManager().getKernel("arithmetic", "divide_images");
-                setKernelArgsTwoInputs(kernel, bufferA, bufferB, outputBuffer, n);
-
-                executeKernel(kernel, n);
-
-                var result = new float[n];
-                context.readBuffer(outputBuffer, result);
-
-                return new Image(width, height, unflatten(result, width, height));
-            } finally {
-                if (bufferA != 0) {
-                    context.releaseBuffer(bufferA);
-                }
-                if (bufferB != 0) {
-                    context.releaseBuffer(bufferB);
-                }
-                if (outputBuffer != 0) {
-                    context.releaseBuffer(outputBuffer);
-                }
-            }
+        return context.runOp(op -> {
+            var bufferA = op.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
+            var bufferB = op.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
+            var outputBuffer = op.allocateBuffer(n * Float.BYTES, CL_MEM_WRITE_ONLY);
+            op.write(bufferA, flatFirst);
+            op.write(bufferB, flatSecond);
+            op.kernel("arithmetic", "divide_images")
+                    .arg(bufferA)
+                    .arg(bufferB)
+                    .arg(outputBuffer)
+                    .arg(n)
+                    .run(n);
+            var result = new float[n];
+            op.read(outputBuffer, result);
+            return new Image(width, height, unflatten(result, width, height));
         });
     }
 
@@ -252,38 +209,18 @@ class OpenCLImageMath extends VectorApiImageMath {
         var flatFirst = flatten(first.data(), width, height);
         var flatSecond = flatten(second.data(), width, height);
 
-        return context.executeWithLock(() -> {
-            long bufferA = 0;
-            long bufferB = 0;
-            long outputBuffer = 0;
-            try {
-                bufferA = context.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
-                bufferB = context.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
-                outputBuffer = context.allocateBuffer(n * Float.BYTES, CL_MEM_WRITE_ONLY);
-
-                context.writeBuffer(bufferA, flatFirst);
-                context.writeBuffer(bufferB, flatSecond);
-
-                var kernel = context.getKernelManager().getKernel("arithmetic", "multiply_images");
-                setKernelArgsTwoInputs(kernel, bufferA, bufferB, outputBuffer, n);
-
-                executeKernel(kernel, n);
-
-                var result = new float[n];
-                context.readBuffer(outputBuffer, result);
-
-                return new Image(width, height, unflatten(result, width, height));
-            } finally {
-                if (bufferA != 0) {
-                    context.releaseBuffer(bufferA);
-                }
-                if (bufferB != 0) {
-                    context.releaseBuffer(bufferB);
-                }
-                if (outputBuffer != 0) {
-                    context.releaseBuffer(outputBuffer);
-                }
-            }
+        return context.runOp(op -> {
+            var bufferA = op.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
+            var bufferB = op.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
+            var outputBuffer = op.allocateBuffer(n * Float.BYTES, CL_MEM_WRITE_ONLY);
+            op.write(bufferA, flatFirst);
+            op.write(bufferB, flatSecond);
+            op.kernel("arithmetic", "multiply_images")
+                    .arg(bufferA).arg(bufferB).arg(outputBuffer).arg(n)
+                    .run(n);
+            var result = new float[n];
+            op.read(outputBuffer, result);
+            return new Image(width, height, unflatten(result, width, height));
         });
     }
 
@@ -316,39 +253,19 @@ class OpenCLImageMath extends VectorApiImageMath {
         var kWidth = krows[0].length;
         var flatKernel = flattenKernel(krows, kWidth, kHeight);
 
-        return context.executeWithLock(() -> {
-            long imageBuffer = 0;
-            long kernelBuffer = 0;
-            long outputBuffer = 0;
-            try {
-                imageBuffer = context.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
-                kernelBuffer = context.allocateBuffer(flatKernel.length * Float.BYTES, CL_MEM_READ_ONLY);
-                outputBuffer = context.allocateBuffer(n * Float.BYTES, CL_MEM_WRITE_ONLY);
-
-                context.writeBuffer(imageBuffer, flatImage);
-                context.writeBuffer(kernelBuffer, flatKernel);
-
-                var clKernel = context.getKernelManager().getKernel("convolution", "convolve2d");
-                setConvolutionKernelArgs(clKernel, imageBuffer, kernelBuffer, outputBuffer,
-                        width, height, kWidth, kHeight, kernel.factor());
-
-                executeKernel2D(clKernel, width, height);
-
-                var result = new float[n];
-                context.readBuffer(outputBuffer, result);
-
-                return image.withData(unflatten(result, width, height));
-            } finally {
-                if (imageBuffer != 0) {
-                    context.releaseBuffer(imageBuffer);
-                }
-                if (kernelBuffer != 0) {
-                    context.releaseBuffer(kernelBuffer);
-                }
-                if (outputBuffer != 0) {
-                    context.releaseBuffer(outputBuffer);
-                }
-            }
+        return context.runOp(op -> {
+            var imageBuffer = op.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
+            var kernelBuffer = op.allocateBuffer(flatKernel.length * Float.BYTES, CL_MEM_READ_ONLY);
+            var outputBuffer = op.allocateBuffer(n * Float.BYTES, CL_MEM_WRITE_ONLY);
+            op.write(imageBuffer, flatImage);
+            op.write(kernelBuffer, flatKernel);
+            op.kernel("convolution", "convolve2d")
+                    .arg(imageBuffer).arg(kernelBuffer).arg(outputBuffer)
+                    .arg(width).arg(height).arg(kWidth).arg(kHeight).arg(kernel.factor())
+                    .run(width, height);
+            var result = new float[n];
+            op.read(outputBuffer, result);
+            return image.withData(unflatten(result, width, height));
         });
     }
 
@@ -464,42 +381,20 @@ class OpenCLImageMath extends VectorApiImageMath {
         int srcN = srcWidth * srcHeight;
         int dstN = dstWidth * dstHeight;
 
-        return context.executeWithLock(() -> {
-            long inputBuffer = 0;
-            long outputBuffer = 0;
-            try {
-                inputBuffer = context.allocateBuffer(srcN * Float.BYTES, CL_MEM_READ_ONLY);
-                outputBuffer = context.allocateBuffer(dstN * Float.BYTES, CL_MEM_WRITE_ONLY);
-
-                context.writeBuffer(inputBuffer, flatInput);
-
-                var kernel = context.getKernelManager().getKernel("transform", "rotate_scale");
-                clSetKernelArg1p(kernel, 0, inputBuffer);
-                clSetKernelArg1p(kernel, 1, outputBuffer);
-                clSetKernelArg1i(kernel, 2, srcWidth);
-                clSetKernelArg1i(kernel, 3, srcHeight);
-                clSetKernelArg1i(kernel, 4, dstWidth);
-                clSetKernelArg1i(kernel, 5, dstHeight);
-                clSetKernelArg1f(kernel, 6, (float) cos);
-                clSetKernelArg1f(kernel, 7, (float) sin);
-                clSetKernelArg1f(kernel, 8, (float) scaleX);
-                clSetKernelArg1f(kernel, 9, (float) scaleY);
-                clSetKernelArg1f(kernel, 10, blackpoint);
-
-                executeKernel2D(kernel, dstWidth, dstHeight);
-
-                var result = new float[dstN];
-                context.readBuffer(outputBuffer, result);
-
-                return new Image(dstWidth, dstHeight, unflatten(result, dstWidth, dstHeight));
-            } finally {
-                if (inputBuffer != 0) {
-                    context.releaseBuffer(inputBuffer);
-                }
-                if (outputBuffer != 0) {
-                    context.releaseBuffer(outputBuffer);
-                }
-            }
+        return context.runOp(op -> {
+            var inputBuffer = op.allocateBuffer(srcN * Float.BYTES, CL_MEM_READ_ONLY);
+            var outputBuffer = op.allocateBuffer(dstN * Float.BYTES, CL_MEM_WRITE_ONLY);
+            op.write(inputBuffer, flatInput);
+            op.kernel("transform", "rotate_scale")
+                    .arg(inputBuffer).arg(outputBuffer)
+                    .arg(srcWidth).arg(srcHeight).arg(dstWidth).arg(dstHeight)
+                    .arg((float) cos).arg((float) sin)
+                    .arg((float) scaleX).arg((float) scaleY)
+                    .arg(blackpoint)
+                    .run(dstWidth, dstHeight);
+            var result = new float[dstN];
+            op.read(outputBuffer, result);
+            return new Image(dstWidth, dstHeight, unflatten(result, dstWidth, dstHeight));
         });
     }
 
@@ -533,40 +428,18 @@ class OpenCLImageMath extends VectorApiImageMath {
         int srcN = srcWidth * srcHeight;
         int dstN = dstWidth * dstHeight;
 
-        return context.executeWithLock(() -> {
-            long inputBuffer = 0;
-            long outputBuffer = 0;
-            try {
-                inputBuffer = context.allocateBuffer(srcN * Float.BYTES, CL_MEM_READ_ONLY);
-                outputBuffer = context.allocateBuffer(dstN * Float.BYTES, CL_MEM_WRITE_ONLY);
-
-                context.writeBuffer(inputBuffer, flatInput);
-
-                var kernel = context.getKernelManager().getKernel("transform", "rotate");
-                clSetKernelArg1p(kernel, 0, inputBuffer);
-                clSetKernelArg1p(kernel, 1, outputBuffer);
-                clSetKernelArg1i(kernel, 2, srcWidth);
-                clSetKernelArg1i(kernel, 3, srcHeight);
-                clSetKernelArg1i(kernel, 4, dstWidth);
-                clSetKernelArg1i(kernel, 5, dstHeight);
-                clSetKernelArg1f(kernel, 6, (float) cos);
-                clSetKernelArg1f(kernel, 7, (float) sin);
-                clSetKernelArg1f(kernel, 8, blackpoint);
-
-                executeKernel2D(kernel, dstWidth, dstHeight);
-
-                var result = new float[dstN];
-                context.readBuffer(outputBuffer, result);
-
-                return new Image(dstWidth, dstHeight, unflatten(result, dstWidth, dstHeight));
-            } finally {
-                if (inputBuffer != 0) {
-                    context.releaseBuffer(inputBuffer);
-                }
-                if (outputBuffer != 0) {
-                    context.releaseBuffer(outputBuffer);
-                }
-            }
+        return context.runOp(op -> {
+            var inputBuffer = op.allocateBuffer(srcN * Float.BYTES, CL_MEM_READ_ONLY);
+            var outputBuffer = op.allocateBuffer(dstN * Float.BYTES, CL_MEM_WRITE_ONLY);
+            op.write(inputBuffer, flatInput);
+            op.kernel("transform", "rotate")
+                    .arg(inputBuffer).arg(outputBuffer)
+                    .arg(srcWidth).arg(srcHeight).arg(dstWidth).arg(dstHeight)
+                    .arg((float) cos).arg((float) sin).arg(blackpoint)
+                    .run(dstWidth, dstHeight);
+            var result = new float[dstN];
+            op.read(outputBuffer, result);
+            return new Image(dstWidth, dstHeight, unflatten(result, dstWidth, dstHeight));
         });
     }
 
@@ -596,37 +469,17 @@ class OpenCLImageMath extends VectorApiImageMath {
         int srcN = srcWidth * srcHeight;
         int dstN = dstWidth * dstHeight;
 
-        return context.executeWithLock(() -> {
-            long inputBuffer = 0;
-            long outputBuffer = 0;
-            try {
-                inputBuffer = context.allocateBuffer(srcN * Float.BYTES, CL_MEM_READ_ONLY);
-                outputBuffer = context.allocateBuffer(dstN * Float.BYTES, CL_MEM_WRITE_ONLY);
-
-                context.writeBuffer(inputBuffer, flatInput);
-
-                var kernel = context.getKernelManager().getKernel("transform", "rescale");
-                clSetKernelArg1p(kernel, 0, inputBuffer);
-                clSetKernelArg1p(kernel, 1, outputBuffer);
-                clSetKernelArg1i(kernel, 2, srcWidth);
-                clSetKernelArg1i(kernel, 3, srcHeight);
-                clSetKernelArg1i(kernel, 4, dstWidth);
-                clSetKernelArg1i(kernel, 5, dstHeight);
-
-                executeKernel2D(kernel, dstWidth, dstHeight);
-
-                var result = new float[dstN];
-                context.readBuffer(outputBuffer, result);
-
-                return new Image(dstWidth, dstHeight, unflatten(result, dstWidth, dstHeight));
-            } finally {
-                if (inputBuffer != 0) {
-                    context.releaseBuffer(inputBuffer);
-                }
-                if (outputBuffer != 0) {
-                    context.releaseBuffer(outputBuffer);
-                }
-            }
+        return context.runOp(op -> {
+            var inputBuffer = op.allocateBuffer(srcN * Float.BYTES, CL_MEM_READ_ONLY);
+            var outputBuffer = op.allocateBuffer(dstN * Float.BYTES, CL_MEM_WRITE_ONLY);
+            op.write(inputBuffer, flatInput);
+            op.kernel("transform", "rescale")
+                    .arg(inputBuffer).arg(outputBuffer)
+                    .arg(srcWidth).arg(srcHeight).arg(dstWidth).arg(dstHeight)
+                    .run(dstWidth, dstHeight);
+            var result = new float[dstN];
+            op.read(outputBuffer, result);
+            return new Image(dstWidth, dstHeight, unflatten(result, dstWidth, dstHeight));
         });
     }
 
@@ -657,37 +510,18 @@ class OpenCLImageMath extends VectorApiImageMath {
         var n = width * height;
         var flatInput = flatten(source.data(), width, height);
 
-        return context.executeWithLock(() -> {
-            long inputBuffer = 0;
-            long outputBuffer = 0;
-            try {
-                inputBuffer = context.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
-                outputBuffer = context.allocateBuffer(n * Float.BYTES, CL_MEM_WRITE_ONLY);
-
-                context.writeBuffer(inputBuffer, flatInput);
-
-                var kernel = context.getKernelManager().getKernel("transform", "mirror");
-                clSetKernelArg1p(kernel, 0, inputBuffer);
-                clSetKernelArg1p(kernel, 1, outputBuffer);
-                clSetKernelArg1i(kernel, 2, width);
-                clSetKernelArg1i(kernel, 3, height);
-                clSetKernelArg1i(kernel, 4, horizontalMirror ? 1 : 0);
-                clSetKernelArg1i(kernel, 5, verticalMirror ? 1 : 0);
-
-                executeKernel2D(kernel, width, height);
-
-                var result = new float[n];
-                context.readBuffer(outputBuffer, result);
-
-                return new Image(width, height, unflatten(result, width, height));
-            } finally {
-                if (inputBuffer != 0) {
-                    context.releaseBuffer(inputBuffer);
-                }
-                if (outputBuffer != 0) {
-                    context.releaseBuffer(outputBuffer);
-                }
-            }
+        return context.runOp(op -> {
+            var inputBuffer = op.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
+            var outputBuffer = op.allocateBuffer(n * Float.BYTES, CL_MEM_WRITE_ONLY);
+            op.write(inputBuffer, flatInput);
+            op.kernel("transform", "mirror")
+                    .arg(inputBuffer).arg(outputBuffer)
+                    .arg(width).arg(height)
+                    .arg(horizontalMirror ? 1 : 0).arg(verticalMirror ? 1 : 0)
+                    .run(width, height);
+            var result = new float[n];
+            op.read(outputBuffer, result);
+            return new Image(width, height, unflatten(result, width, height));
         });
     }
 
@@ -721,53 +555,22 @@ class OpenCLImageMath extends VectorApiImageMath {
         var flatGridDx = flatten(gridDx, gridWidth, gridHeight);
         var flatGridDy = flatten(gridDy, gridWidth, gridHeight);
 
-        return context.executeWithLock(() -> {
-            long inputBuffer = 0;
-            long outputBuffer = 0;
-            long gridDxBuffer = 0;
-            long gridDyBuffer = 0;
-            try {
-                inputBuffer = context.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
-                outputBuffer = context.allocateBuffer(n * Float.BYTES, CL_MEM_WRITE_ONLY);
-                gridDxBuffer = context.allocateBuffer(gridN * Float.BYTES, CL_MEM_READ_ONLY);
-                gridDyBuffer = context.allocateBuffer(gridN * Float.BYTES, CL_MEM_READ_ONLY);
-
-                context.writeBuffer(inputBuffer, flatInput);
-                context.writeBuffer(gridDxBuffer, flatGridDx);
-                context.writeBuffer(gridDyBuffer, flatGridDy);
-
-                var kernelName = useLanczos ? "dedistort_sparse_lanczos" : "dedistort_sparse_bilinear";
-                var kernel = context.getKernelManager().getKernel("dedistort", kernelName);
-                clSetKernelArg1p(kernel, 0, inputBuffer);
-                clSetKernelArg1p(kernel, 1, gridDxBuffer);
-                clSetKernelArg1p(kernel, 2, gridDyBuffer);
-                clSetKernelArg1p(kernel, 3, outputBuffer);
-                clSetKernelArg1i(kernel, 4, width);
-                clSetKernelArg1i(kernel, 5, height);
-                clSetKernelArg1i(kernel, 6, gridWidth);
-                clSetKernelArg1i(kernel, 7, gridHeight);
-                clSetKernelArg1i(kernel, 8, gridStep);
-
-                executeKernel2D(kernel, width, height);
-
-                var result = new float[n];
-                context.readBuffer(outputBuffer, result);
-
-                return new Image(width, height, unflatten(result, width, height));
-            } finally {
-                if (inputBuffer != 0) {
-                    context.releaseBuffer(inputBuffer);
-                }
-                if (outputBuffer != 0) {
-                    context.releaseBuffer(outputBuffer);
-                }
-                if (gridDxBuffer != 0) {
-                    context.releaseBuffer(gridDxBuffer);
-                }
-                if (gridDyBuffer != 0) {
-                    context.releaseBuffer(gridDyBuffer);
-                }
-            }
+        var kernelName = useLanczos ? "dedistort_sparse_lanczos" : "dedistort_sparse_bilinear";
+        return context.runOp(op -> {
+            var inputBuffer = op.allocateBuffer(n * Float.BYTES, CL_MEM_READ_ONLY);
+            var outputBuffer = op.allocateBuffer(n * Float.BYTES, CL_MEM_WRITE_ONLY);
+            var gridDxBuffer = op.allocateBuffer(gridN * Float.BYTES, CL_MEM_READ_ONLY);
+            var gridDyBuffer = op.allocateBuffer(gridN * Float.BYTES, CL_MEM_READ_ONLY);
+            op.write(inputBuffer, flatInput);
+            op.write(gridDxBuffer, flatGridDx);
+            op.write(gridDyBuffer, flatGridDy);
+            op.kernel("dedistort", kernelName)
+                    .arg(inputBuffer).arg(gridDxBuffer).arg(gridDyBuffer).arg(outputBuffer)
+                    .arg(width).arg(height).arg(gridWidth).arg(gridHeight).arg(gridStep)
+                    .run(width, height);
+            var result = new float[n];
+            op.read(outputBuffer, result);
+            return new Image(width, height, unflatten(result, width, height));
         });
     }
 

--- a/math/src/main/java/me/champeau/a4j/math/image/VectorApiImageMath.java
+++ b/math/src/main/java/me/champeau/a4j/math/image/VectorApiImageMath.java
@@ -201,7 +201,6 @@ class VectorApiImageMath implements ImageMath {
         var halfK = kernelSize / 2;
         float invN2 = 1f / ((float) kernelSize * kernelSize);
 
-        // Horizontal pass: sliding window across each row (sequential per row)
         var hPass = new float[height][width];
         for (int y = 0; y < height; y++) {
             var srcRow = source[y];
@@ -218,7 +217,6 @@ class VectorApiImageMath implements ImageMath {
             }
         }
 
-        // Vertical pass: vectorized column sum updates
         var result = new float[height][width];
         var colSums = new float[width];
         for (int ky = -halfK; ky <= halfK; ky++) {

--- a/math/src/main/java/me/champeau/a4j/math/opencl/GPUImageCache.java
+++ b/math/src/main/java/me/champeau/a4j/math/opencl/GPUImageCache.java
@@ -15,6 +15,9 @@
  */
 package me.champeau.a4j.math.opencl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.IntFunction;
@@ -29,22 +32,13 @@ import static org.lwjgl.opencl.CL10.CL_MEM_READ_ONLY;
  * efficient multi-image correlation by keeping frequently accessed images
  * on the GPU.
  * <p>
- * All methods must be called within {@link OpenCLContext#executeWithLock}.
- * The cache is not thread-safe on its own - it relies on the GPU lock for
- * synchronization.
- * <p>
- * Usage:
- * <pre>
- * try (var cache = new GPUImageCache(context, maxImages, width, height, imageSupplier)) {
- *     context.executeWithLock(() -> {
- *         long buffer0 = cache.getImage(0);  // Uploads if not cached
- *         long buffer1 = cache.getImage(1);  // May evict buffer0 if at capacity
- *         // Use buffers for correlation...
- *     });
- * }
- * </pre>
+ * The cache itself is not thread-safe — confine each cache instance to a
+ * single owner (typically the orchestrator running a sequence of GPU
+ * operations against it).
  */
 public final class GPUImageCache implements AutoCloseable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GPUImageCache.class);
+
     private final OpenCLContext context;
     private final int width;
     private final int height;
@@ -83,8 +77,6 @@ public final class GPUImageCache implements AutoCloseable {
      * If the image is already cached, returns the existing buffer and marks
      * it as recently used. If not cached, uploads the image data to GPU,
      * potentially evicting the least recently used image if at capacity.
-     * <p>
-     * Must be called within executeWithLock.
      *
      * @param imageIndex the index of the image
      * @return the GPU buffer handle
@@ -148,7 +140,6 @@ public final class GPUImageCache implements AutoCloseable {
 
     /**
      * Evicts all images from the cache, freeing GPU memory.
-     * Must be called within executeWithLock.
      */
     public void clear() {
         for (var entry : cache.values()) {
@@ -163,8 +154,6 @@ public final class GPUImageCache implements AutoCloseable {
      * This is used during iterative refinement when images are warped on GPU.
      * The old buffer is released and replaced with the new buffer.
      * The new buffer ownership is transferred to the cache.
-     * <p>
-     * Must be called within executeWithLock.
      *
      * @param imageIndex the index of the image to replace
      * @param newBuffer  the new GPU buffer handle (ownership transferred to cache)
@@ -212,12 +201,11 @@ public final class GPUImageCache implements AutoCloseable {
 
     @Override
     public void close() {
-        // Release all GPU buffers - must be called within executeWithLock
         for (var entry : cache.values()) {
             try {
                 context.releaseBuffer(entry.buffer);
             } catch (Exception e) {
-                System.err.println("[GPUImageCache] Failed to release buffer for image " + entry.imageIndex + ": " + e.getMessage());
+                LOGGER.error("Failed to release buffer for image {}", entry.imageIndex, e);
             }
         }
         cache.clear();

--- a/math/src/main/java/me/champeau/a4j/math/opencl/GPUImageCacheBudget.java
+++ b/math/src/main/java/me/champeau/a4j/math/opencl/GPUImageCacheBudget.java
@@ -21,7 +21,7 @@ package me.champeau.a4j.math.opencl;
  * This class determines how much GPU memory is available for caching images,
  * accounting for memory needed by correlation kernels and driver overhead.
  */
-public final class GPUMemoryBudget {
+public final class GPUImageCacheBudget {
     private static final double KERNEL_WORKSPACE_FRACTION = 0.3;
     private static final double IMAGE_CACHE_FRACTION = 0.5;
 
@@ -36,7 +36,7 @@ public final class GPUMemoryBudget {
      * @param tileSize        the tile size used for correlation (32, 64, or 128)
      * @param maxTilesPerBatch maximum number of tiles processed in a single batch
      */
-    public GPUMemoryBudget(OpenCLContext context, int tileSize, int maxTilesPerBatch) {
+    public GPUImageCacheBudget(OpenCLContext context, int tileSize, int maxTilesPerBatch) {
         this.totalGpuMemory = context.getCapabilities().globalMemSize();
 
         // Reserve memory for correlation workspace:
@@ -63,7 +63,7 @@ public final class GPUMemoryBudget {
      *
      * @param context the OpenCL context
      */
-    public GPUMemoryBudget(OpenCLContext context) {
+    public GPUImageCacheBudget(OpenCLContext context) {
         this(context, 32, 10000);
     }
 
@@ -105,7 +105,7 @@ public final class GPUMemoryBudget {
 
     @Override
     public String toString() {
-        return String.format("GPUMemoryBudget[total=%d MB, reserved=%d MB, available=%d MB]",
+        return String.format("GPUImageCacheBudget[total=%d MB, reserved=%d MB, available=%d MB]",
                 totalGpuMemory / (1024 * 1024),
                 reservedForKernels / (1024 * 1024),
                 availableForImages / (1024 * 1024));

--- a/math/src/main/java/me/champeau/a4j/math/opencl/GpuMemoryBudget.java
+++ b/math/src/main/java/me/champeau/a4j/math/opencl/GpuMemoryBudget.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.math.opencl;
+
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Byte-counted budget guarding GPU memory allocations. Concurrent callers
+ * may proceed in parallel as long as the total of their requested allocations
+ * fits within {@code totalBytes}; allocations that don't fit block until
+ * enough memory is released by other callers.
+ *
+ * <p>This is the GPU analog of a memory-pressure semaphore: it replaces a
+ * coarse "max concurrent ops" cap with the only constraint that actually
+ * matters — the device's physical memory size. Two requests of 1 GB each
+ * on a 24 GB GPU run in parallel; a single 30 GB request fails immediately.
+ *
+ * <p>{@link #acquire(long)} is FIFO-ish but not strictly fair under heavy
+ * contention: a steady stream of small allocations can theoretically starve
+ * a large one. For the workloads this targets — a small number of states
+ * each requesting buffers of similar size — that's not a problem in practice.
+ */
+public final class GpuMemoryBudget {
+    private final long totalBytes;
+    private final Lock lock = new ReentrantLock();
+    private final Condition freed = lock.newCondition();
+    private long available;
+
+    public GpuMemoryBudget(long totalBytes) {
+        if (totalBytes <= 0) {
+            throw new IllegalArgumentException("totalBytes must be positive: " + totalBytes);
+        }
+        this.totalBytes = totalBytes;
+        this.available = totalBytes;
+    }
+
+    /**
+     * Reserves {@code bytes} from the budget, blocking until enough is
+     * available. Throws if the request can never succeed (exceeds the
+     * configured total).
+     */
+    public void acquire(long bytes) {
+        if (bytes <= 0) {
+            return;
+        }
+        if (bytes > totalBytes) {
+            throw new OpenCLException("GPU allocation request of " + bytes
+                    + " bytes exceeds total budget " + totalBytes);
+        }
+        lock.lock();
+        try {
+            while (available < bytes) {
+                freed.await();
+            }
+            available -= bytes;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new OpenCLException("Interrupted while waiting for GPU memory", e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns {@code bytes} to the budget and wakes up any waiting acquirers.
+     */
+    public void release(long bytes) {
+        if (bytes <= 0) {
+            return;
+        }
+        lock.lock();
+        try {
+            available += bytes;
+            if (available > totalBytes) {
+                available = totalBytes;
+            }
+            freed.signalAll();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Total budget in bytes.
+     */
+    public long totalBytes() {
+        return totalBytes;
+    }
+
+    /**
+     * Currently-available bytes. Snapshot value, useful for diagnostics only.
+     */
+    public long availableBytes() {
+        lock.lock();
+        try {
+            return available;
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/math/src/main/java/me/champeau/a4j/math/opencl/GpuOp.java
+++ b/math/src/main/java/me/champeau/a4j/math/opencl/GpuOp.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.math.opencl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Scoped GPU operation: tracks the buffers allocated through it and releases
+ * them automatically when the body returns. Created via
+ * {@link OpenCLContext#runOp(java.util.function.Consumer)} and
+ * {@link OpenCLContext#runOp(java.util.function.Function)}; not intended to
+ * be instantiated directly.
+ *
+ * <p>Concurrent ops on the same {@link OpenCLContext} are safe — each op
+ * holds its own buffer references, and per-op {@link #kernel(String, String)}
+ * calls borrow private kernel handles from the manager's pool, so no global
+ * lock is required. Buffer allocations are gated by
+ * {@link OpenCLContext#memoryBudget()}, which blocks rather than fails when
+ * the GPU is full.
+ *
+ * <p>Kernel handles borrowed by this op are held until {@link #close} drains
+ * the command queue via {@code clFinish}, only then returned to the pool.
+ * This is required because OpenCL stores kernel arguments on the kernel
+ * object itself; releasing a handle before its enqueued execution actually
+ * runs would let another op modify the args from underneath the in-flight
+ * kernel, producing data corruption or native crashes.
+ */
+public final class GpuOp implements AutoCloseable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GpuOp.class);
+
+    private final OpenCLContext context;
+    private final Deque<Long> ownedBuffers = new ArrayDeque<>();
+    private final Deque<KernelHandle> borrowedKernels = new ArrayDeque<>();
+
+    GpuOp(OpenCLContext context) {
+        this.context = context;
+    }
+
+    OpenCLContext getContext() {
+        return context;
+    }
+
+    /**
+     * Adopts a kernel handle so it's returned to the pool only after {@link #close} finishes.
+     */
+    void trackKernel(String programName, String kernelName, long kernel) {
+        borrowedKernels.push(new KernelHandle(programName, kernelName, kernel));
+    }
+
+    private record KernelHandle(String programName, String kernelName, long kernel) {
+    }
+
+    /**
+     * Allocates a GPU buffer owned by this op. The buffer is released when
+     * the op closes; if the budget is exhausted, the call blocks until
+     * another op releases enough memory.
+     */
+    public long allocateBuffer(int sizeInBytes, long flags) {
+        long buffer = context.allocateBuffer(sizeInBytes, flags);
+        ownedBuffers.push(buffer);
+        return buffer;
+    }
+
+    /**
+     * Uploads {@code data} to {@code buffer}.
+     */
+    public void write(long buffer, float[] data) {
+        context.writeBuffer(buffer, data);
+    }
+
+    /**
+     * Uploads {@code data} to {@code buffer}.
+     */
+    public void writeInts(long buffer, int[] data) {
+        context.writeBufferInt(buffer, data);
+    }
+
+    /**
+     * Downloads {@code buffer} contents into {@code data}. Blocks until any
+     * pending kernel work that wrote to the buffer has completed.
+     */
+    public void read(long buffer, float[] data) {
+        context.readBuffer(buffer, data);
+    }
+
+    /**
+     * Same as {@link #read} but for int buffers.
+     */
+    public void readInts(long buffer, int[] data) {
+        context.readBufferInt(buffer, data);
+    }
+
+    /**
+     * Begins building a kernel invocation. Borrows a fresh kernel handle from
+     * the manager's pool that this op tracks until {@link #close}; this is
+     * what guarantees the handle isn't reused by another op while the kernel
+     * is still in flight.
+     */
+    public KernelCall kernel(String programName, String kernelName) {
+        return new KernelCall(this, programName, kernelName);
+    }
+
+    @Override
+    public void close() {
+        // Always wait for pending kernel work to drain. This serves three roles:
+        //  - if buffers are owned, the budget can't be returned until the GPU
+        //    actually releases their memory (post-completion);
+        //  - if no buffers are owned but the body enqueued kernels (e.g. against
+        //    externally-owned buffers passed in), the caller still expects the
+        //    GPU work to be done by the time runOp returns;
+        //  - kernel handles can only be safely returned to the pool after the
+        //    enqueued executions that bound their args have actually run.
+        try {
+            context.finish();
+        } catch (RuntimeException e) {
+            LOGGER.error("finish failed during close", e);
+        }
+        // Return kernels first, then buffers — order doesn't matter for
+        // correctness post-finish, but kernels are pool-cheap to release.
+        KernelHandle handle;
+        var manager = context.getKernelManager();
+        while ((handle = borrowedKernels.poll()) != null) {
+            try {
+                manager.release(handle.programName(), handle.kernelName(), handle.kernel());
+            } catch (RuntimeException e) {
+                LOGGER.error("kernel release failed", e);
+            }
+        }
+        // LIFO release: most-recently-allocated first.
+        Long buffer;
+        while ((buffer = ownedBuffers.poll()) != null) {
+            try {
+                context.releaseBuffer(buffer);
+            } catch (RuntimeException e) {
+                // Best-effort cleanup: log and continue so a single failure
+                // doesn't leak the rest. The OpenCLContext records the error.
+                LOGGER.error("releaseBuffer failed", e);
+            }
+        }
+    }
+}

--- a/math/src/main/java/me/champeau/a4j/math/opencl/KernelCall.java
+++ b/math/src/main/java/me/champeau/a4j/math/opencl/KernelCall.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.math.opencl;
+
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+
+import static org.lwjgl.opencl.CL10.CL_SUCCESS;
+import static org.lwjgl.opencl.CL10.clEnqueueNDRangeKernel;
+import static org.lwjgl.opencl.CL10.clSetKernelArg;
+import static org.lwjgl.opencl.CL10.clSetKernelArg1f;
+import static org.lwjgl.opencl.CL10.clSetKernelArg1i;
+import static org.lwjgl.opencl.CL10.clSetKernelArg1p;
+
+/**
+ * Fluent builder for one OpenCL kernel invocation. Returned by
+ * {@link GpuOp#kernel(String, String)}; chain {@code arg(...)},
+ * {@code global(...)}, optionally {@code local(...)}, then call
+ * {@link #run()} (or one of the convenience {@code run(...)} overloads) to
+ * enqueue the kernel.
+ *
+ * <p>Args are positional — each {@code arg(...)} call corresponds to one
+ * {@code clSetKernelArg} on the next index. Buffer handles are passed as
+ * {@code long}; primitive scalars use the typed overloads;
+ * {@link #argLocalMemory(long)} reserves {@code __local} memory.
+ *
+ * <p>Each KernelCall borrows a fresh kernel handle from the manager pool
+ * and hands it to the surrounding {@link GpuOp}, which keeps it out of the
+ * pool until {@code clFinish} runs. This is required because OpenCL stores
+ * kernel arguments on the kernel object and reads them at execution time,
+ * not at enqueue time — returning the handle to the pool too early would
+ * let another op set new args on it before the previous enqueue actually
+ * runs on the device.
+ */
+public final class KernelCall {
+
+    private final OpenCLContext context;
+    private final long kernel;
+    private int nextArg;
+    private long[] globalWorkSize;
+    private long[] localWorkSize;
+    private boolean done;
+
+    KernelCall(GpuOp op, String programName, String kernelName) {
+        this.context = op.getContext();
+        this.kernel = context.getKernelManager().borrow(programName, kernelName);
+        op.trackKernel(programName, kernelName, this.kernel);
+    }
+
+    /**
+     * Sets the next positional arg as a buffer handle (pointer).
+     */
+    public KernelCall arg(long buffer) {
+        ensureOpen();
+        check(clSetKernelArg1p(kernel, nextArg++, buffer), "clSetKernelArg pointer");
+        return this;
+    }
+
+    /**
+     * Sets the next positional arg as an int scalar.
+     */
+    public KernelCall arg(int value) {
+        ensureOpen();
+        check(clSetKernelArg1i(kernel, nextArg++, value), "clSetKernelArg int");
+        return this;
+    }
+
+    /**
+     * Sets the next positional arg as a float scalar.
+     */
+    public KernelCall arg(float value) {
+        ensureOpen();
+        check(clSetKernelArg1f(kernel, nextArg++, value), "clSetKernelArg float");
+        return this;
+    }
+
+    /**
+     * Allocates {@code sizeBytes} of {@code __local} memory at the next
+     * positional arg. OpenCL: {@code clSetKernelArg(kernel, idx, sizeBytes)}
+     * with a {@code long} third argument and no data pointer.
+     */
+    public KernelCall argLocalMemory(long sizeBytes) {
+        ensureOpen();
+        check(clSetKernelArg(kernel, nextArg++, sizeBytes), "clSetKernelArg local memory");
+        return this;
+    }
+
+    /**
+     * Sets the global work size. Vararg supports 1D, 2D, 3D dispatches.
+     */
+    public KernelCall global(long... dims) {
+        ensureOpen();
+        if (dims.length < 1 || dims.length > 3) {
+            throw new IllegalArgumentException("global work size must have 1-3 dimensions");
+        }
+        this.globalWorkSize = dims;
+        return this;
+    }
+
+    /**
+     * Sets the local work size. Must match the dimensionality of {@link #global}.
+     */
+    public KernelCall local(long... dims) {
+        ensureOpen();
+        if (dims.length < 1 || dims.length > 3) {
+            throw new IllegalArgumentException("local work size must have 1-3 dimensions");
+        }
+        this.localWorkSize = dims;
+        return this;
+    }
+
+    /**
+     * Enqueues the kernel with the previously-configured work sizes. Does
+     * <em>not</em> call {@code clFinish} — the in-order command queue
+     * guarantees that the next enqueued kernel won't start until this one
+     * completes, and any subsequent {@link GpuOp#read} (or
+     * {@link GpuOp#close}) provides the host-visible synchronization point.
+     * The borrowed kernel handle stays out of the pool until the surrounding
+     * {@link GpuOp#close} drains the queue.
+     */
+    public void run() {
+        ensureOpen();
+        if (globalWorkSize == null) {
+            throw new IllegalStateException("global work size not set");
+        }
+        try (var stack = MemoryStack.stackPush()) {
+            PointerBuffer globalPtr = stack.mallocPointer(globalWorkSize.length);
+            for (int i = 0; i < globalWorkSize.length; i++) {
+                globalPtr.put(i, globalWorkSize[i]);
+            }
+            PointerBuffer localPtr = null;
+            if (localWorkSize != null) {
+                if (localWorkSize.length != globalWorkSize.length) {
+                    throw new IllegalStateException(
+                            "local work size dimensionality (" + localWorkSize.length
+                                    + ") must match global (" + globalWorkSize.length + ")");
+                }
+                localPtr = stack.mallocPointer(localWorkSize.length);
+                for (int i = 0; i < localWorkSize.length; i++) {
+                    localPtr.put(i, localWorkSize[i]);
+                }
+            }
+            int err = clEnqueueNDRangeKernel(context.getCommandQueue(), kernel,
+                    globalWorkSize.length, null, globalPtr, localPtr, null, null);
+            check(err, "clEnqueueNDRangeKernel");
+        }
+        done = true;
+    }
+
+    /**
+     * Convenience: 1D dispatch over {@code n} work-items.
+     */
+    public void run(long n) {
+        global(n).run();
+    }
+
+    /**
+     * Convenience: 2D dispatch.
+     */
+    public void run(long width, long height) {
+        global(width, height).run();
+    }
+
+    private void ensureOpen() {
+        if (done) {
+            throw new IllegalStateException("kernel call already run");
+        }
+    }
+
+    private static void check(int err, String op) {
+        if (err != CL_SUCCESS) {
+            throw new OpenCLException(op + " failed: " + err);
+        }
+    }
+}

--- a/math/src/main/java/me/champeau/a4j/math/opencl/OpenCLContext.java
+++ b/math/src/main/java/me/champeau/a4j/math/opencl/OpenCLContext.java
@@ -20,16 +20,19 @@ import org.lwjgl.opencl.CL;
 import org.lwjgl.opencl.CL11;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Supplier;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static org.lwjgl.opencl.CL10.*;
 
@@ -37,14 +40,15 @@ import static org.lwjgl.opencl.CL10.*;
  * Manages the OpenCL context, device, and command queue lifecycle.
  * Provides device selection prioritizing discrete GPUs over integrated GPUs and CPUs.
  * <p>
- * Thread-safety: OpenCL kernel objects cache their arguments, which can cause race conditions
- * if multiple threads set arguments on the same kernel simultaneously. All GPU operations
- * must be synchronized using {@link #executeWithLock(Supplier)} or {@link #executeWithLock(Runnable)}.
+ * Thread-safety: OpenCL kernel objects cache their arguments, so multiple threads
+ * cannot set arguments on the same kernel handle concurrently. To run GPU work, use
+ * {@link #runOp(Consumer)} or {@link #runOp(Function)} — the {@link GpuOp} body
+ * borrows private kernel handles per call, so concurrent ops on this context run in
+ * parallel without any global lock. Buffer allocations are gated by
+ * {@link #memoryBudget()} which blocks rather than failing when the GPU is full.
  */
 public class OpenCLContext implements AutoCloseable {
-    // Global lock for all GPU operations to prevent kernel argument race conditions.
-    // This lock must be used by all code that sets kernel arguments and executes kernels.
-    private final ReentrantLock gpuLock = new ReentrantLock();
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenCLContext.class);
 
     private final long platform;
     private final long device;
@@ -52,6 +56,7 @@ public class OpenCLContext implements AutoCloseable {
     private final long commandQueue;
     private final DeviceCapabilities capabilities;
     private final OpenCLKernelManager kernelManager;
+    private final GpuMemoryBudget memoryBudget;
 
     // Memory tracking for debugging GPU memory leaks
     private final Map<Long, Long> allocatedBuffers = new ConcurrentHashMap<>();
@@ -65,9 +70,12 @@ public class OpenCLContext implements AutoCloseable {
     private final AtomicInteger totalErrors = new AtomicInteger(0);
     private volatile GPUError lastError;
 
-    // Cache for writeBuffer operations - reused across calls
-    // Safe because gpuLock ensures sequential access
-    private FloatBuffer writeCache;
+    // Cache for writeBuffer operations — one buffer per thread so that
+    // concurrent writes via runOp don't collide. Native memory is freed by
+    // {@link #close} via {@link #freeWriteCaches}.
+    private final ThreadLocal<FloatBuffer> writeCache = new ThreadLocal<>();
+    private final Set<FloatBuffer> writeCacheBuffers =
+            ConcurrentHashMap.newKeySet();
 
     /**
      * Records a GPU error with the given message and cause.
@@ -127,6 +135,11 @@ public class OpenCLContext implements AutoCloseable {
         this.commandQueue = commandQueue;
         this.capabilities = capabilities;
         this.kernelManager = new OpenCLKernelManager(this);
+        // Reserve 25% of device global memory as headroom for the OpenCL
+        // runtime, the OS, the display compositor, etc. The remaining 75% is
+        // exposed as the budget concurrent runOp callers compete on.
+        long budget = (long) (capabilities.globalMemSize() * 0.75);
+        this.memoryBudget = new GpuMemoryBudget(Math.max(64L * 1024 * 1024, budget));
     }
 
     /**
@@ -139,8 +152,7 @@ public class OpenCLContext implements AutoCloseable {
         try {
             return create();
         } catch (Exception | UnsatisfiedLinkError e) {
-            System.err.println("[OpenCLContext] Failed to create OpenCL context");
-            e.printStackTrace();
+            LOGGER.error("Failed to create OpenCL context", e);
             return null;
         }
     }
@@ -344,85 +356,54 @@ public class OpenCLContext implements AutoCloseable {
     }
 
     /**
-     * Executes a GPU operation while holding the GPU lock.
-     * This method properly acquires and releases the lock to ensure thread-safe
-     * kernel argument setting and execution.
-     *
-     * @param operation the operation to execute
-     * @param <T>       the return type
-     * @return the result of the operation
+     * Returns the GPU memory budget. Used by {@link GpuOp} to gate buffer
+     * allocations against the device's physical memory size; concurrent ops
+     * proceed in parallel as long as their combined buffers fit, and block
+     * (rather than fail) if they would exceed the budget.
      */
-    public <T> T executeWithLock(Supplier<T> operation) {
-        gpuLock.lock();
-        try {
-            return operation.get();
-        } finally {
-            gpuLock.unlock();
+    public GpuMemoryBudget memoryBudget() {
+        return memoryBudget;
+    }
+
+    /**
+     * Runs a GPU operation in a scoped {@link GpuOp}. Buffers allocated via
+     * the op are automatically released when the body returns; kernels used
+     * via {@code op.kernel(...)} are borrowed from the per-thread pool and
+     * returned automatically. No global lock is held — concurrent calls run
+     * in parallel up to the GPU memory budget.
+     */
+    public void runOp(Consumer<? super GpuOp> body) {
+        try (var op = new GpuOp(this)) {
+            body.accept(op);
         }
     }
 
     /**
-     * Executes a GPU operation while holding the GPU lock.
-     * This method properly acquires and releases the lock to ensure thread-safe
-     * kernel argument setting and execution.
-     *
-     * @param operation the operation to execute
+     * {@link #runOp(Consumer)} variant that returns a value.
      */
-    public void executeWithLock(Runnable operation) {
-        gpuLock.lock();
-        try {
-            operation.run();
-        } finally {
-            gpuLock.unlock();
+    public <T> T runOp(Function<? super GpuOp, ? extends T> body) {
+        try (var op = new GpuOp(this)) {
+            return body.apply(op);
         }
     }
 
     /**
-     * Attempts to execute a GPU operation without blocking.
-     * If the GPU lock is available, acquires it and runs the GPU operation.
-     * If the GPU is busy (lock held by another thread), runs the CPU fallback immediately.
-     *
-     * @param gpuOperation the GPU operation to execute if the lock is available
-     * @param cpuFallback  the CPU fallback to execute if the GPU is busy
-     * @param <T>          the return type
-     * @return the result from either the GPU operation or the CPU fallback
-     */
-    public <T> T tryExecuteWithLock(Supplier<T> gpuOperation, Supplier<T> cpuFallback) {
-        if (gpuLock.tryLock()) {
-            try {
-                return gpuOperation.get();
-            } finally {
-                gpuLock.unlock();
-            }
-        }
-        return cpuFallback.get();
-    }
-
-    /**
-     * Verifies that the current thread holds the GPU lock.
-     * All GPU operations must be performed while holding the lock.
-     *
-     * @throws IllegalStateException if the current thread does not hold the lock
-     */
-    private void requireLock() {
-        if (!gpuLock.isHeldByCurrentThread()) {
-            throw new IllegalStateException(
-                    "GPU operations must be performed within executeWithLock(). " +
-                    "Current thread does not hold the GPU lock.");
-        }
-    }
-
-    /**
-     * Allocates a buffer on the device.
-     * Must be called within {@link #executeWithLock(Supplier)} or {@link #executeWithLock(Runnable)}.
+     * Allocates a buffer on the device. Prefer {@link GpuOp#allocateBuffer}
+     * for normal use — it ties the buffer's lifetime to the surrounding
+     * {@link #runOp} call. This method exists for buffers whose lifetime
+     * escapes the op (e.g. wrapped in a {@code GPUImage} returned to the
+     * caller); such buffers must be freed explicitly via {@link #releaseBuffer}.
      *
      * @param sizeInBytes the size in bytes
      * @param flags       memory flags (e.g., CL_MEM_READ_WRITE)
      * @return the buffer handle
-     * @throws IllegalStateException if not called within executeWithLock
      */
     public long allocateBuffer(int sizeInBytes, long flags) {
-        requireLock();
+        // Reserve space in the device-level budget *before* asking OpenCL.
+        // If another op is currently holding the memory we need, this blocks
+        // here rather than letting clCreateBuffer fail with a hard OOM.
+        memoryBudget.acquire(sizeInBytes);
+        boolean acquired = true;
         try (var stack = MemoryStack.stackPush()) {
             var errBuf = stack.mallocInt(1);
             long buffer = clCreateBuffer(context, flags, sizeInBytes, errBuf);
@@ -436,7 +417,7 @@ public class OpenCLContext implements AutoCloseable {
                         ", peak=" + peakMB + " MB" +
                         ", outstandingBuffers=" + outstanding);
                 recordError("allocateBuffer", ex);
-                System.err.println("[OpenCLContext] " + ex.getMessage());
+                LOGGER.error("{}", ex.getMessage());
                 throw ex;
             }
             // Track allocation
@@ -444,37 +425,43 @@ public class OpenCLContext implements AutoCloseable {
             long newTotal = totalAllocatedBytes.addAndGet(sizeInBytes);
             peakAllocatedBytes.updateAndGet(peak -> Math.max(peak, newTotal));
             allocationCount.incrementAndGet();
+            acquired = false;   // ownership transferred to the live buffer; releaseBuffer will free the budget
             return buffer;
+        } finally {
+            if (acquired) {
+                memoryBudget.release(sizeInBytes);
+            }
         }
     }
 
     /**
-     * Gets or grows the write cache to hold at least minCapacity floats.
-     * The cache is reused across writeBuffer calls to avoid repeated allocations.
+     * Gets or grows the calling thread's write cache to hold at least
+     * {@code minCapacity} floats. Each thread keeps its own buffer so
+     * concurrent {@link #writeBuffer} calls don't collide.
      */
     private FloatBuffer getOrGrowWriteCache(int minCapacity) {
-        if (writeCache == null || writeCache.capacity() < minCapacity) {
-            if (writeCache != null) {
-                MemoryUtil.memFree(writeCache);
+        var current = writeCache.get();
+        if (current == null || current.capacity() < minCapacity) {
+            if (current != null) {
+                writeCacheBuffers.remove(current);
+                MemoryUtil.memFree(current);
             }
             // Round up to power of 2 for efficient reuse
             int newCapacity = Integer.highestOneBit(minCapacity - 1) << 1;
             newCapacity = Math.max(newCapacity, 64 * 1024); // Min 64K floats (~256KB)
-            writeCache = MemoryUtil.memAllocFloat(newCapacity);
+            var fresh = MemoryUtil.memAllocFloat(newCapacity);
+            writeCache.set(fresh);
+            writeCacheBuffers.add(fresh);
+            return fresh;
         }
-        return writeCache;
+        return current;
     }
 
     /**
-     * Writes float data to a buffer.
-     * Must be called within {@link #executeWithLock(Supplier)} or {@link #executeWithLock(Runnable)}.
-     *
-     * @param buffer the buffer handle
-     * @param data the data to write
-     * @throws IllegalStateException if not called within executeWithLock
+     * Writes float data to {@code buffer}. Blocking — returns once the write
+     * is complete on the device.
      */
     public void writeBuffer(long buffer, float[] data) {
-        requireLock();
         var floatBuffer = getOrGrowWriteCache(data.length);
         floatBuffer.clear();
         floatBuffer.put(data).flip();
@@ -489,15 +476,10 @@ public class OpenCLContext implements AutoCloseable {
     }
 
     /**
-     * Writes int data to a buffer.
-     * Must be called within {@link #executeWithLock(Supplier)} or {@link #executeWithLock(Runnable)}.
-     *
-     * @param buffer the buffer handle
-     * @param data the data to write
-     * @throws IllegalStateException if not called within executeWithLock
+     * Writes int data to {@code buffer}. Blocking — returns once the write
+     * is complete on the device.
      */
     public void writeBufferInt(long buffer, int[] data) {
-        requireLock();
         var intBuffer = MemoryUtil.memAllocInt(data.length);
         try {
             intBuffer.put(data).flip();
@@ -513,37 +495,27 @@ public class OpenCLContext implements AutoCloseable {
     }
 
     /**
-     * Reads float data from a buffer, ensuring all pending operations complete first.
-     * Must be called within {@link #executeWithLock(Supplier)} or {@link #executeWithLock(Runnable)}.
-     *
-     * @param buffer the buffer handle
-     * @param data the array to read into
-     * @throws IllegalStateException if not called within executeWithLock
+     * Reads float data from {@code buffer}, finishing pending kernel work
+     * first so the read sees the post-kernel contents.
      */
     public void readBuffer(long buffer, float[] data) {
-        requireLock();
         // Ensure all pending kernel operations complete before reading
         int finishErr = clFinish(commandQueue);
         if (finishErr != CL_SUCCESS) {
             var ex = new OpenCLException("clFinish failed in readBuffer with error: " + finishErr + " | " + getMemoryStats());
             recordError("readBuffer.clFinish", ex);
-            System.err.println("[OpenCLContext] " + ex.getMessage());
+            LOGGER.error("{}", ex.getMessage());
         }
         readBufferNoSync(buffer, data);
     }
 
     /**
-     * Reads float data from a buffer without synchronizing first.
-     * Caller must ensure all kernel operations affecting this buffer have completed
-     * (typically by calling {@link #finish()} once before multiple reads).
-     * Must be called within {@link #executeWithLock(Supplier)} or {@link #executeWithLock(Runnable)}.
-     *
-     * @param buffer the buffer handle
-     * @param data the array to read into
-     * @throws IllegalStateException if not called within executeWithLock
+     * Reads float data from {@code buffer} without finishing pending kernel
+     * work first. The caller must guarantee any kernels writing this buffer
+     * have completed (typically by a single {@link #finish()} before a batch
+     * of reads).
      */
     public void readBufferNoSync(long buffer, float[] data) {
-        requireLock();
         var floatBuffer = MemoryUtil.memAllocFloat(data.length);
         try {
             // blocking=true ensures the read completes before returning
@@ -561,68 +533,79 @@ public class OpenCLContext implements AutoCloseable {
     }
 
     /**
-     * Releases a buffer.
-     * Must be called within {@link #executeWithLock(Supplier)} or {@link #executeWithLock(Runnable)}.
-     *
-     * @param buffer the buffer handle
-     * @throws IllegalStateException if not called within executeWithLock
+     * Reads int data from a buffer, finishing pending kernel work first.
+     */
+    public void readBufferInt(long buffer, int[] data) {
+        int finishErr = clFinish(commandQueue);
+        if (finishErr != CL_SUCCESS) {
+            recordError("readBufferInt.clFinish", new OpenCLException("clFinish failed: " + finishErr));
+        }
+        var intBuffer = MemoryUtil.memAllocInt(data.length);
+        try {
+            int err = clEnqueueReadBuffer(commandQueue, buffer, true, 0, intBuffer, null, null);
+            if (err != CL_SUCCESS) {
+                var ex = new OpenCLException("Failed to read int buffer: " + err + " | " + getMemoryStats());
+                recordError("readBufferInt", ex);
+                throw ex;
+            }
+            intBuffer.rewind();
+            intBuffer.get(data);
+        } finally {
+            MemoryUtil.memFree(intBuffer);
+        }
+    }
+
+    /**
+     * Releases a buffer that was allocated directly via
+     * {@link #allocateBuffer}. Buffers owned by a {@link GpuOp} are released
+     * automatically and must not be passed here.
      */
     public void releaseBuffer(long buffer) {
-        requireLock();
         // Track release
         Long size = allocatedBuffers.remove(buffer);
         if (size != null) {
             totalAllocatedBytes.addAndGet(-size);
             releaseCount.incrementAndGet();
+            memoryBudget.release(size);
         } else {
-            System.err.println("[OpenCLContext] Releasing unknown buffer: " + buffer);
+            LOGGER.error("Releasing unknown buffer: {}", buffer);
         }
         int err = clReleaseMemObject(buffer);
         if (err != CL_SUCCESS) {
             var ex = new OpenCLException("clReleaseMemObject failed with error: " + err + " | " + getMemoryStats());
             recordError("releaseBuffer", ex);
-            System.err.println("[OpenCLContext] " + ex.getMessage());
+            LOGGER.error("{}", ex.getMessage());
         }
     }
 
     /**
-     * Flushes the command queue to ensure all commands are submitted.
-     * This is lighter than finish() - it doesn't wait for completion.
-     * Must be called within {@link #executeWithLock(Supplier)} or {@link #executeWithLock(Runnable)}.
-     *
-     * @throws IllegalStateException if not called within executeWithLock
+     * Flushes the command queue. Lighter than {@link #finish()} — it submits
+     * pending commands but does not wait for them to complete.
      */
     public void flush() {
-        requireLock();
         int err = clFlush(commandQueue);
         if (err != CL_SUCCESS) {
             var ex = new OpenCLException("clFlush failed with error: " + err + " | " + getMemoryStats());
             recordError("flush", ex);
-            System.err.println("[OpenCLContext] " + ex.getMessage());
+            LOGGER.error("{}", ex.getMessage());
         }
     }
 
     /**
-     * Waits for all enqueued operations to complete.
-     * Must be called within {@link #executeWithLock(Supplier)} or {@link #executeWithLock(Runnable)}.
-     *
-     * @throws IllegalStateException if not called within executeWithLock
+     * Waits for all enqueued commands on this context's queue to complete.
      */
     public void finish() {
-        requireLock();
         int err = clFinish(commandQueue);
         if (err != CL_SUCCESS) {
             var ex = new OpenCLException("clFinish failed with error: " + err + " | " + getMemoryStats());
             recordError("finish", ex);
-            System.err.println("[OpenCLContext] " + ex.getMessage());
+            LOGGER.error("{}", ex.getMessage());
         }
     }
 
     /**
-     * Returns the current GPU memory allocation statistics for debugging.
-     * Can be called without holding the lock.
-     *
-     * @return a string describing current memory usage
+     * Returns a snapshot of the current GPU memory allocation statistics
+     * (current/peak usage, outstanding buffer count) for diagnostics.
      */
     public String getMemoryStats() {
         long currentBytes = totalAllocatedBytes.get();
@@ -641,51 +624,31 @@ public class OpenCLContext implements AutoCloseable {
      * @return true if the self-test passes
      */
     public boolean runSelfTest() {
-        return executeWithLock(() -> {
+        return runOp(op -> {
             int testSize = 16;
+            var outputBuffer = op.allocateBuffer(testSize * Float.BYTES, CL_MEM_WRITE_ONLY);
+            op.kernel("selftest", "selftest")
+                    .arg(outputBuffer)
+                    .run(testSize);
             var output = new float[testSize];
-            long outputBuffer = 0;
-
-            try {
-                var kernel = kernelManager.getKernel("selftest", "selftest");
-
-                outputBuffer = allocateBuffer(testSize * Float.BYTES, CL_MEM_WRITE_ONLY);
-
-                try (var stack = MemoryStack.stackPush()) {
-                    clSetKernelArg(kernel, 0, stack.pointers(outputBuffer));
-
-                    var globalSize = stack.pointers(testSize);
-                    int err = clEnqueueNDRangeKernel(commandQueue, kernel, 1, null, globalSize, null, null, null);
-                    if (err != CL_SUCCESS) {
-                        return false;
-                    }
-                }
-
-                finish();
-                readBuffer(outputBuffer, output);
-
-                for (int i = 0; i < testSize; i++) {
-                    float expected = i * 2 + 1;
-                    if (Math.abs(output[i] - expected) > 0.001f) {
-                        return false;
-                    }
-                }
-
-                return true;
-            } finally {
-                if (outputBuffer != 0) {
-                    releaseBuffer(outputBuffer);
+            op.read(outputBuffer, output);
+            for (int i = 0; i < testSize; i++) {
+                float expected = i * 2 + 1;
+                if (Math.abs(output[i] - expected) > 0.001f) {
+                    return false;
                 }
             }
+            return true;
         });
     }
 
     @Override
     public void close() {
-        if (writeCache != null) {
-            MemoryUtil.memFree(writeCache);
-            writeCache = null;
+        for (var buf : writeCacheBuffers) {
+            MemoryUtil.memFree(buf);
         }
+        writeCacheBuffers.clear();
+        writeCache.remove();
         kernelManager.close();
         clReleaseCommandQueue(commandQueue);
         clReleaseContext(context);
@@ -694,12 +657,12 @@ public class OpenCLContext implements AutoCloseable {
     /**
      * Capabilities of an OpenCL device.
      *
-     * @param deviceName the device name
+     * @param deviceName       the device name
      * @param maxWorkGroupSize maximum work group size
-     * @param maxMemAllocSize maximum memory allocation size for a single buffer
-     * @param globalMemSize total global memory size on the device
-     * @param maxComputeUnits number of compute units
-     * @param supportsDouble whether double precision is supported
+     * @param maxMemAllocSize  maximum memory allocation size for a single buffer
+     * @param globalMemSize    total global memory size on the device
+     * @param maxComputeUnits  number of compute units
+     * @param supportsDouble   whether double precision is supported
      */
     public record DeviceCapabilities(
             String deviceName,

--- a/math/src/main/java/me/champeau/a4j/math/opencl/OpenCLKernelManager.java
+++ b/math/src/main/java/me/champeau/a4j/math/opencl/OpenCLKernelManager.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.stream.Collectors;
 
 import static org.lwjgl.opencl.CL10.*;
@@ -38,26 +39,57 @@ public class OpenCLKernelManager implements AutoCloseable {
 
     private final OpenCLContext context;
     private final Map<String, Long> compiledPrograms = new ConcurrentHashMap<>();
-    private final Map<String, Long> kernelCache = new ConcurrentHashMap<>();
+    /**
+     * Per-(program, kernel) pool of free kernel handles. Used by {@link #borrow}/{@link #release}.
+     */
+    private final Map<String, ConcurrentLinkedDeque<Long>> kernelPool = new ConcurrentHashMap<>();
+    /**
+     * Tracks every kernel handle ever created via this manager so {@link #close} can release them all.
+     */
+    private final ConcurrentLinkedDeque<Long> allKernels = new ConcurrentLinkedDeque<>();
 
     OpenCLKernelManager(OpenCLContext context) {
         this.context = context;
     }
 
     /**
-     * Gets a kernel by program name and kernel name.
-     * Compiles the program if not already cached.
-     *
-     * @param programName the program file name (without .cl extension)
-     * @param kernelName  the kernel function name
-     * @return the kernel handle
+     * Borrows a kernel handle private to the calling thread for the duration
+     * of one operation. The caller must {@link #release} the handle when
+     * done; while held, only the borrowing thread should call
+     * {@code clSetKernelArg} on it. Multiple concurrent borrows of the same
+     * (program, kernel) name return distinct handles, removing the need for
+     * a global lock around kernel argument setup.
      */
-    public long getKernel(String programName, String kernelName) {
+    public long borrow(String programName, String kernelName) {
         var key = programName + ":" + kernelName;
-        return kernelCache.computeIfAbsent(key, k -> {
-            var program = getOrCompileProgram(programName);
-            return createKernel(program, kernelName);
-        });
+        var pool = kernelPool.get(key);
+        if (pool != null) {
+            Long existing = pool.pollFirst();
+            if (existing != null) {
+                return existing;
+            }
+        }
+        // Miss: create a fresh kernel against the (already-compiled) program.
+        var program = getOrCompileProgram(programName);
+        long kernel = createKernel(program, kernelName);
+        allKernels.add(kernel);
+        return kernel;
+    }
+
+    /**
+     * Returns a previously-borrowed kernel handle to the pool for reuse.
+     */
+    public void release(String programName, String kernelName, long kernel) {
+        var key = programName + ":" + kernelName;
+        kernelPool.computeIfAbsent(key, k -> new ConcurrentLinkedDeque<>()).offerFirst(kernel);
+    }
+
+    /**
+     * Returns the number of free kernel handles currently in the pool for {@code (programName, kernelName)}.
+     */
+    public int poolSize(String programName, String kernelName) {
+        var pool = kernelPool.get(programName + ":" + kernelName);
+        return pool == null ? 0 : pool.size();
     }
 
     private long getOrCompileProgram(String programName) {
@@ -120,10 +152,11 @@ public class OpenCLKernelManager implements AutoCloseable {
 
     @Override
     public void close() {
-        for (var kernel : kernelCache.values()) {
+        for (var kernel : allKernels) {
             clReleaseKernel(kernel);
         }
-        kernelCache.clear();
+        allKernels.clear();
+        kernelPool.clear();
         for (var program : compiledPrograms.values()) {
             clReleaseProgram(program);
         }

--- a/math/src/main/java/me/champeau/a4j/math/opencl/OpenCLSupport.java
+++ b/math/src/main/java/me/champeau/a4j/math/opencl/OpenCLSupport.java
@@ -15,6 +15,9 @@
  */
 package me.champeau.a4j.math.opencl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -24,6 +27,8 @@ import java.util.concurrent.atomic.AtomicReference;
  * {@code OPENCL_ENABLED=true} or system property {@code opencl.enabled=true}.
  */
 public class OpenCLSupport {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenCLSupport.class);
+
     /**
      * Environment variable name for enabling OpenCL.
      */
@@ -65,7 +70,7 @@ public class OpenCLSupport {
             // Run a simple test kernel to verify the full pipeline works
             return ctx.runSelfTest();
         } catch (Exception e) {
-            System.err.println("[OpenCL] Self-test failed: " + e.getMessage());
+            LOGGER.error("Self-test failed", e);
             return false;
         } finally {
             if (ctx != null) {
@@ -122,7 +127,7 @@ public class OpenCLSupport {
                 ctx.close();
                 ctx = SHARED_CONTEXT.get();
             } else if (ctx != null) {
-                System.out.println("[OpenCL] Using GPU: " + ctx.getCapabilities().deviceName());
+                LOGGER.info("Using GPU: {}", ctx.getCapabilities().deviceName());
             }
         }
         return ctx;

--- a/math/src/main/java/me/champeau/a4j/math/regression/DistortionGridFilter.java
+++ b/math/src/main/java/me/champeau/a4j/math/regression/DistortionGridFilter.java
@@ -18,6 +18,8 @@ package me.champeau.a4j.math.regression;
 import me.champeau.a4j.math.opencl.OpenCLContext;
 import me.champeau.a4j.math.opencl.OpenCLSupport;
 import org.lwjgl.system.MemoryStack;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.lwjgl.opencl.CL10.*;
 
@@ -33,6 +35,8 @@ import static org.lwjgl.opencl.CL10.*;
  * </ul>
  */
 public class DistortionGridFilter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DistortionGridFilter.class);
+
     private static final int MIN_GRID_SIZE_FOR_GPU = 1000;
     // Maximum half-window size supported by GPU kernel (11x11 window = 120 neighbors)
     private static final int MAX_GPU_HALF_WINDOW = 5;
@@ -69,7 +73,7 @@ public class DistortionGridFilter {
         if (context != null && OpenCLSupport.isEnabled() && totalPoints >= MIN_GRID_SIZE_FOR_GPU && halfWindow <= MAX_GPU_HALF_WINDOW) {
             try {
                 filterAndSmoothFusedGPU(context, gridDx, gridDy, sampled, gridWidth, gridHeight,
-                    searchRadius, halfWindow, madThreshold, sigma);
+                        searchRadius, halfWindow, madThreshold, sigma);
                 return;
             } catch (Exception e) {
                 context.recordError("DistortionGridFilter.filterAndSmoothFused", e);
@@ -91,141 +95,71 @@ public class DistortionGridFilter {
         int kernelRadius = (int) Math.ceil(3 * sigma);
         var gaussianKernel = createGaussianKernel1D(sigma, kernelRadius);
 
-        context.executeWithLock(() -> {
-            long dxBuf = 0, dyBuf = 0, sampledBuf = 0;
-            long tempDxBuf = 0, tempDyBuf = 0, kernelBuf = 0;
-            try {
-                int floatSize = gridWidth * gridHeight * Float.BYTES;
-                int intSize = gridWidth * gridHeight * Integer.BYTES;
-                int kernelSize = gaussianKernel.length * Float.BYTES;
+        int floatSize = gridWidth * gridHeight * Float.BYTES;
+        int intSize = gridWidth * gridHeight * Integer.BYTES;
+        int kernelSize = gaussianKernel.length * Float.BYTES;
 
-                dxBuf = context.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
-                dyBuf = context.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
-                sampledBuf = context.allocateBuffer(intSize, CL_MEM_READ_ONLY);
-                tempDxBuf = context.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
-                tempDyBuf = context.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
-                kernelBuf = context.allocateBuffer(kernelSize, CL_MEM_READ_ONLY);
+        context.runOp(op -> {
+            var dxBuf = op.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
+            var dyBuf = op.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
+            var sampledBuf = op.allocateBuffer(intSize, CL_MEM_READ_ONLY);
+            var tempDxBuf = op.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
+            var tempDyBuf = op.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
+            var kernelBuf = op.allocateBuffer(kernelSize, CL_MEM_READ_ONLY);
 
-                context.writeBuffer(dxBuf, flatDx);
-                context.writeBuffer(dyBuf, flatDy);
-                context.writeBufferInt(sampledBuf, flatSampled);
-                context.writeBuffer(kernelBuf, gaussianKernel);
+            op.write(dxBuf, flatDx);
+            op.write(dyBuf, flatDy);
+            op.writeInts(sampledBuf, flatSampled);
+            op.write(kernelBuf, gaussianKernel);
 
-                try (var stack = MemoryStack.stackPush()) {
-                    // Step 1: Interpolate unsampled points
-                    var interpKernel = context.getKernelManager().getKernel("distortion_filter", "interpolate_unsampled");
-                    clSetKernelArg(interpKernel, 0, stack.pointers(dxBuf));
-                    clSetKernelArg(interpKernel, 1, stack.pointers(dyBuf));
-                    clSetKernelArg(interpKernel, 2, stack.pointers(sampledBuf));
-                    clSetKernelArg(interpKernel, 3, stack.ints(gridWidth));
-                    clSetKernelArg(interpKernel, 4, stack.ints(gridHeight));
-                    clSetKernelArg(interpKernel, 5, stack.ints(searchRadius));
+            // Step 1: Interpolate unsampled points
+            int localX = Math.min(16, gridWidth);
+            int localY = Math.min(16, gridHeight);
+            int globalX = ((gridWidth + localX - 1) / localX) * localX;
+            int globalY = ((gridHeight + localY - 1) / localY) * localY;
+            op.kernel("distortion_filter", "interpolate_unsampled")
+                    .arg(dxBuf).arg(dyBuf).arg(sampledBuf)
+                    .arg(gridWidth).arg(gridHeight).arg(searchRadius)
+                    .global(globalX, globalY).local(localX, localY)
+                    .run();
 
-                    int localX = Math.min(16, gridWidth);
-                    int localY = Math.min(16, gridHeight);
-                    int globalX = ((gridWidth + localX - 1) / localX) * localX;
-                    int globalY = ((gridHeight + localY - 1) / localY) * localY;
-                    var globalSize = stack.pointers(globalX, globalY);
-                    var localSize = stack.pointers(localX, localY);
+            // Step 2: MAD filter (dx -> tempDx, dy -> tempDy)
+            int madLocalX = Math.min(8, gridWidth);
+            int madLocalY = Math.min(8, gridHeight);
+            int madGlobalX = ((gridWidth + madLocalX - 1) / madLocalX) * madLocalX;
+            int madGlobalY = ((gridHeight + madLocalY - 1) / madLocalY) * madLocalY;
+            op.kernel("distortion_filter", "mad_filter_grid_histogram")
+                    .arg(dxBuf).arg(dyBuf).arg(tempDxBuf).arg(tempDyBuf)
+                    .arg(gridWidth).arg(gridHeight).arg(halfWindow).arg(madThreshold)
+                    .global(madGlobalX, madGlobalY).local(madLocalX, madLocalY)
+                    .run();
 
-                    int err = clEnqueueNDRangeKernel(context.getCommandQueue(), interpKernel, 2, null, globalSize, localSize, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to enqueue interpolate_unsampled kernel: " + err);
-                    }
+            // Step 3: Gaussian smooth horizontal (tempDx -> dxBuf, tempDy -> dyBuf)
+            op.kernel("distortion_filter", "gaussian_smooth_horizontal")
+                    .arg(tempDxBuf).arg(dxBuf).arg(kernelBuf)
+                    .arg(gridWidth).arg(gridHeight).arg(kernelRadius)
+                    .global(gridWidth, gridHeight).local(1, 1)
+                    .run();
+            op.kernel("distortion_filter", "gaussian_smooth_horizontal")
+                    .arg(tempDyBuf).arg(dyBuf).arg(kernelBuf)
+                    .arg(gridWidth).arg(gridHeight).arg(kernelRadius)
+                    .global(gridWidth, gridHeight).local(1, 1)
+                    .run();
 
-                    // Step 2: MAD filter (dx -> tempDx, dy -> tempDy)
-                    var madKernel = context.getKernelManager().getKernel("distortion_filter", "mad_filter_grid_histogram");
-                    clSetKernelArg(madKernel, 0, stack.pointers(dxBuf));
-                    clSetKernelArg(madKernel, 1, stack.pointers(dyBuf));
-                    clSetKernelArg(madKernel, 2, stack.pointers(tempDxBuf));
-                    clSetKernelArg(madKernel, 3, stack.pointers(tempDyBuf));
-                    clSetKernelArg(madKernel, 4, stack.ints(gridWidth));
-                    clSetKernelArg(madKernel, 5, stack.ints(gridHeight));
-                    clSetKernelArg(madKernel, 6, stack.ints(halfWindow));
-                    clSetKernelArg(madKernel, 7, stack.floats(madThreshold));
+            // Step 4: Gaussian smooth vertical (dxBuf -> tempDx, dyBuf -> tempDy)
+            op.kernel("distortion_filter", "gaussian_smooth_vertical")
+                    .arg(dxBuf).arg(tempDxBuf).arg(kernelBuf)
+                    .arg(gridWidth).arg(gridHeight).arg(kernelRadius)
+                    .global(gridWidth, gridHeight).local(1, 1)
+                    .run();
+            op.kernel("distortion_filter", "gaussian_smooth_vertical")
+                    .arg(dyBuf).arg(tempDyBuf).arg(kernelBuf)
+                    .arg(gridWidth).arg(gridHeight).arg(kernelRadius)
+                    .global(gridWidth, gridHeight).local(1, 1)
+                    .run();
 
-                    // Histogram-based kernel with 512 bins, use 8x8 work groups
-                    int madLocalX = Math.min(8, gridWidth);
-                    int madLocalY = Math.min(8, gridHeight);
-                    int madGlobalX = ((gridWidth + madLocalX - 1) / madLocalX) * madLocalX;
-                    int madGlobalY = ((gridHeight + madLocalY - 1) / madLocalY) * madLocalY;
-                    var madGlobalSize = stack.pointers(madGlobalX, madGlobalY);
-                    var madLocalSize = stack.pointers(madLocalX, madLocalY);
-
-                    err = clEnqueueNDRangeKernel(context.getCommandQueue(), madKernel, 2, null, madGlobalSize, madLocalSize, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to enqueue mad_filter_grid_histogram kernel: " + err);
-                    }
-
-                    // Step 3: Gaussian smooth horizontal (tempDx -> dxBuf, tempDy -> dyBuf)
-                    var hKernel = context.getKernelManager().getKernel("distortion_filter", "gaussian_smooth_horizontal");
-                    var vKernel = context.getKernelManager().getKernel("distortion_filter", "gaussian_smooth_vertical");
-
-                    var gaussGlobalSize = stack.pointers(gridWidth, gridHeight);
-                    var gaussLocalSize = stack.pointers(1, 1);
-
-                    clSetKernelArg(hKernel, 0, stack.pointers(tempDxBuf));
-                    clSetKernelArg(hKernel, 1, stack.pointers(dxBuf));
-                    clSetKernelArg(hKernel, 2, stack.pointers(kernelBuf));
-                    clSetKernelArg(hKernel, 3, stack.ints(gridWidth));
-                    clSetKernelArg(hKernel, 4, stack.ints(gridHeight));
-                    clSetKernelArg(hKernel, 5, stack.ints(kernelRadius));
-                    err = clEnqueueNDRangeKernel(context.getCommandQueue(), hKernel, 2, null, gaussGlobalSize, gaussLocalSize, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to enqueue gaussian_smooth_horizontal (Dx): " + err);
-                    }
-
-                    clSetKernelArg(hKernel, 0, stack.pointers(tempDyBuf));
-                    clSetKernelArg(hKernel, 1, stack.pointers(dyBuf));
-                    err = clEnqueueNDRangeKernel(context.getCommandQueue(), hKernel, 2, null, gaussGlobalSize, gaussLocalSize, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to enqueue gaussian_smooth_horizontal (Dy): " + err);
-                    }
-
-                    // Step 4: Gaussian smooth vertical (dxBuf -> tempDx -> dxBuf, dyBuf -> tempDy -> dyBuf)
-                    clSetKernelArg(vKernel, 0, stack.pointers(dxBuf));
-                    clSetKernelArg(vKernel, 1, stack.pointers(tempDxBuf));
-                    clSetKernelArg(vKernel, 2, stack.pointers(kernelBuf));
-                    clSetKernelArg(vKernel, 3, stack.ints(gridWidth));
-                    clSetKernelArg(vKernel, 4, stack.ints(gridHeight));
-                    clSetKernelArg(vKernel, 5, stack.ints(kernelRadius));
-                    err = clEnqueueNDRangeKernel(context.getCommandQueue(), vKernel, 2, null, gaussGlobalSize, gaussLocalSize, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to enqueue gaussian_smooth_vertical (Dx): " + err);
-                    }
-
-                    clSetKernelArg(vKernel, 0, stack.pointers(dyBuf));
-                    clSetKernelArg(vKernel, 1, stack.pointers(tempDyBuf));
-                    err = clEnqueueNDRangeKernel(context.getCommandQueue(), vKernel, 2, null, gaussGlobalSize, gaussLocalSize, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to enqueue gaussian_smooth_vertical (Dy): " + err);
-                    }
-                }
-
-                context.finish();
-                context.readBuffer(tempDxBuf, flatDx);
-                context.readBuffer(tempDyBuf, flatDy);
-            } finally {
-                try {
-                    context.finish();
-                } catch (Exception e) {
-                    System.err.println("[DistortionGridFilter] finish() failed in filterAndSmoothFusedGPU");
-                    e.printStackTrace();
-                }
-                safeRelease(context, dxBuf);
-                safeRelease(context, dyBuf);
-                safeRelease(context, sampledBuf);
-                safeRelease(context, tempDxBuf);
-                safeRelease(context, tempDyBuf);
-                safeRelease(context, kernelBuf);
-                try {
-                    context.flush();
-                } catch (Exception e) {
-                    System.err.println("[DistortionGridFilter] flush() failed in filterAndSmoothFusedGPU");
-                    e.printStackTrace();
-                }
-            }
-            return null;
+            op.read(tempDxBuf, flatDx);
+            op.read(tempDyBuf, flatDy);
         });
 
         unflatten2D(flatDx, gridDx);
@@ -236,11 +170,11 @@ public class DistortionGridFilter {
      * Applies MAD-based outlier filtering to a distortion grid.
      * Uses GPU if available and grid is large enough.
      *
-     * @param gridDx      displacement X values [gridHeight][gridWidth]
-     * @param gridDy      displacement Y values [gridHeight][gridWidth]
-     * @param gridWidth   width of the grid
-     * @param gridHeight  height of the grid
-     * @param halfWindow  half-size of the filtering window (e.g., 2 for 5x5)
+     * @param gridDx       displacement X values [gridHeight][gridWidth]
+     * @param gridDy       displacement Y values [gridHeight][gridWidth]
+     * @param gridWidth    width of the grid
+     * @param gridHeight   height of the grid
+     * @param halfWindow   half-size of the filtering window (e.g., 2 for 5x5)
      * @param madThreshold MAD threshold for outlier detection (typically 3.0)
      */
     public void madFilter(float[][] gridDx, float[][] gridDy,
@@ -292,11 +226,11 @@ public class DistortionGridFilter {
      * Applies separable Gaussian smoothing to a distortion grid.
      * Uses GPU if available and grid is large enough.
      *
-     * @param gridDx      displacement X values [gridHeight][gridWidth]
-     * @param gridDy      displacement Y values [gridHeight][gridWidth]
-     * @param gridWidth   width of the grid
-     * @param gridHeight  height of the grid
-     * @param sigma       Gaussian sigma parameter
+     * @param gridDx     displacement X values [gridHeight][gridWidth]
+     * @param gridDy     displacement Y values [gridHeight][gridWidth]
+     * @param gridWidth  width of the grid
+     * @param gridHeight height of the grid
+     * @param sigma      Gaussian sigma parameter
      */
     public void gaussianSmooth(float[][] gridDx, float[][] gridDy,
                                int gridWidth, int gridHeight, float sigma) {
@@ -308,8 +242,7 @@ public class DistortionGridFilter {
                 gaussianSmoothGPU(context, gridDx, gridDy, gridWidth, gridHeight, sigma);
                 return;
             } catch (Exception e) {
-                System.err.println("[DistortionGridFilter] GPU gaussianSmooth failed, falling back to CPU");
-                e.printStackTrace();
+                LOGGER.error("GPU gaussianSmooth failed, falling back to CPU", e);
                 context.recordError("DistortionGridFilter.gaussianSmooth", e);
             }
         }
@@ -325,66 +258,29 @@ public class DistortionGridFilter {
         var outputDx = new float[gridWidth * gridHeight];
         var outputDy = new float[gridWidth * gridHeight];
 
-        context.executeWithLock(() -> {
-            long inputDxBuf = 0, inputDyBuf = 0, outputDxBuf = 0, outputDyBuf = 0;
-            try {
-                int size = gridWidth * gridHeight * Float.BYTES;
-                inputDxBuf = context.allocateBuffer(size, CL_MEM_READ_ONLY);
-                inputDyBuf = context.allocateBuffer(size, CL_MEM_READ_ONLY);
-                outputDxBuf = context.allocateBuffer(size, CL_MEM_WRITE_ONLY);
-                outputDyBuf = context.allocateBuffer(size, CL_MEM_WRITE_ONLY);
+        int size = gridWidth * gridHeight * Float.BYTES;
 
-                context.writeBuffer(inputDxBuf, inputDx);
-                context.writeBuffer(inputDyBuf, inputDy);
+        context.runOp(op -> {
+            var inputDxBuf = op.allocateBuffer(size, CL_MEM_READ_ONLY);
+            var inputDyBuf = op.allocateBuffer(size, CL_MEM_READ_ONLY);
+            var outputDxBuf = op.allocateBuffer(size, CL_MEM_WRITE_ONLY);
+            var outputDyBuf = op.allocateBuffer(size, CL_MEM_WRITE_ONLY);
 
-                var kernel = context.getKernelManager().getKernel("distortion_filter", "mad_filter_grid_histogram");
+            op.write(inputDxBuf, inputDx);
+            op.write(inputDyBuf, inputDy);
 
-                try (var stack = MemoryStack.stackPush()) {
-                    clSetKernelArg(kernel, 0, stack.pointers(inputDxBuf));
-                    clSetKernelArg(kernel, 1, stack.pointers(inputDyBuf));
-                    clSetKernelArg(kernel, 2, stack.pointers(outputDxBuf));
-                    clSetKernelArg(kernel, 3, stack.pointers(outputDyBuf));
-                    clSetKernelArg(kernel, 4, stack.ints(gridWidth));
-                    clSetKernelArg(kernel, 5, stack.ints(gridHeight));
-                    clSetKernelArg(kernel, 6, stack.ints(halfWindow));
-                    clSetKernelArg(kernel, 7, stack.floats(madThreshold));
+            int localX = Math.min(8, gridWidth);
+            int localY = Math.min(8, gridHeight);
+            int globalX = ((gridWidth + localX - 1) / localX) * localX;
+            int globalY = ((gridHeight + localY - 1) / localY) * localY;
+            op.kernel("distortion_filter", "mad_filter_grid_histogram")
+                    .arg(inputDxBuf).arg(inputDyBuf).arg(outputDxBuf).arg(outputDyBuf)
+                    .arg(gridWidth).arg(gridHeight).arg(halfWindow).arg(madThreshold)
+                    .global(globalX, globalY).local(localX, localY)
+                    .run();
 
-                    // Histogram-based kernel with 512 bins uses ~2KB for histogram
-                    // Can use 8x8 work groups
-                    int localX = Math.min(8, gridWidth);
-                    int localY = Math.min(8, gridHeight);
-                    int globalX = ((gridWidth + localX - 1) / localX) * localX;
-                    int globalY = ((gridHeight + localY - 1) / localY) * localY;
-                    var globalSize = stack.pointers(globalX, globalY);
-                    var localSize = stack.pointers(localX, localY);
-                    int err = clEnqueueNDRangeKernel(context.getCommandQueue(), kernel, 2, null, globalSize, localSize, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to enqueue mad_filter_grid_histogram kernel: " + err);
-                    }
-                }
-
-                context.finish();
-                context.readBuffer(outputDxBuf, outputDx);
-                context.readBuffer(outputDyBuf, outputDy);
-            } finally {
-                try {
-                    context.finish();
-                } catch (Exception e) {
-                    System.err.println("[DistortionGridFilter] finish() failed in madFilterGPU");
-                    e.printStackTrace();
-                }
-                safeRelease(context, inputDxBuf);
-                safeRelease(context, inputDyBuf);
-                safeRelease(context, outputDxBuf);
-                safeRelease(context, outputDyBuf);
-                try {
-                    context.flush();
-                } catch (Exception e) {
-                    System.err.println("[DistortionGridFilter] flush() failed in madFilterGPU");
-                    e.printStackTrace();
-                }
-            }
-            return null;
+            op.read(outputDxBuf, outputDx);
+            op.read(outputDyBuf, outputDy);
         });
 
         unflatten2D(outputDx, gridDx);
@@ -397,65 +293,30 @@ public class DistortionGridFilter {
         var flatDy = flatten2D(gridDy);
         var flatSampled = flattenBooleanToInt(sampled);
 
-        context.executeWithLock(() -> {
-            long dxBuf = 0, dyBuf = 0, sampledBuf = 0;
-            try {
-                int floatSize = gridWidth * gridHeight * Float.BYTES;
-                int intSize = gridWidth * gridHeight * Integer.BYTES;
+        int floatSize = gridWidth * gridHeight * Float.BYTES;
+        int intSize = gridWidth * gridHeight * Integer.BYTES;
 
-                dxBuf = context.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
-                dyBuf = context.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
-                sampledBuf = context.allocateBuffer(intSize, CL_MEM_READ_ONLY);
+        context.runOp(op -> {
+            var dxBuf = op.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
+            var dyBuf = op.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
+            var sampledBuf = op.allocateBuffer(intSize, CL_MEM_READ_ONLY);
 
-                context.writeBuffer(dxBuf, flatDx);
-                context.writeBuffer(dyBuf, flatDy);
-                context.writeBufferInt(sampledBuf, flatSampled);
+            op.write(dxBuf, flatDx);
+            op.write(dyBuf, flatDy);
+            op.writeInts(sampledBuf, flatSampled);
 
-                var kernel = context.getKernelManager().getKernel("distortion_filter", "interpolate_unsampled");
+            int localX = Math.min(16, gridWidth);
+            int localY = Math.min(16, gridHeight);
+            int globalX = ((gridWidth + localX - 1) / localX) * localX;
+            int globalY = ((gridHeight + localY - 1) / localY) * localY;
+            op.kernel("distortion_filter", "interpolate_unsampled")
+                    .arg(dxBuf).arg(dyBuf).arg(sampledBuf)
+                    .arg(gridWidth).arg(gridHeight).arg(searchRadius)
+                    .global(globalX, globalY).local(localX, localY)
+                    .run();
 
-                try (var stack = MemoryStack.stackPush()) {
-                    clSetKernelArg(kernel, 0, stack.pointers(dxBuf));
-                    clSetKernelArg(kernel, 1, stack.pointers(dyBuf));
-                    clSetKernelArg(kernel, 2, stack.pointers(sampledBuf));
-                    clSetKernelArg(kernel, 3, stack.ints(gridWidth));
-                    clSetKernelArg(kernel, 4, stack.ints(gridHeight));
-                    clSetKernelArg(kernel, 5, stack.ints(searchRadius));
-
-                    // Use explicit local work size for consistency and to avoid driver issues
-                    int localX = Math.min(16, gridWidth);
-                    int localY = Math.min(16, gridHeight);
-                    int globalX = ((gridWidth + localX - 1) / localX) * localX;
-                    int globalY = ((gridHeight + localY - 1) / localY) * localY;
-
-                    var globalSize = stack.pointers(globalX, globalY);
-                    var localSize = stack.pointers(localX, localY);
-                    int err = clEnqueueNDRangeKernel(context.getCommandQueue(), kernel, 2, null, globalSize, localSize, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to enqueue interpolate_unsampled kernel: " + err);
-                    }
-                }
-
-                context.finish();
-                context.readBuffer(dxBuf, flatDx);
-                context.readBuffer(dyBuf, flatDy);
-            } finally {
-                try {
-                    context.finish();
-                } catch (Exception e) {
-                    System.err.println("[DistortionGridFilter] finish() failed in interpolateUnsampledGPU");
-                    e.printStackTrace();
-                }
-                safeRelease(context, dxBuf);
-                safeRelease(context, dyBuf);
-                safeRelease(context, sampledBuf);
-                try {
-                    context.flush();
-                } catch (Exception e) {
-                    System.err.println("[DistortionGridFilter] flush() failed in interpolateUnsampledGPU");
-                    e.printStackTrace();
-                }
-            }
-            return null;
+            op.read(dxBuf, flatDx);
+            op.read(dyBuf, flatDy);
         });
 
         unflatten2D(flatDx, gridDx);
@@ -470,94 +331,46 @@ public class DistortionGridFilter {
         var flatDx = flatten2D(gridDx);
         var flatDy = flatten2D(gridDy);
 
-        context.executeWithLock(() -> {
-            long dxBuf = 0, dyBuf = 0, tempDxBuf = 0, tempDyBuf = 0, kernelBuf = 0;
-            try {
-                int floatSize = gridWidth * gridHeight * Float.BYTES;
-                int kernelSize = gaussianKernel.length * Float.BYTES;
+        int floatSize = gridWidth * gridHeight * Float.BYTES;
+        int kernelSize = gaussianKernel.length * Float.BYTES;
 
-                dxBuf = context.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
-                dyBuf = context.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
-                tempDxBuf = context.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
-                tempDyBuf = context.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
-                kernelBuf = context.allocateBuffer(kernelSize, CL_MEM_READ_ONLY);
+        context.runOp(op -> {
+            var dxBuf = op.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
+            var dyBuf = op.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
+            var tempDxBuf = op.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
+            var tempDyBuf = op.allocateBuffer(floatSize, CL_MEM_READ_WRITE);
+            var kernelBuf = op.allocateBuffer(kernelSize, CL_MEM_READ_ONLY);
 
-                context.writeBuffer(dxBuf, flatDx);
-                context.writeBuffer(dyBuf, flatDy);
-                context.writeBuffer(kernelBuf, gaussianKernel);
+            op.write(dxBuf, flatDx);
+            op.write(dyBuf, flatDy);
+            op.write(kernelBuf, gaussianKernel);
 
-                var hKernel = context.getKernelManager().getKernel("distortion_filter", "gaussian_smooth_horizontal");
-                var vKernel = context.getKernelManager().getKernel("distortion_filter", "gaussian_smooth_vertical");
+            // Horizontal pass for Dx and Dy
+            op.kernel("distortion_filter", "gaussian_smooth_horizontal")
+                    .arg(dxBuf).arg(tempDxBuf).arg(kernelBuf)
+                    .arg(gridWidth).arg(gridHeight).arg(kernelRadius)
+                    .global(gridWidth, gridHeight).local(1, 1)
+                    .run();
+            op.kernel("distortion_filter", "gaussian_smooth_horizontal")
+                    .arg(dyBuf).arg(tempDyBuf).arg(kernelBuf)
+                    .arg(gridWidth).arg(gridHeight).arg(kernelRadius)
+                    .global(gridWidth, gridHeight).local(1, 1)
+                    .run();
 
-                try (var stack = MemoryStack.stackPush()) {
-                    // Use explicit (1, 1) local size to avoid driver issues
-                    var globalSize = stack.pointers(gridWidth, gridHeight);
-                    var localSize = stack.pointers(1, 1);
+            // Vertical pass for Dx and Dy
+            op.kernel("distortion_filter", "gaussian_smooth_vertical")
+                    .arg(tempDxBuf).arg(dxBuf).arg(kernelBuf)
+                    .arg(gridWidth).arg(gridHeight).arg(kernelRadius)
+                    .global(gridWidth, gridHeight).local(1, 1)
+                    .run();
+            op.kernel("distortion_filter", "gaussian_smooth_vertical")
+                    .arg(tempDyBuf).arg(dyBuf).arg(kernelBuf)
+                    .arg(gridWidth).arg(gridHeight).arg(kernelRadius)
+                    .global(gridWidth, gridHeight).local(1, 1)
+                    .run();
 
-                    // Horizontal pass for Dx
-                    clSetKernelArg(hKernel, 0, stack.pointers(dxBuf));
-                    clSetKernelArg(hKernel, 1, stack.pointers(tempDxBuf));
-                    clSetKernelArg(hKernel, 2, stack.pointers(kernelBuf));
-                    clSetKernelArg(hKernel, 3, stack.ints(gridWidth));
-                    clSetKernelArg(hKernel, 4, stack.ints(gridHeight));
-                    clSetKernelArg(hKernel, 5, stack.ints(kernelRadius));
-                    int err = clEnqueueNDRangeKernel(context.getCommandQueue(), hKernel, 2, null, globalSize, localSize, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to enqueue gaussian_smooth_horizontal (Dx): " + err);
-                    }
-
-                    // Horizontal pass for Dy
-                    clSetKernelArg(hKernel, 0, stack.pointers(dyBuf));
-                    clSetKernelArg(hKernel, 1, stack.pointers(tempDyBuf));
-                    err = clEnqueueNDRangeKernel(context.getCommandQueue(), hKernel, 2, null, globalSize, localSize, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to enqueue gaussian_smooth_horizontal (Dy): " + err);
-                    }
-
-                    // Vertical pass for Dx
-                    clSetKernelArg(vKernel, 0, stack.pointers(tempDxBuf));
-                    clSetKernelArg(vKernel, 1, stack.pointers(dxBuf));
-                    clSetKernelArg(vKernel, 2, stack.pointers(kernelBuf));
-                    clSetKernelArg(vKernel, 3, stack.ints(gridWidth));
-                    clSetKernelArg(vKernel, 4, stack.ints(gridHeight));
-                    clSetKernelArg(vKernel, 5, stack.ints(kernelRadius));
-                    err = clEnqueueNDRangeKernel(context.getCommandQueue(), vKernel, 2, null, globalSize, localSize, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to enqueue gaussian_smooth_vertical (Dx): " + err);
-                    }
-
-                    // Vertical pass for Dy
-                    clSetKernelArg(vKernel, 0, stack.pointers(tempDyBuf));
-                    clSetKernelArg(vKernel, 1, stack.pointers(dyBuf));
-                    err = clEnqueueNDRangeKernel(context.getCommandQueue(), vKernel, 2, null, globalSize, localSize, null, null);
-                    if (err != CL_SUCCESS) {
-                        throw new RuntimeException("Failed to enqueue gaussian_smooth_vertical (Dy): " + err);
-                    }
-                }
-
-                context.finish();
-                context.readBuffer(dxBuf, flatDx);
-                context.readBuffer(dyBuf, flatDy);
-            } finally {
-                try {
-                    context.finish();
-                } catch (Exception e) {
-                    System.err.println("[DistortionGridFilter] finish() failed in gaussianSmoothGPU");
-                    e.printStackTrace();
-                }
-                safeRelease(context, dxBuf);
-                safeRelease(context, dyBuf);
-                safeRelease(context, tempDxBuf);
-                safeRelease(context, tempDyBuf);
-                safeRelease(context, kernelBuf);
-                try {
-                    context.flush();
-                } catch (Exception e) {
-                    System.err.println("[DistortionGridFilter] flush() failed in gaussianSmoothGPU");
-                    e.printStackTrace();
-                }
-            }
-            return null;
+            op.read(dxBuf, flatDx);
+            op.read(dyBuf, flatDy);
         });
 
         unflatten2D(flatDx, gridDx);
@@ -721,7 +534,6 @@ public class DistortionGridFilter {
 
         var tempDx = new float[gridHeight][gridWidth];
         var tempDy = new float[gridHeight][gridWidth];
-
         // Horizontal pass
         for (int gy = 0; gy < gridHeight; gy++) {
             for (int gx = 0; gx < gridWidth; gx++) {
@@ -766,8 +578,7 @@ public class DistortionGridFilter {
             try {
                 context.releaseBuffer(buffer);
             } catch (Exception e) {
-                System.err.println("[DistortionGridFilter] Failed to release GPU buffer");
-                e.printStackTrace();
+                LOGGER.error("Failed to release GPU buffer", e);
             }
         }
     }

--- a/math/src/main/java/me/champeau/a4j/math/regression/LinearRegression.java
+++ b/math/src/main/java/me/champeau/a4j/math/regression/LinearRegression.java
@@ -58,7 +58,7 @@ public abstract class LinearRegression {
     /**
      * Computes the first order regression of a series of points with weights.
      *
-     * @param series the series of points
+     * @param series  the series of points
      * @param weights the weights associated to each point of the series
      * @return the coefficients of the regression for the form y = a * x + b
      */
@@ -127,7 +127,7 @@ public abstract class LinearRegression {
     /**
      * Computes the second order regression of a series of points with weights.
      *
-     * @param series the series of points
+     * @param series  the series of points
      * @param weights the weights associated to each point of the series
      * @return the coefficients of the regression for the form y = a * x^2 + b * x + c
      */
@@ -184,7 +184,7 @@ public abstract class LinearRegression {
      * the direct methods which should be preferred for order 1 and 2.
      *
      * @param series the series of points
-     * @param k the order of the polynomial
+     * @param k      the order of the polynomial
      * @return the polynomial coefficients
      */
     public static double[] kOrderRegression(Point2D[] series, int k) {
@@ -218,9 +218,105 @@ public abstract class LinearRegression {
     }
 
     /**
+     * Primitive-array overload of {@link #kOrderRegression(Point2D[], int)} that avoids
+     * the {@code Point2D[]} indirection and the heavyweight matrix machinery used by the
+     * other overload. The normal equations form a Hankel-style {@code (k+1)×(k+1)} system
+     * whose entries are sums of {@code x^q}; we accumulate those sums in one pass and
+     * solve the small dense system in place via Gaussian elimination with partial pivoting.
+     * <p>For a singular system, returns an array of zeros — matching the existing overload's
+     * behaviour for inputs the matrix path can't invert.
+     *
+     * @param xs the x coordinates of the series
+     * @param ys the y coordinates of the series (must have the same length as {@code xs})
+     * @param k  the polynomial order
+     * @return the polynomial coefficients in descending power order
+     */
+    public static double[] kOrderRegression(double[] xs, double[] ys, int k) {
+        if (k < 0) {
+            throw new IllegalArgumentException("Order must be >= 0");
+        }
+        if (xs.length != ys.length) {
+            throw new IllegalArgumentException("xs and ys must have the same length");
+        }
+        int n = xs.length;
+        int p = k + 1;
+        // sumXq[q] = sum of x^q over all points, for q = 0..2k
+        // sumXqY[q] = sum of (x^q * y) over all points, for q = 0..k
+        double[] sumXq = new double[2 * k + 1];
+        double[] sumXqY = new double[p];
+        for (int i = 0; i < n; i++) {
+            double x = xs[i];
+            double y = ys[i];
+            double xq = 1.0;
+            sumXq[0] += xq;
+            sumXqY[0] += y;
+            for (int q = 1; q < 2 * k + 1; q++) {
+                xq *= x;
+                sumXq[q] += xq;
+                if (q <= k) {
+                    sumXqY[q] += xq * y;
+                }
+            }
+        }
+        // Augmented matrix [M^T M | M^T y], shape (p) x (p+1).
+        double[][] aug = new double[p][p + 1];
+        for (int i = 0; i < p; i++) {
+            for (int j = 0; j < p; j++) {
+                aug[i][j] = sumXq[i + j];
+            }
+            aug[i][p] = sumXqY[i];
+        }
+        // Forward elimination with partial pivoting.
+        for (int col = 0; col < p; col++) {
+            int pivot = col;
+            double pivotMag = Math.abs(aug[col][col]);
+            for (int r = col + 1; r < p; r++) {
+                double mag = Math.abs(aug[r][col]);
+                if (mag > pivotMag) {
+                    pivot = r;
+                    pivotMag = mag;
+                }
+            }
+            if (pivotMag == 0) {
+                return new double[p];
+            }
+            if (pivot != col) {
+                double[] tmp = aug[col];
+                aug[col] = aug[pivot];
+                aug[pivot] = tmp;
+            }
+            double inv = 1.0 / aug[col][col];
+            for (int r = col + 1; r < p; r++) {
+                double factor = aug[r][col] * inv;
+                if (factor != 0) {
+                    for (int c = col; c <= p; c++) {
+                        aug[r][c] -= factor * aug[col][c];
+                    }
+                }
+            }
+        }
+        // Back-substitution; coeff[i] is the coefficient of x^i (ascending power).
+        double[] coeff = new double[p];
+        for (int i = p - 1; i >= 0; i--) {
+            double sum = aug[i][p];
+            for (int j = i + 1; j < p; j++) {
+                sum -= aug[i][j] * coeff[j];
+            }
+            coeff[i] = sum / aug[i][i];
+        }
+        // Re-order to descending power, matching the existing convention.
+        double[] res = new double[p];
+        for (int i = 0; i <= k; i++) {
+            res[k - i] = coeff[i];
+        }
+        return res;
+    }
+
+    /**
      * Returns a polynomial function from the given coefficients.
      * The coefficients are ordered by power descending, i.e. the
      * first coefficient is the coefficient of the highest power.
+     *
      * @param coefficients the coefficients
      * @return the polynomial function
      */

--- a/math/src/main/java/module-info.java
+++ b/math/src/main/java/module-info.java
@@ -28,8 +28,10 @@ module me.champeau.a4j.math {
     exports me.champeau.a4j.math.tuples;
     exports me.champeau.a4j.math.image.analysis;
     exports me.champeau.a4j.math.spatial;
+    requires transitive me.champeau.a4j.utilities;
     requires jdk.incubator.vector;
     requires commons.math3;
+    requires org.slf4j;
     requires static org.lwjgl;
     requires static org.lwjgl.opencl;
 }

--- a/math/src/test/groovy/me/champeau/a4j/math/LinearRegressionTest.groovy
+++ b/math/src/test/groovy/me/champeau/a4j/math/LinearRegressionTest.groovy
@@ -79,6 +79,100 @@ class LinearRegressionTest extends Specification {
         [0.1, -2.1, 1.0, 0.6, 2.1, 0.1, 3.1, -3.6] | -1.6304   | 4.70323   | -2.53146
     }
 
+    def "primitive kOrderRegression matches Point2D variant — #scenario, k=#k"() {
+        given:
+        def series = createSeries(points as double[])
+        def xs = new double[series.length]
+        def ys = new double[series.length]
+        for (int i = 0; i < series.length; i++) {
+            xs[i] = series[i].x()
+            ys[i] = series[i].y()
+        }
+
+        when:
+        double[] viaPoints = LinearRegression.kOrderRegression(series, k)
+        double[] viaPrimitive = LinearRegression.kOrderRegression(xs, ys, k)
+
+        then:
+        viaPoints.length == viaPrimitive.length
+        viaPoints.length == k + 1
+        for (int i = 0; i < viaPoints.length; i++) {
+            assertEquals(viaPrimitive[i], viaPoints[i])
+        }
+
+        where:
+        scenario           | k | points
+        "linear, exact"    | 1 | [0.0, 1.0, 1.0, 3.0, 2.0, 5.0, 3.0, 7.0]
+        "linear, noisy"    | 1 | [0.0, 1.1, 1.0, 2.9, 2.0, 5.05, 3.0, 6.95, 4.0, 9.1]
+        "quadratic, exact" | 2 | [0.0, 1.0, 1.0, 6.0, 2.0, 17.0, 3.0, 34.0]
+        "quadratic, noisy" | 2 | [0.1, -2.1, 1.0, 0.6, 2.1, 0.1, 3.1, -3.6]
+        "cubic, exact"     | 3 | [0.0, -5.0, 1.0, -5.0, 2.0, 1.0, 3.0, 25.0, 4.0, 79.0, 5.0, 175.0, 6.0, 325.0, 7.0, 541.0]
+        "negative x"       | 2 | [-3.0, 9.0, -1.0, 1.0, 1.0, 1.0, 3.0, 9.0]
+    }
+
+    def "primitive kOrderRegression matches Point2D variant on column-index data (k=3, 200 points)"() {
+        // Mimics PhenomenaDetector.computeColumnModels: xs are column indices, ys are smoothly varying.
+        given:
+        int n = 200
+        def xs = new double[n]
+        def ys = new double[n]
+        def series = new Point2D[n]
+        def rng = new Random(0xC0FFEE as long)
+        for (int i = 0; i < n; i++) {
+            double x = i
+            double y = 0.0001 * x * x * x - 0.05 * x * x + 2 * x + 100 + rng.nextGaussian() * 5
+            xs[i] = x
+            ys[i] = y
+            series[i] = new Point2D(x, y)
+        }
+
+        when:
+        double[] viaPoints = LinearRegression.kOrderRegression(series, 3)
+        double[] viaPrimitive = LinearRegression.kOrderRegression(xs, ys, 3)
+
+        then:
+        viaPoints.length == 4
+        viaPrimitive.length == 4
+        // Both implementations solve the same normal equations; expect coefficients to agree
+        // to several significant figures even with the worse conditioning of column-index x ranges.
+        for (int i = 0; i < 4; i++) {
+            // Relative tolerance: large coefficient magnitudes call for relative comparison.
+            def scale = Math.max(Math.abs(viaPoints[i]), 1.0d)
+            assert Math.abs(viaPrimitive[i] - viaPoints[i]) / scale < 1e-9
+        }
+    }
+
+    def "primitive kOrderRegression recovers cubic coefficients exactly"() {
+        given:
+        // y = 2 x^3 - 3 x^2 + x - 5, sampled at x = 0..7
+        def xs = (0..7).collect { it as double } as double[]
+        def ys = xs.collect { x -> 2 * x * x * x - 3 * x * x + x - 5 } as double[]
+
+        when:
+        double[] coeffs = LinearRegression.kOrderRegression(xs, ys, 3)
+
+        then:
+        coeffs.length == 4
+        assertEquals(coeffs[0], 2.0)
+        assertEquals(coeffs[1], -3.0)
+        assertEquals(coeffs[2], 1.0)
+        assertEquals(coeffs[3], -5.0)
+    }
+
+    def "primitive kOrderRegression returns zeros on a singular system"() {
+        given:
+        // All x identical → design matrix singular for any k>=1.
+        def xs = [3.0, 3.0, 3.0, 3.0] as double[]
+        def ys = [1.0, 2.0, 3.0, 4.0] as double[]
+
+        when:
+        double[] coeffs = LinearRegression.kOrderRegression(xs, ys, 3)
+
+        then:
+        coeffs.length == 4
+        coeffs.every { it == 0.0d }
+    }
+
     static void assertEquals(double actual, double expected) {
         assert abs(actual - expected) < EPSILON
     }

--- a/math/src/test/groovy/me/champeau/a4j/math/opencl/GpuOpKernelLifetimeTest.groovy
+++ b/math/src/test/groovy/me/champeau/a4j/math/opencl/GpuOpKernelLifetimeTest.groovy
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.math.opencl
+
+import spock.lang.Requires
+import spock.lang.Specification
+
+import java.util.function.Consumer
+
+import static org.lwjgl.opencl.CL10.CL_MEM_READ_WRITE
+
+/**
+ * Regression tests for kernel-handle lifetime in {@link GpuOp}.
+ *
+ * Background: OpenCL stores kernel arguments on the kernel object itself and
+ * reads them when the kernel actually executes on the device, not when it is
+ * enqueued. Returning a handle to the manager pool right after
+ * {@code clEnqueueNDRangeKernel} would let a concurrent op re-borrow it and
+ * call {@code clSetKernelArg} on it before the previously-enqueued execution
+ * has run — corrupting the in-flight kernel's args and causing native
+ * crashes. The fix: GpuOp keeps the borrowed handle out of the pool until
+ * its {@code close()} drains the queue via {@code clFinish}.
+ */
+@Requires({ OpenCLSupport.isAvailable() })
+class GpuOpKernelLifetimeTest extends Specification {
+
+    private static final String PROGRAM = "arithmetic"
+    private static final String KERNEL = "add_scalar"
+
+    private OpenCLContext context
+    private OpenCLKernelManager manager
+    private List<Long> drained
+
+    def setup() {
+        context = OpenCLSupport.getContext()
+        manager = context.getKernelManager()
+        // Drain the pool for this kernel so we have a deterministic baseline.
+        drained = []
+        while (manager.poolSize(PROGRAM, KERNEL) > 0) {
+            drained << manager.borrow(PROGRAM, KERNEL)
+        }
+    }
+
+    def cleanup() {
+        drained.each { manager.release(PROGRAM, KERNEL, it) }
+    }
+
+    def "borrowed kernel handle stays out of the pool until the runOp closes"() {
+        given:
+        int poolWhileOpen = -1
+
+        when: "we run a kernel inside a runOp body and inspect the pool from inside the body"
+        context.runOp({ op ->
+            long buf = op.allocateBuffer(4 * Float.BYTES, CL_MEM_READ_WRITE)
+            op.kernel(PROGRAM, KERNEL)
+                    .arg(buf).arg(0f).arg(buf).arg(4)
+                    .run(4)
+            poolWhileOpen = manager.poolSize(PROGRAM, KERNEL)
+        } as Consumer)
+
+        then: "the handle is held by the op, not yet returned to the pool"
+        poolWhileOpen == 0
+
+        and: "after the runOp closes, the handle is returned to the pool"
+        manager.poolSize(PROGRAM, KERNEL) == 1
+    }
+
+    def "multiple kernel calls in one runOp consume distinct handles"() {
+        given:
+        int poolAfterFirst = -1
+        int poolAfterSecond = -1
+
+        when: "two kernel calls in the same runOp body, with no clFinish between them"
+        context.runOp({ op ->
+            long buf = op.allocateBuffer(4 * Float.BYTES, CL_MEM_READ_WRITE)
+            op.kernel(PROGRAM, KERNEL)
+                    .arg(buf).arg(0f).arg(buf).arg(4)
+                    .run(4)
+            poolAfterFirst = manager.poolSize(PROGRAM, KERNEL)
+
+            op.kernel(PROGRAM, KERNEL)
+                    .arg(buf).arg(1f).arg(buf).arg(4)
+                    .run(4)
+            poolAfterSecond = manager.poolSize(PROGRAM, KERNEL)
+        } as Consumer)
+
+        then: "neither handle was recycled while the op was still open"
+        poolAfterFirst == 0
+        poolAfterSecond == 0
+
+        and: "both handles are released back to the pool after close"
+        manager.poolSize(PROGRAM, KERNEL) == 2
+    }
+
+    def "a concurrent op cannot borrow the in-flight handle"() {
+        given:
+        long innerBorrow = 0L
+
+        when: "while one op is still open, another caller borrows the same kernel from the manager"
+        context.runOp({ op ->
+            long buf = op.allocateBuffer(4 * Float.BYTES, CL_MEM_READ_WRITE)
+            op.kernel(PROGRAM, KERNEL)
+                    .arg(buf).arg(0f).arg(buf).arg(4)
+                    .run(4)
+            // Simulate a concurrent op grabbing the same (program, kernel)
+            // from the pool. With the fix, the pool is empty, so the manager
+            // creates a fresh handle distinct from the one the op holds.
+            innerBorrow = manager.borrow(PROGRAM, KERNEL)
+            manager.release(PROGRAM, KERNEL, innerBorrow)
+        } as Consumer)
+
+        then: "the second borrow had to allocate a new handle (pool was empty)"
+        innerBorrow != 0L
+
+        and: "after close, both handles are pooled"
+        manager.poolSize(PROGRAM, KERNEL) == 2
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ rootProject.name = "astro4j-parent"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 include("docs")
+include("utilities")
 include("jserfile")
 include("ser-player")
 include("math")

--- a/utilities/build.gradle.kts
+++ b/utilities/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    id("me.champeau.astro4j.library")
+}
+
+description = "Shared low-level utilities (memory budget, heap pressure)"

--- a/utilities/src/main/java/me/champeau/a4j/utilities/HeapPressure.java
+++ b/utilities/src/main/java/me/champeau/a4j/utilities/HeapPressure.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.utilities;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * JVM-wide heap pressure ratio cache. Returns
+ * {@code (totalMemory - freeMemory) / totalMemory}, refreshed at most once
+ * every {@value #REFRESH_INTERVAL_NS} ns. Lock-free fast path: a single
+ * atomic read.
+ *
+ * <p>Heap pressure is a process-global signal — sharing one cached snapshot
+ * across all callers avoids redundant {@code Runtime} probes when several
+ * subsystems sample within the same window.
+ */
+public final class HeapPressure {
+    private static final long REFRESH_INTERVAL_NS = 100_000_000L; // 100 ms
+
+    private record Snapshot(double ratio, long takenAtNs) {
+    }
+
+    private static final AtomicReference<Snapshot> REF = new AtomicReference<>();
+
+    private HeapPressure() {
+    }
+
+    /**
+     * Current heap pressure ratio: {@code (totalMemory - freeMemory) / totalMemory}.
+     * {@code 0} means the currently-committed heap is empty; {@code 1} means the
+     * currently-committed heap is full and the GC is about to either reclaim or
+     * commit more memory from the OS. Using committed (not max) as the denominator
+     * keeps the signal meaningful across a wide range of host RAM sizes — on a
+     * 128 GB box where {@code -Xmx} is set very high, {@code used/max} stays low
+     * even when the JVM has already grabbed tens of GB from the OS.
+     */
+    public static double current() {
+        var snap = REF.get();
+        long now = System.nanoTime();
+        if (snap != null && now - snap.takenAtNs() < REFRESH_INTERVAL_NS) {
+            return snap.ratio();
+        }
+        var rt = Runtime.getRuntime();
+        long total = rt.totalMemory();
+        double ratio = total == 0 ? 0.0 : (double) (total - rt.freeMemory()) / total;
+        REF.lazySet(new Snapshot(ratio, now));
+        return ratio;
+    }
+}

--- a/utilities/src/main/java/module-info.java
+++ b/utilities/src/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Shared low-level utilities (heap pressure sampling, float array allocator).
+ */
+module me.champeau.a4j.utilities {
+    requires jdk.jfr;
+    exports me.champeau.a4j.utilities;
+}


### PR DESCRIPTION
This branch reduces allocation pressure, GC overhead and lock contention in the hot paths of the processing pipeline.

Float arrays are now obtained from a singleton pool shared across reconstruction, background neutralization, regression, convolution during phenomena detection, image drawing and SER frame reading, replacing many short-lived buffers and removing the explicit System.gc calls that used to compensate for them. FileBackedImage was reworked to behave well under ZGC.

Reconstruction view updates are now lock-free, image emission is asynchronous, GPU operations no longer serialize on a single global lock, and SER frame reading avoids the double copy it used to do. AbstractTask no longer takes defensive copies, IntPair allocation in the color curve was removed, and a specialized k-order regression avoids intermediate arrays.

A few related correctness issues were fixed along the way: non reproducible flare detection, unnecessary SER reopens and broken parallelism in the main video processor.