### PR TITLE
fix: Center viewport when double clicking

### DIFF
--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ZoomableImageView.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/jfx/ZoomableImageView.java
@@ -96,13 +96,23 @@ public class ZoomableImageView extends HBox {
         imageView.setOnMouseClicked(evt -> {
             if (evt.getButton().equals(MouseButton.PRIMARY)) {
                 if (evt.getClickCount() == 2) {
+                    var image = imageView.getImage();
+                    if (image == null) {
+                        return;
+                    }
+                    double imageX = evt.getX() / zoom;
+                    double imageY = evt.getY() / zoom;
+                    boolean zoomingIn = zoom != 1.0;
                     if (zoom == 1.0) {
-                        zoom = getWidth() / imageView.getImage().getWidth();
+                        zoom = getWidth() / image.getWidth();
                     } else {
                         zoom = 1.0;
                     }
                     applyZoom();
                     triggerOnZoomChanged();
+                    if (zoomingIn) {
+                        centerViewportOn(imageX, imageY);
+                    }
                 } else if (evt.getClickCount() == 1 && onClickListener != null) {
                     int imageX = (int) Math.round(evt.getX() / zoom);
                     int imageY = (int) Math.round(evt.getY() / zoom);
@@ -474,6 +484,29 @@ public class ZoomableImageView extends HBox {
         var boundsInLocal = imageView.getBoundsInLocal();
         scrollPane.setPrefViewportWidth(boundsInLocal.getWidth());
         scrollPane.setPrefViewportHeight(boundsInLocal.getHeight());
+    }
+
+    private void centerViewportOn(double imageX, double imageY) {
+        var image = imageView.getImage();
+        if (image == null) {
+            return;
+        }
+        scrollPane.layout();
+        var viewportBounds = scrollPane.getViewportBounds();
+        double viewportWidth = viewportBounds.getWidth();
+        double viewportHeight = viewportBounds.getHeight();
+        double contentWidth = image.getWidth() * zoom;
+        double contentHeight = image.getHeight() * zoom;
+        double hmax = Math.max(0, contentWidth - viewportWidth);
+        double vmax = Math.max(0, contentHeight - viewportHeight);
+        if (hmax > 0) {
+            double targetX = imageX * zoom - viewportWidth / 2.0;
+            scrollPane.setHvalue(Math.max(0, Math.min(1, targetX / hmax)));
+        }
+        if (vmax > 0) {
+            double targetY = imageY * zoom - viewportHeight / 2.0;
+            scrollPane.setVvalue(Math.max(0, Math.min(1, targetY / vmax)));
+        }
     }
 
     public void setRectangleSelectionListener(RectangleSelectionListener rectangleSelectionListener) {

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -6,6 +6,7 @@
 - Colorized images now use a more even tonal range thanks to a revised stretching pipeline.
 - Images in the sidebar can now be renamed via the right-click menu to disambiguate them in collages.
 - The `dedistort` ImageMath function gained a `drizzle` parameter (any value between 1 and 4, e.g. 1.5, 2, 3) that produces a super-resolved output to recover detail under excellent seeing.
+- Double-clicking an image to zoom in at 1:1 now centers the viewport on the clicked point.
 
 ## What's New in Version 5.1.3
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -6,6 +6,7 @@
 - Les images colorisées bénéficient désormais d'une plage tonale plus équilibrée grâce à une chaîne d'étirement revue.
 - Les images dans la barre latérale peuvent désormais être renommées via le menu contextuel (clic droit) pour les distinguer dans les collages.
 - La fonction ImageMath `dedistort` accepte désormais un paramètre `drizzle` (toute valeur entre 1 et 4, par ex. 1.5, 2, 3) qui produit une image super-résolue pour récupérer des détails sous d'excellentes conditions.
+- Le double-clic sur une image pour zoomer à 1:1 centre désormais la vue sur le point cliqué.
 
 ## Nouveautés de la version 5.1.3
 


### PR DESCRIPTION
This commit fixes the behavior of the zoom when double clicking. Before this change, double clicking changed the zoom level, but didn't center the image when the click happened.