### PR TITLE
fix: Use sigmoid weights on local dedistortion

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Stacking.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Stacking.java
@@ -58,6 +58,9 @@ public class Stacking extends AbstractFunctionImpl {
     private static final String STACKING_MESSAGE = message("stacking");
     private static final String FIND_CORRESP_MESSAGE = message("finding.correspondances");
     private static final double DECAY_RATE = -2.0;
+    // Width of the soft selection transition, as a fraction of the local weight spread. Larger =
+    // smoother fade between kept and dropped frames (fewer seams, but less aggressive selection).
+    private static final double SOFT_SELECTION_SOFTNESS = 0.3;
     public static final int DEFAULT_TILE_SIZE = 32;
     public static final float DEFAULT_SAMPLING = .5f;
     public static final double DEFAULT_SELECTION_RATIO = 1;
@@ -240,20 +243,35 @@ public class Stacking extends AbstractFunctionImpl {
                         }
 
                         if (localMaxError > 0 && maxSharpness > 0) {
-                            var weightsAndIndices = new double[imagesWithError.size()][2];
-                            for (int i = 0; i < imagesWithError.size(); i++) {
+                            var n = imagesWithError.size();
+                            var weights = new double[n];
+                            for (int i = 0; i < n; i++) {
                                 var errorWeight = Math.exp(DECAY_RATE * localErrors[i] / localMaxError);
                                 var sharpnessWeight = localSharpness[i] / maxSharpness;
-                                weightsAndIndices[i][0] = errorWeight * sharpnessWeight;
-                                weightsAndIndices[i][1] = i;
+                                weights[i] = errorWeight * sharpnessWeight;
                             }
-                            Arrays.sort(weightsAndIndices, (a, b) -> Double.compare(b[0], a[0]));
-
-                            for (int i = 0; i < maxImagesToKeep; i++) {
-                                var weight = weightsAndIndices[i][0];
-                                var idx = (int) weightsAndIndices[i][1];
-                                sum += weight * imagesWithError.get(idx).image().data()[y][x];
-                                weightSum += weight;
+                            if (maxImagesToKeep >= n) {
+                                for (int i = 0; i < n; i++) {
+                                    sum += weights[i] * imagesWithError.get(i).image().data()[y][x];
+                                    weightSum += weights[i];
+                                }
+                            } else {
+                                // Soft selection: instead of a hard top-K cutoff (which makes the set of
+                                // contributing frames change abruptly across the image, producing visible
+                                // seam/line artifacts), fade frames in and out with a smooth sigmoid mask
+                                // centred on the ratio cut. This keeps the lucky-imaging benefit while
+                                // making the per-pixel weighting continuous, so no seams appear.
+                                var keep = Math.max(1, maxImagesToKeep);
+                                var sorted = weights.clone();
+                                Arrays.sort(sorted);
+                                var threshold = 0.5 * (sorted[n - keep] + sorted[n - keep - 1]);
+                                var band = SOFT_SELECTION_SOFTNESS * (sorted[n - 1] - sorted[0]) + 1e-9;
+                                for (int i = 0; i < n; i++) {
+                                    var mask = 1.0 / (1.0 + Math.exp(-(weights[i] - threshold) / band));
+                                    var weight = weights[i] * mask;
+                                    sum += weight * imagesWithError.get(i).image().data()[y][x];
+                                    weightSum += weight;
+                                }
                             }
                         } else {
                             for (int i = 0; i < maxImagesToKeep; i++) {

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -1,5 +1,9 @@
 # Welcome to JSol'Ex {{version}}!
 
+## What's New in Version 5.3.4
+
+- Fixed line artifacts that could appear when stacking with local dedistortion enabled.
+
 ## What's New in Version 5.3.3
 
 - Fixed Helium D3 images that were not generated in some cases when the reference line was not in the middle of the frame.

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -1,5 +1,9 @@
 # Bienvenue dans JSol'Ex {{version}} !
 
+## Nouveautés de la version 5.3.4
+
+- Correction d'artefacts en forme de lignes pouvant apparaître lors de l'empilement avec la dédistorsion locale activée.
+
 ## Nouveautés de la version 5.3.3
 
 - Correction des images Hélium qui n'étaient parfois pas générées lorsque la ligne de référence était trop proche du bord de l'image.


### PR DESCRIPTION
The ratio factor becomes a baseline rather than an absolute cutoff. Previously, neighbouring regions could select very different images (e.g. with different illumination), producing line artifacts at the boundaries.

Now all images contribute, with a weight that fades around the ratio threshold, so the blend is smooth and seam-free.