### PR TITLE
feat: Add deghost function

### DIFF
--- a/jsolex-core/src/main/functions/deghost.yml
+++ b/jsolex-core/src/main/functions/deghost.yml
@@ -1,0 +1,29 @@
+name: DEGHOST
+category: ENHANCEMENT
+description:
+  fr: "Atténue le reflet unilatéral (fantôme) du disque solaire en soustrayant une estimation lisse de son excès de luminosité, sans supprimer les détails sous-jacents. Tout est déduit de l'image, sans paramètre de position."
+  en: "Attenuates a one-sided reflection (ghost) of the solar disk by subtracting a smooth estimate of its excess brightness, without removing the underlying detail. Everything is derived from the image, with no position parameter."
+arguments:
+  - name: img
+    description: Image(s)
+  - name: strength
+    optional: true
+    default: 1.0
+    description:
+      fr: "Force de l'atténuation (0 désactive)."
+      en: "Attenuation strength (0 disables)."
+  - name: iterations
+    optional: true
+    default: 1
+    description:
+      fr: "Nombre de passes ; plus de passes atténuent davantage le reflet."
+      en: "Number of passes; more passes attenuate the reflection further."
+  - name: debug
+    optional: true
+    default: 0
+    description:
+      fr: "Affiche l'estimation du reflet retiré au lieu de la soustraire (pour le réglage)."
+      en: "Shows the estimated reflection that would be removed instead of subtracting it (for tuning)."
+examples:
+  - "deghost(img(0))"
+  - "deghost(img: some_image, strength: 0.8, iterations: 3)"

--- a/jsolex-core/src/main/functions/fix_banding.yml
+++ b/jsolex-core/src/main/functions/fix_banding.yml
@@ -14,6 +14,12 @@ arguments:
     description:
       fr: "Nombre de passes"
       en: "Number of passes"
+  - name: ellipseMode
+    optional: true
+    default: 1
+    description:
+      fr: "Utilisation du disque solaire : 0 = ignoré (tous les pixels de la ligne), 1 = pixels du disque (défaut), 2 = pixels hors du disque uniquement."
+      en: "Solar disk usage: 0 = ignored (all pixels in the line), 1 = pixels inside the disk (default), 2 = pixels outside the disk only."
 examples:
   - "fix_banding(img(0), 64, 3)"
-  - "fix_banding(img: img(0), bs: 48, passes: 10)"
+  - "fix_banding(img: img(0), bs: 48, passes: 10, ellipseMode: 2)"

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
@@ -53,6 +53,7 @@ import me.champeau.a4j.jsolex.processing.expr.impl.PolyFit2D;
 import me.champeau.a4j.jsolex.processing.expr.impl.PythonScript;
 import me.champeau.a4j.jsolex.processing.expr.impl.RGBCombination;
 import me.champeau.a4j.jsolex.processing.expr.impl.RemoteScriptGen;
+import me.champeau.a4j.jsolex.processing.expr.impl.Deghost;
 import me.champeau.a4j.jsolex.processing.expr.impl.Rotate;
 import me.champeau.a4j.jsolex.processing.expr.impl.Saturation;
 import me.champeau.a4j.jsolex.processing.expr.impl.Scaling;
@@ -152,6 +153,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
     private final PolyFit2D polyFit2D;
     private final PythonScript pythonScript;
     private final RemoteScriptGen remoteScriptGen;
+    private final Deghost deghost;
     private final Rotate rotate;
     private final Saturation saturation;
     private final Scaling scaling;
@@ -194,6 +196,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
         this.polyFit2D = new PolyFit2D(context, broadcaster);
         this.pythonScript = new PythonScript(this, context, broadcaster);
         this.remoteScriptGen = new RemoteScriptGen(this, context, broadcaster);
+        this.deghost = new Deghost(context, broadcaster);
         this.rotate = new Rotate(context, broadcaster);
         this.saturation = new Saturation(context, broadcaster);
         this.signedDiff = new SignedDiff(context, broadcaster);
@@ -416,6 +419,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
             case FIT_CANVAS -> scaling.fitCanvas(arguments);
             case RANGE -> createRange(arguments);
             case REMOVE_BG -> bgRemoval.removeBackground(arguments);
+            case DEGHOST -> deghost.deghost(arguments);
             case RESCALE_ABS -> scaling.absoluteRescale(arguments);
             case RESCALE_REL -> scaling.relativeRescale(arguments);
             case RL_DECON -> convolution.richardsonLucy(arguments);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Deghost.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Deghost.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.expr.impl;
+
+import me.champeau.a4j.jsolex.expr.BuiltinFunction;
+import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
+import me.champeau.a4j.jsolex.processing.util.FileBackedImage;
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
+import me.champeau.a4j.math.image.ImageMath;
+import me.champeau.a4j.math.regression.Ellipse;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Attenuates a one-sided reflection (ghost) of the solar disk. The reflection is the excess of each pixel over its
+ * point reflection through the disk centre (which cancels everything symmetric); smoothing that excess heavily along
+ * the limb keeps the broad reflection band while dropping the fine radial detail, so subtracting it removes the
+ * reflection and leaves the underlying detail untouched. Everything is derived from the image relative to the disk
+ * radius, so nothing is fitted to a particular frame.
+ */
+public class Deghost extends AbstractFunctionImpl {
+
+    private static final int AZIMUTH_SAMPLES = 720;
+    private static final int RADIAL_SAMPLES = 240;
+    private static final double SAMPLE_RADIUS = 1.35;      // sample the excess out to this (× R)
+    private static final double OUTER_RADIUS = 1.30;       // subtraction taper ends here (× R)
+    private static final double OUTER_FEATHER = 0.15;      // taper width (× R)
+    private static final double INNER_FEATHER = 0.015;     // limb feather (× R)
+    private static final double AZIMUTH_SIGMA_BINS = 30;   // ≈ 15° smoothing along the limb
+    private static final double RADIAL_SIGMA_BINS = 3;
+
+    private record Disk(double cx, double cy, double radius) {
+    }
+
+    public Deghost(Map<Class<?>, Object> context, Broadcaster broadcaster) {
+        super(context, broadcaster);
+    }
+
+    public Object deghost(Map<String, Object> arguments) {
+        BuiltinFunction.DEGHOST.validateArgs(arguments);
+        var arg = arguments.get("img");
+        if (arg instanceof List<?>) {
+            return expandToImageList("deghost", "img", arguments, this::deghost);
+        }
+        if (arg instanceof FileBackedImage fileBackedImage) {
+            arg = fileBackedImage.unwrapToMemory();
+        }
+        if (!(arg instanceof ImageWrapper32)) {
+            throw new IllegalArgumentException("deghost only supports mono images");
+        }
+        var ellipse = getEllipse(arguments, "ellipse");
+        if (ellipse.isEmpty()) {
+            throw new IllegalArgumentException("Cannot remove the reflection because the solar disk wasn't found");
+        }
+        var e = ellipse.get();
+        var strength = doubleArg(arguments, "strength", 1.0);
+        var iterations = Math.max(1, intArg(arguments, "iterations", 1));
+        var debug = booleanArg(arguments, "debug", false);
+        return monoToMonoImageTransformer("deghost", "img", arguments, src -> {
+            if (src instanceof ImageWrapper32 image) {
+                var passes = debug ? 1 : iterations;
+                for (int i = 0; i < passes; i++) {
+                    apply(image, e, strength, debug);
+                }
+            } else {
+                throw new IllegalArgumentException("deghost only supports mono images");
+            }
+        });
+    }
+
+    private void apply(ImageWrapper32 image, Ellipse ellipse, double strength, boolean debug) {
+        if (strength <= 0 && !debug) {
+            return;
+        }
+        var data = image.data();
+        var center = ellipse.center();
+        var semiAxis = ellipse.semiAxis();
+        var disk = new Disk(center.a(), center.b(), (semiAxis.a() + semiAxis.b()) / 2.0);
+        if (disk.radius() <= 0) {
+            return;
+        }
+        var reflection = estimateReflection(data, disk);
+
+        var height = data.length;
+        var width = data[0].length;
+        var cx = disk.cx();
+        var cy = disk.cy();
+        var radius = disk.radius();
+        var innerWidth = Math.max(1.0, INNER_FEATHER * radius);
+        var outerFeather = Math.max(1.0, OUTER_FEATHER * radius);
+        var outerR = OUTER_RADIUS * radius;
+        var yFrom = Math.max(0, (int) Math.floor(cy - outerR));
+        var yTo = Math.min(height - 1, (int) Math.ceil(cy + outerR));
+        var xFrom = Math.max(0, (int) Math.floor(cx - outerR));
+        var xTo = Math.min(width - 1, (int) Math.ceil(cx + outerR));
+        for (int y = yFrom; y <= yTo; y++) {
+            for (int x = xFrom; x <= xTo; x++) {
+                var dx = x - cx;
+                var dy = y - cy;
+                var r = Math.sqrt(dx * dx + dy * dy);
+                if (r <= radius || r > outerR) {
+                    continue;
+                }
+                var mask = smoothstep((r - radius) / innerWidth) * smoothstep((outerR - r) / outerFeather);
+                if (mask <= 0) {
+                    continue;
+                }
+                var removed = strength * reflection[y][x] * mask;
+                if (debug) {
+                    data[y][x] = (float) removed;
+                } else if (removed > 0) {
+                    var value = data[y][x] - removed;
+                    data[y][x] = value > 0 ? (float) value : 0f;
+                }
+            }
+        }
+    }
+
+    /**
+     * Builds the one-sided reflection band: the per-pixel excess over its point reflection through the disk centre,
+     * sampled on a polar grid around the disk, smoothed heavily along the limb (which keeps the broad reflection and
+     * drops the fine radial structure), then mapped back to image space.
+     */
+    private float[][] estimateReflection(float[][] data, Disk disk) {
+        var height = data.length;
+        var width = data[0].length;
+        var cx = disk.cx();
+        var cy = disk.cy();
+        var radius = disk.radius();
+        var innerR = radius;
+        var outerR = SAMPLE_RADIUS * radius;
+
+        var polar = new double[RADIAL_SAMPLES][AZIMUTH_SAMPLES];
+        for (int ir = 0; ir < RADIAL_SAMPLES; ir++) {
+            var r = innerR + (ir / (double) (RADIAL_SAMPLES - 1)) * (outerR - innerR);
+            for (int it = 0; it < AZIMUTH_SAMPLES; it++) {
+                var th = -Math.PI + it * (2 * Math.PI / AZIMUTH_SAMPLES);
+                var px = cx + r * Math.cos(th);
+                var py = cy + r * Math.sin(th);
+                var value = ImageMath.bilinear2D(data, px, py, width, height);
+                var mirror = ImageMath.bilinear2D(data, 2 * cx - px, 2 * cy - py, width, height);
+                polar[ir][it] = Math.max(0, value - mirror);
+            }
+        }
+        smoothAzimuthal(polar, AZIMUTH_SIGMA_BINS);
+        smoothRadial(polar, RADIAL_SIGMA_BINS);
+
+        var reflection = new float[height][width];
+        var yFrom = Math.max(0, (int) Math.floor(cy - outerR));
+        var yTo = Math.min(height - 1, (int) Math.ceil(cy + outerR));
+        var xFrom = Math.max(0, (int) Math.floor(cx - outerR));
+        var xTo = Math.min(width - 1, (int) Math.ceil(cx + outerR));
+        for (int y = yFrom; y <= yTo; y++) {
+            for (int x = xFrom; x <= xTo; x++) {
+                var dx = x - cx;
+                var dy = y - cy;
+                var r = Math.sqrt(dx * dx + dy * dy);
+                if (r < innerR || r > outerR) {
+                    continue;
+                }
+                var th = Math.atan2(dy, dx);
+                var fr = (r - innerR) / (outerR - innerR) * (RADIAL_SAMPLES - 1);
+                var ft = (th + Math.PI) / (2 * Math.PI) * AZIMUTH_SAMPLES;
+                reflection[y][x] = (float) samplePolar(polar, fr, ft);
+            }
+        }
+        return reflection;
+    }
+
+    private static void smoothAzimuthal(double[][] polar, double sigma) {
+        var kernel = gaussianKernel(sigma);
+        var half = kernel.length / 2;
+        var nt = polar[0].length;
+        var row = new double[nt];
+        for (var radial : polar) {
+            System.arraycopy(radial, 0, row, 0, nt);
+            for (int it = 0; it < nt; it++) {
+                var sum = 0.0;
+                for (int k = -half; k <= half; k++) {
+                    var idx = ((it + k) % nt + nt) % nt;
+                    sum += row[idx] * kernel[k + half];
+                }
+                radial[it] = sum;
+            }
+        }
+    }
+
+    private static void smoothRadial(double[][] polar, double sigma) {
+        var kernel = gaussianKernel(sigma);
+        var half = kernel.length / 2;
+        var nr = polar.length;
+        var nt = polar[0].length;
+        var col = new double[nr];
+        for (int it = 0; it < nt; it++) {
+            for (int ir = 0; ir < nr; ir++) {
+                col[ir] = polar[ir][it];
+            }
+            for (int ir = 0; ir < nr; ir++) {
+                var sum = 0.0;
+                var weight = 0.0;
+                for (int k = -half; k <= half; k++) {
+                    var idx = ir + k;
+                    if (idx < 0 || idx >= nr) {
+                        continue;
+                    }
+                    sum += col[idx] * kernel[k + half];
+                    weight += kernel[k + half];
+                }
+                polar[ir][it] = sum / weight;
+            }
+        }
+    }
+
+    private static double[] gaussianKernel(double sigma) {
+        var radius = Math.max(1, (int) Math.ceil(3 * sigma));
+        var kernel = new double[2 * radius + 1];
+        var sum = 0.0;
+        for (int i = -radius; i <= radius; i++) {
+            var v = Math.exp(-(i * i) / (2 * sigma * sigma));
+            kernel[i + radius] = v;
+            sum += v;
+        }
+        for (int i = 0; i < kernel.length; i++) {
+            kernel[i] /= sum;
+        }
+        return kernel;
+    }
+
+    private static double samplePolar(double[][] polar, double fr, double ft) {
+        var nr = polar.length;
+        var nt = polar[0].length;
+        fr = Math.max(0, Math.min(nr - 1.0001, fr));
+        var r0 = (int) Math.floor(fr);
+        var r1 = Math.min(r0 + 1, nr - 1);
+        var wr = fr - r0;
+        var t0 = ((int) Math.floor(ft) % nt + nt) % nt;
+        var t1 = (t0 + 1) % nt;
+        var wt = ft - Math.floor(ft);
+        var top = polar[r0][t0] * (1 - wt) + polar[r0][t1] * wt;
+        var bottom = polar[r1][t0] * (1 - wt) + polar[r1][t1] * wt;
+        return top * (1 - wr) + bottom * wr;
+    }
+
+    private static double smoothstep(double x) {
+        var t = x < 0 ? 0 : (x > 1 ? 1 : x);
+        return t * t * (3 - 2 * t);
+    }
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/FixBanding.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/FixBanding.java
@@ -20,8 +20,10 @@ import me.champeau.a4j.jsolex.processing.sun.BandingReduction;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.ProcessingException;
+import me.champeau.a4j.math.regression.Ellipse;
 
 import java.util.Map;
+import java.util.Optional;
 
 public class FixBanding extends AbstractFunctionImpl {
     public FixBanding(Map<Class<?>, Object> context, Broadcaster broadcaster) {
@@ -30,7 +32,12 @@ public class FixBanding extends AbstractFunctionImpl {
 
     public Object fixBanding(Map<String ,Object> arguments) {
         BuiltinFunction.FIX_BANDING.validateArgs(arguments);
-        var ellipse = getEllipse(arguments, "ellipse");
+        var mode = switch (intArg(arguments, "ellipseMode", 1)) {
+            case 0 -> BandingReduction.Mode.WHOLE_LINE;
+            case 2 -> BandingReduction.Mode.OUTSIDE_DISK;
+            default -> BandingReduction.Mode.INSIDE_DISK;
+        };
+        var ellipse = mode == BandingReduction.Mode.WHOLE_LINE ? Optional.<Ellipse>empty() : getEllipse(arguments, "ellipse");
         int bandSize = intArg(arguments, "bs", 32);
         int passes = intArg(arguments, "passes", 1);
         return monoToMonoImageTransformer( "fix_banding", "img", arguments, src -> {
@@ -39,7 +46,7 @@ public class FixBanding extends AbstractFunctionImpl {
                 var height = image.height();
                 var data = image.data();
                 for (int i = 0; i < passes; i++) {
-                    BandingReduction.reduceBanding(width, height, data, bandSize, ellipse.orElse(null));
+                    BandingReduction.reduceBanding(width, height, data, bandSize, ellipse.orElse(null), mode);
                 }
             } else {
                 throw new ProcessingException("fix_banding can only be applied to mono images");

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/PolyFit2D.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/PolyFit2D.java
@@ -20,8 +20,9 @@ import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.util.FileBackedImage;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
-import me.champeau.a4j.math.matrix.DoubleMatrix;
 import me.champeau.a4j.math.regression.Ellipse;
+import me.champeau.a4j.math.regression.LeastSquares;
+import me.champeau.a4j.math.regression.Polynomial2D;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -71,10 +72,9 @@ public class PolyFit2D extends AbstractFunctionImpl {
         var width = img.width();
         var height = img.height();
         var data = img.data();
-        var polyTerms = (degree + 1) * (degree + 2) / 2;
-
-        var xtx = new double[polyTerms][polyTerms];
-        var xty = new double[polyTerms];
+        var polyTerms = Polynomial2D.termCount(degree);
+        var basis = new double[polyTerms];
+        var fit = new LeastSquares(polyTerms);
         var fitRadius = 0.97 * radius;
         var fitRadius2 = fitRadius * fitRadius;
         for (int y = 0; y < height; y++) {
@@ -84,37 +84,13 @@ public class PolyFit2D extends AbstractFunctionImpl {
                 if (px * px + py * py >= fitRadius2) {
                     continue;
                 }
-                var dx = px / radius;
-                var dy = py / radius;
-                var value = data[y][x];
-                var terms = polyTerms2D(dx, dy, degree, polyTerms);
-                for (int i = 0; i < polyTerms; i++) {
-                    xty[i] += terms[i] * value;
-                    for (int j = i; j < polyTerms; j++) {
-                        xtx[i][j] += terms[i] * terms[j];
-                    }
-                }
+                Polynomial2D.terms(px / radius, py / radius, degree, basis);
+                fit.add(basis, data[y][x]);
             }
         }
-        for (int i = 1; i < polyTerms; i++) {
-            for (int j = 0; j < i; j++) {
-                xtx[i][j] = xtx[j][i];
-            }
-        }
-
-        double[] coeffs;
-        try {
-            var xtyMatrix = new double[polyTerms][1];
-            for (int i = 0; i < polyTerms; i++) {
-                xtyMatrix[i][0] = xty[i];
-            }
-            var result = DoubleMatrix.of(xtx).inverse().mul(DoubleMatrix.of(xtyMatrix)).asArray();
-            coeffs = new double[polyTerms];
-            for (int i = 0; i < polyTerms; i++) {
-                coeffs[i] = result[i][0];
-            }
-        } catch (Exception e) {
-            throw new IllegalStateException("poly_fit_2d: failed to solve normal equations", e);
+        var coeffs = fit.solve();
+        if (coeffs == null) {
+            throw new IllegalStateException("poly_fit_2d: failed to solve normal equations");
         }
 
         var radius2 = radius * radius;
@@ -126,28 +102,9 @@ public class PolyFit2D extends AbstractFunctionImpl {
                 if (px * px + py * py >= radius2) {
                     continue;
                 }
-                var dx = px / radius;
-                var dy = py / radius;
-                var terms = polyTerms2D(dx, dy, degree, polyTerms);
-                double val = 0;
-                for (int i = 0; i < polyTerms; i++) {
-                    val += coeffs[i] * terms[i];
-                }
-                surface[y][x] = (float) val;
+                surface[y][x] = (float) Polynomial2D.evaluate(coeffs, px / radius, py / radius, degree, basis);
             }
         }
         return new ImageWrapper32(width, height, surface, new LinkedHashMap<>(img.metadata()));
-    }
-
-    private static double[] polyTerms2D(double dx, double dy, int degree, int numTerms) {
-        var terms = new double[numTerms];
-        int idx = 0;
-        for (int d = 0; d <= degree; d++) {
-            for (int px = d; px >= 0; px--) {
-                int py = d - px;
-                terms[idx++] = Math.pow(dx, px) * Math.pow(dy, py);
-            }
-        }
-        return terms;
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/BandingReduction.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/BandingReduction.java
@@ -45,6 +45,18 @@ public class BandingReduction {
     }
 
     /**
+     * Which pixels of each line feed the banding correction.
+     */
+    public enum Mode {
+        /** Ignore the solar disk: use all pixels of the line. */
+        WHOLE_LINE,
+        /** Use only pixels inside the solar disk. */
+        INSIDE_DISK,
+        /** Use only pixels outside the solar disk. */
+        OUTSIDE_DISK
+    }
+
+    /**
      * Reduces banding artifacts in the provided image data.
      * The algorithm computes line averages, applies multi-scale corrections,
      * and optionally constrains the operation within an elliptical region.
@@ -61,9 +73,11 @@ public class BandingReduction {
      *
      * @return the mean absolute deviation of per-line corrections from 1.0
      */
-    public static double reduceBanding(int width, int height, float[][] data, int bandSize, Ellipse ellipse) {
-        var lineAverages = lineAverages(width, height, data, ellipse);
-        var corrections = computeMultiScaleCorrections(height, lineAverages, bandSize, ellipse);
+    public static double reduceBanding(int width, int height, float[][] data, int bandSize, Ellipse ellipse, Mode mode) {
+        var effectiveEllipse = mode == Mode.WHOLE_LINE ? null : ellipse;
+        var outsideDisk = mode == Mode.OUTSIDE_DISK;
+        var lineAverages = lineAverages(width, height, data, effectiveEllipse, outsideDisk);
+        var corrections = computeMultiScaleCorrections(height, lineAverages, bandSize, effectiveEllipse);
 
         double totalDeviation = 0;
         int deviationCount = 0;
@@ -73,14 +87,14 @@ public class BandingReduction {
                 totalDeviation += Math.abs(correction - 1.0);
                 deviationCount++;
                 for (var x = 0; x < width; x++) {
-                    if (ellipse == null || ellipse.isWithin(x, y)) {
+                    if (effectiveEllipse == null || outsideDisk != effectiveEllipse.isWithin(x, y)) {
                         data[y][x] *= correction;
                     }
                 }
             }
         }
-        if (ellipse != null) {
-            bilinearSmoothing(ellipse, width, height, data);
+        if (effectiveEllipse != null && !outsideDisk) {
+            bilinearSmoothing(effectiveEllipse, width, height, data);
         }
         for (var y = 0; y < height; y++) {
             for (var x = 0; x < width; x++) {
@@ -183,21 +197,21 @@ public class BandingReduction {
         return baseWeight * poleWeight;
     }
 
-    private static double[] lineAverages(int width, int height, float[][] data, Ellipse ellipse) {
+    private static double[] lineAverages(int width, int height, float[][] data, Ellipse ellipse, boolean outsideDisk) {
         if (ellipse == null) {
             return ImageMath.newInstance().lineAverages(new Image(width, height, data));
         }
         return IntStream.range(0, height)
                 .parallel()
-                .mapToDouble(y -> lineAverage(width, y, data, ellipse))
+                .mapToDouble(y -> lineAverage(width, y, data, ellipse, outsideDisk))
                 .toArray();
     }
 
-    private static double lineAverage(int width, int y, float[][] data, Ellipse ellipse) {
+    private static double lineAverage(int width, int y, float[][] data, Ellipse ellipse, boolean outsideDisk) {
         double sum = 0;
         var count = 0;
         for (var x = 0; x < width; x++) {
-            if (ellipse.isWithin(x, y)) {
+            if (outsideDisk != ellipse.isWithin(x, y)) {
                 sum += data[y][x];
                 count++;
             }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/SolexVideoProcessor.java
@@ -945,7 +945,7 @@ public class SolexVideoProcessor implements Broadcaster {
         var buffer = rotated.data();
         var ellipse = e != null ? e.rotate(-Math.PI / 2, reconstructed.width(), reconstructed.height(), width, height) : null;
         for (int i = 0; i < passes; i++) {
-            BandingReduction.reduceBanding(width, height, buffer, bandSize, ellipse);
+            BandingReduction.reduceBanding(width, height, buffer, bandSize, ellipse, BandingReduction.Mode.INSIDE_DISK);
             broadcast(operation.update((i + 1d) / passes));
         }
         broadcast(operation.complete());

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DopplerSupport.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/DopplerSupport.java
@@ -27,8 +27,9 @@ import me.champeau.a4j.jsolex.processing.sun.tasks.GeometryCorrector;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
 import me.champeau.a4j.jsolex.processing.util.MetadataMerger;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
-import me.champeau.a4j.math.matrix.DoubleMatrix;
 import me.champeau.a4j.math.regression.Ellipse;
+import me.champeau.a4j.math.regression.LeastSquares;
+import me.champeau.a4j.math.regression.Polynomial2D;
 
 import java.util.Arrays;
 import java.util.List;
@@ -143,9 +144,7 @@ public class DopplerSupport {
         var d2 = grey2.data();
 
         // Fit a 2D polynomial of degree 3 to (d1 - d2) within the disk
-        // using normal equations: β = (XᵀX)⁻¹ Xᵀy
-        var xtx = new double[POLY_TERMS][POLY_TERMS];
-        var xty = new double[POLY_TERMS];
+        var fit = new LeastSquares(POLY_TERMS);
         var fitRadius = 0.97 * radius;
         var fitRadius2 = fitRadius * fitRadius;
         var terms = new double[POLY_TERMS];
@@ -156,36 +155,12 @@ public class DopplerSupport {
                 if (px * px + py * py >= fitRadius2) {
                     continue;
                 }
-                var dx = px / radius;
-                var dy = py / radius;
-                var diff = d1[y][x] - d2[y][x];
-                polyTerms2DInto(dx, dy, terms);
-                for (int i = 0; i < POLY_TERMS; i++) {
-                    xty[i] += terms[i] * diff;
-                    for (int j = i; j < POLY_TERMS; j++) {
-                        xtx[i][j] += terms[i] * terms[j];
-                    }
-                }
+                Polynomial2D.terms(px / radius, py / radius, POLY_DEGREE, terms);
+                fit.add(terms, d1[y][x] - d2[y][x]);
             }
         }
-        for (int i = 1; i < POLY_TERMS; i++) {
-            for (int j = 0; j < i; j++) {
-                xtx[i][j] = xtx[j][i];
-            }
-        }
-
-        double[] coeffs;
-        try {
-            var xtyMatrix = new double[POLY_TERMS][1];
-            for (int i = 0; i < POLY_TERMS; i++) {
-                xtyMatrix[i][0] = xty[i];
-            }
-            var result = DoubleMatrix.of(xtx).inverse().mul(DoubleMatrix.of(xtyMatrix)).asArray();
-            coeffs = new double[POLY_TERMS];
-            for (int i = 0; i < POLY_TERMS; i++) {
-                coeffs[i] = result[i][0];
-            }
-        } catch (Exception e) {
+        var coeffs = fit.solve();
+        if (coeffs == null) {
             return false;
         }
 
@@ -198,29 +173,12 @@ public class DopplerSupport {
                 if (px * px + py * py >= radius2) {
                     continue;
                 }
-                var dx = px / radius;
-                var dy = py / radius;
-                polyTerms2DInto(dx, dy, terms);
-                double surface = 0;
-                for (int i = 0; i < POLY_TERMS; i++) {
-                    surface += coeffs[i] * terms[i];
-                }
-                var halfCorrection = (float) (surface / 2.0);
+                var halfCorrection = (float) (Polynomial2D.evaluate(coeffs, px / radius, py / radius, POLY_DEGREE, terms) / 2.0);
                 d1[y][x] = Math.max(0, d1[y][x] - halfCorrection);
                 d2[y][x] = Math.max(0, d2[y][x] + halfCorrection);
             }
         }
         return true;
-    }
-
-    private static void polyTerms2DInto(double dx, double dy, double[] out) {
-        int idx = 0;
-        for (int d = 0; d <= POLY_DEGREE; d++) {
-            for (int px = d; px >= 0; px--) {
-                int py = d - px;
-                out[idx++] = Math.pow(dx, px) * Math.pow(dy, py);
-            }
-        }
     }
 
     static float[][][] toDopplerImage(int width, int height, ImageWrapper32 grey1, ImageWrapper32 grey2) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/HeliumLineProcessor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/HeliumLineProcessor.java
@@ -225,7 +225,7 @@ public class HeliumLineProcessor {
                     (double) iter / maxIterations,
                     message("helium.banding.reduction") + " (band=" + bandSize + ", pass=" + (iter + 1) + ")"
             ));
-            var deviation = BandingReduction.reduceBanding(image.width(), image.height(), image.data(), bandSize, ellipse);
+            var deviation = BandingReduction.reduceBanding(image.width(), image.height(), image.data(), bandSize, ellipse, BandingReduction.Mode.INSIDE_DISK);
             if (iter == 0) {
                 firstPassDeviation = deviation;
                 if (firstPassDeviation < 1e-6) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/OscillationCorrection.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/workflow/OscillationCorrection.java
@@ -19,8 +19,8 @@ import me.champeau.a4j.jsolex.processing.sun.detection.PhenomenaDetector;
 import me.champeau.a4j.jsolex.processing.util.Constants;
 import me.champeau.a4j.jsolex.processing.util.ImageInterpolation;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper32;
-import me.champeau.a4j.math.matrix.DoubleMatrix;
 import me.champeau.a4j.math.regression.Ellipse;
+import me.champeau.a4j.math.regression.LeastSquares;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -495,35 +495,19 @@ public class OscillationCorrection {
     private static Fit fitAt(double[] values, double[] weights, double frequency, int harmonics) {
         var n = values.length;
         var k = 2 + 2 * harmonics;
-        var normal = new double[k][k];
-        var rhs = new double[k][1];
         var basis = new double[k];
+        var fit = new LeastSquares(k);
         for (var y = 0; y < n; y++) {
             var weight = weights[y];
             if (weight <= 0) {
                 continue;
             }
             computeBasis(basis, y, n, frequency, harmonics);
-            for (var i = 0; i < k; i++) {
-                var wb = weight * basis[i];
-                for (var j = i; j < k; j++) {
-                    normal[i][j] += wb * basis[j];
-                }
-                rhs[i][0] += wb * values[y];
-            }
+            fit.add(basis, values[y], weight);
         }
-        for (var i = 0; i < k; i++) {
-            for (var j = 0; j < i; j++) {
-                normal[i][j] = normal[j][i];
-            }
-        }
-        var solution = DoubleMatrix.of(normal).inverse().mul(DoubleMatrix.of(rhs)).asArray();
-        var coefficients = new double[k];
-        for (var i = 0; i < k; i++) {
-            coefficients[i] = solution[i][0];
-            if (!Double.isFinite(coefficients[i])) {
-                return null;
-            }
+        var coefficients = fit.solve();
+        if (coefficients == null) {
+            return null;
         }
         double rss = 0;
         for (var y = 0; y < n; y++) {

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/impl/DeghostTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/impl/DeghostTest.groovy
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.expr.impl
+
+import me.champeau.a4j.jsolex.processing.sun.Broadcaster
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32
+import me.champeau.a4j.jsolex.processing.util.RGBImage
+import me.champeau.a4j.math.regression.Ellipse
+import me.champeau.a4j.math.tuples.DoubleSextuplet
+import spock.lang.Specification
+
+class DeghostTest extends Specification {
+
+    static final int SIZE = 400
+    static final double CX = 200
+    static final double CY = 200
+    static final double R = 120
+    // the reflection is a same-radius disk shifted to the right
+    static final double OX = CX + 30
+    static final double OY = CY
+    static final float GHOST = 800
+
+    private static double background(double x, double y) {
+        double r = Math.hypot(x - CX, y - CY)
+        return 100 + 1500 * Math.exp(-Math.max(0, r - R) / 30.0)
+    }
+
+    // reflection amplitude at a point: constant inside the ghost disk, smoothly fading to 0 at its edge
+    private static double ghostAt(double x, double y) {
+        double t = (R - Math.hypot(x - OX, y - OY)) / (0.08 * R)
+        t = Math.max(0, Math.min(1, t))
+        return GHOST * t * t * (3 - 2 * t)
+    }
+
+    private static Ellipse diskEllipse() {
+        double a = 1.0 / (R * R), c = 1.0 / (R * R), d = -2.0 * CX / (R * R), e = -2.0 * CY / (R * R)
+        double f = CX * CX / (R * R) + CY * CY / (R * R) - 1.0
+        Ellipse.ofCartesian(new DoubleSextuplet(a, 0, c, d, e, f))
+    }
+
+    private ImageWrapper32 syntheticImage() {
+        float[][] data = new float[SIZE][SIZE]
+        for (int y = 0; y < SIZE; y++) {
+            for (int x = 0; x < SIZE; x++) {
+                double v = background(x, y)
+                if (Math.hypot(x - CX, y - CY) > R) {
+                    v += ghostAt(x, y)
+                }
+                // a sharp high-frequency feature sitting inside the reflection band
+                v += 300 * Math.exp(-((x - 330) * (x - 330) + (y - 215) * (y - 215)) / (2 * 4))
+                data[y][x] = (float) v
+            }
+        }
+        def meta = new HashMap<Class<?>, Object>()
+        meta.put(Ellipse.class, diskEllipse())
+        return new ImageWrapper32(SIZE, SIZE, data, meta)
+    }
+
+    private ImageWrapper32 backgroundImage() {
+        float[][] data = new float[SIZE][SIZE]
+        for (int y = 0; y < SIZE; y++) {
+            for (int x = 0; x < SIZE; x++) {
+                data[y][x] = (float) background(x, y)
+            }
+        }
+        def meta = new HashMap<Class<?>, Object>()
+        meta.put(Ellipse.class, diskEllipse())
+        return new ImageWrapper32(SIZE, SIZE, data, meta)
+    }
+
+    // reflection side (326,200) minus its clean mirror (74,200), both at radius 126
+    private static double crescentExcess(float[][] data) {
+        return data[200][326] - data[200][74]
+    }
+
+    private static Deghost deghost() {
+        new Deghost([:] as Map<Class<?>, Object>, Broadcaster.NO_OP)
+    }
+
+    def "attenuates the reflection while preserving the sharp feature and untouched regions"() {
+        given:
+        def before = syntheticImage().data()
+
+        when:
+        def after = (deghost().deghost([img: syntheticImage()]) as ImageWrapper32).data()
+
+        then: "the reflection band is strongly attenuated"
+        double excessBefore = crescentExcess(before)
+        double excessAfter = crescentExcess(after)
+        excessBefore > 600
+        excessAfter < 0.4 * excessBefore
+
+        and: "the sharp feature remains a local peak (fine detail preserved)"
+        after[215][330] > after[209][330] + 80
+        after[215][330] > after[221][330] + 80
+
+        and: "no reflection-side pixel is dug catastrophically below the background (no hard dark ring)"
+        // the synthetic ghost has sharp azimuthal edges the smoothing over-shoots slightly; a real ring is thousands deep
+        double worst = Double.POSITIVE_INFINITY
+        for (int y = 40; y < SIZE - 40; y++) {
+            for (int x = (int) CX; x < SIZE; x++) {
+                double r = Math.hypot(x - CX, y - CY)
+                if (r > R && r < 1.3 * R) {
+                    worst = Math.min(worst, after[y][x] - background(x, y))
+                }
+            }
+        }
+        worst > -0.35 * GHOST
+
+        and: "the anti-reflection side and the interior are left untouched"
+        Math.abs(after[200][74] - before[200][74]) < 1e-3
+        Math.abs(after[100][100] - before[100][100]) < 1e-3
+    }
+
+    def "strength 0 is a no-op"() {
+        given:
+        def before = syntheticImage().data()
+
+        when:
+        def after = (deghost().deghost([img: syntheticImage(), strength: 0d]) as ImageWrapper32).data()
+
+        then:
+        Math.abs(after[200][335] - before[200][335]) < 1e-3
+    }
+
+    def "more iterations attenuate the reflection further"() {
+        given:
+        double before = crescentExcess(syntheticImage().data())
+
+        when:
+        double one = crescentExcess((deghost().deghost([img: syntheticImage(), strength: 0.5d, iterations: 1]) as ImageWrapper32).data())
+        double three = crescentExcess((deghost().deghost([img: syntheticImage(), strength: 0.5d, iterations: 3]) as ImageWrapper32).data())
+
+        then:
+        one < before
+        three < one
+        three > 0
+    }
+
+    def "no reflection leaves the image unchanged"() {
+        given:
+        def before = backgroundImage().data()
+
+        when:
+        def after = (deghost().deghost([img: backgroundImage()]) as ImageWrapper32).data()
+
+        then:
+        Math.abs(after[200][326] - before[200][326]) < 1e-3
+        Math.abs(after[100][100] - before[100][100]) < 1e-3
+    }
+
+    def "debug shows the estimated reflection instead of subtracting it"() {
+        when:
+        def dbg = (deghost().deghost([img: syntheticImage(), debug: 1]) as ImageWrapper32).data()
+
+        then: "the reflection side carries the estimate, the anti-reflection side is zero"
+        dbg[200][326] > 300
+        dbg[200][74] < 1e-3
+    }
+
+    def "handles a disk large relative to the frame (mirror sampling off-image) without crashing"() {
+        given: "a disk whose 1.35R sampling radius runs off the left edge (mirror point x < 0)"
+        int size = 300
+        double r = 130, cx = 150, cy = 150
+        float[][] data = new float[size][size]
+        for (int y = 0; y < size; y++) {
+            for (int x = 0; x < size; x++) {
+                double dist = Math.hypot(x - cx, y - cy)
+                data[y][x] = (float) (1000 + (dist > r ? 400 * Math.exp(-(dist - r) / 20.0) : 0))
+            }
+        }
+        double a = 1.0 / (r * r), c = 1.0 / (r * r), d = -2.0 * cx / (r * r), e = -2.0 * cy / (r * r)
+        double f = cx * cx / (r * r) + cy * cy / (r * r) - 1.0
+        def meta = new HashMap<Class<?>, Object>()
+        meta.put(Ellipse.class, Ellipse.ofCartesian(new DoubleSextuplet(a, 0, c, d, e, f)))
+        def img = new ImageWrapper32(size, size, data, meta)
+
+        when:
+        def result = deghost().deghost([img: img])
+
+        then:
+        noExceptionThrown()
+        result instanceof ImageWrapper32
+    }
+
+    def "rejects RGB images"() {
+        given:
+        def plane = new float[SIZE][SIZE]
+        def rgb = new RGBImage(SIZE, SIZE, plane, plane, plane, new HashMap<Class<?>, Object>())
+
+        when:
+        deghost().deghost([img: rgb])
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+}

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/sun/BandingReductionTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/sun/BandingReductionTest.groovy
@@ -28,7 +28,7 @@ class BandingReductionTest extends Specification {
         def data = createTestImage(width, height)
 
         when:
-        BandingReduction.reduceBanding(width, height, data, BandingReduction.DEFAULT_BAND_SIZE, null)
+        BandingReduction.reduceBanding(width, height, data, BandingReduction.DEFAULT_BAND_SIZE, null, BandingReduction.Mode.WHOLE_LINE)
 
         then:
         !hasNaN(data, width, height)
@@ -43,7 +43,7 @@ class BandingReductionTest extends Specification {
         def ellipse = createTestEllipse(width, height)
 
         when:
-        BandingReduction.reduceBanding(width, height, data, BandingReduction.DEFAULT_BAND_SIZE, ellipse)
+        BandingReduction.reduceBanding(width, height, data, BandingReduction.DEFAULT_BAND_SIZE, ellipse, BandingReduction.Mode.INSIDE_DISK)
 
         then:
         !hasNaN(data, width, height)
@@ -57,7 +57,7 @@ class BandingReductionTest extends Specification {
         def data = createTestImage(width, height)
 
         when:
-        BandingReduction.reduceBanding(width, height, data, bandSize, null)
+        BandingReduction.reduceBanding(width, height, data, bandSize, null, BandingReduction.Mode.WHOLE_LINE)
 
         then:
         !hasNaN(data, width, height)

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -3,6 +3,7 @@
 ## What's New in Version 5.3.4
 
 - A new "saturated disk mode" lets you reuse the spectral line polynomial from the closest non-saturated scan when the solar disk is overexposed.
+- A new `deghost` scripting function attenuates the ghost reflection of the solar disk caused by optical reflections.
 - The spectrum browser can now be overlaid on your capture software, with adjustable transparency and spectral curvature matching.
 - The spectrum browser window can now be made borderless with its controls moved to the bottom, for cleaner overlays at the top of the screen.
 - Fixed line artifacts that could appear when stacking with local dedistortion enabled.

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -3,6 +3,7 @@
 ## Nouveautés de la version 5.3.4
 
 - Un nouveau « mode disque saturé » permet de réutiliser le polynôme de la raie spectrale du scan non saturé le plus proche lorsque le disque solaire est surexposé.
+- Une nouvelle fonction de script `deghost` atténue l'image fantôme du disque solaire causée par les reflets optiques.
 - L'explorateur de spectre peut désormais être superposé à votre logiciel de capture, avec transparence réglable et correspondance de la courbure du spectre.
 - La fenêtre de l'explorateur de spectre peut désormais être affichée sans bordure avec ses contrôles déplacés en bas, pour une superposition plus propre en haut de l'écran.
 - Correction d'artefacts en forme de lignes pouvant apparaître lors de l'empilement avec la dédistorsion locale activée.

--- a/math/src/main/java/me/champeau/a4j/math/image/ImageMath.java
+++ b/math/src/main/java/me/champeau/a4j/math/image/ImageMath.java
@@ -1028,14 +1028,11 @@ public interface ImageMath {
         return image.withData(result);
     }
 
-    private static float bilinear2D(float[][] image, double xx, double yy, int width, int height) {
-        int x0 = (int) Math.floor(xx);
-        int y0 = (int) Math.floor(yy);
+    static float bilinear2D(float[][] image, double xx, double yy, int width, int height) {
+        int x0 = Math.max(0, Math.min((int) Math.floor(xx), width - 1));
+        int y0 = Math.max(0, Math.min((int) Math.floor(yy), height - 1));
         int x1 = Math.min(x0 + 1, width - 1);
         int y1 = Math.min(y0 + 1, height - 1);
-
-        x0 = Math.max(0, Math.min(x0, width - 1));
-        y0 = Math.max(0, Math.min(y0, height - 1));
 
         double fx = xx - Math.floor(xx);
         double fy = yy - Math.floor(yy);

--- a/math/src/main/java/me/champeau/a4j/math/regression/LeastSquares.java
+++ b/math/src/main/java/me/champeau/a4j/math/regression/LeastSquares.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.math.regression;
+
+import me.champeau.a4j.math.matrix.DoubleMatrix;
+
+/**
+ * Accumulates the normal equations of a linear least-squares problem and solves them.
+ * Callers add samples as {@code (basis, value)} pairs (optionally weighted) and call {@link #solve()}.
+ */
+public final class LeastSquares {
+    private final int terms;
+    private final double[][] xtx;
+    private final double[] xty;
+
+    public LeastSquares(int terms) {
+        this.terms = terms;
+        this.xtx = new double[terms][terms];
+        this.xty = new double[terms];
+    }
+
+    public void add(double[] basis, double value) {
+        add(basis, value, 1.0);
+    }
+
+    public void add(double[] basis, double value, double weight) {
+        for (int i = 0; i < terms; i++) {
+            var wb = weight * basis[i];
+            xty[i] += wb * value;
+            for (int j = i; j < terms; j++) {
+                xtx[i][j] += wb * basis[j];
+            }
+        }
+    }
+
+    /**
+     * @return the least-squares coefficients, or {@code null} if the system is singular or the solution is not finite
+     */
+    public double[] solve() {
+        for (int i = 1; i < terms; i++) {
+            for (int j = 0; j < i; j++) {
+                xtx[i][j] = xtx[j][i];
+            }
+        }
+        try {
+            var rhs = new double[terms][1];
+            for (int i = 0; i < terms; i++) {
+                rhs[i][0] = xty[i];
+            }
+            var solved = DoubleMatrix.of(xtx).inverse().mul(DoubleMatrix.of(rhs)).asArray();
+            var coeffs = new double[terms];
+            for (int i = 0; i < terms; i++) {
+                coeffs[i] = solved[i][0];
+                if (!Double.isFinite(coeffs[i])) {
+                    return null;
+                }
+            }
+            return coeffs;
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+}

--- a/math/src/main/java/me/champeau/a4j/math/regression/Polynomial2D.java
+++ b/math/src/main/java/me/champeau/a4j/math/regression/Polynomial2D.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.math.regression;
+
+/**
+ * Basis of a 2D polynomial surface, with terms ordered by ascending total degree.
+ */
+public final class Polynomial2D {
+    private Polynomial2D() {
+    }
+
+    public static int termCount(int degree) {
+        return (degree + 1) * (degree + 2) / 2;
+    }
+
+    /**
+     * Fills {@code out} (length {@link #termCount(int)}) with the polynomial basis terms for {@code (dx, dy)}.
+     */
+    public static void terms(double dx, double dy, int degree, double[] out) {
+        var xpow = new double[degree + 1];
+        var ypow = new double[degree + 1];
+        xpow[0] = 1;
+        ypow[0] = 1;
+        for (int i = 1; i <= degree; i++) {
+            xpow[i] = xpow[i - 1] * dx;
+            ypow[i] = ypow[i - 1] * dy;
+        }
+        var idx = 0;
+        for (int d = 0; d <= degree; d++) {
+            for (int px = d; px >= 0; px--) {
+                out[idx++] = xpow[px] * ypow[d - px];
+            }
+        }
+    }
+
+    /**
+     * Evaluates the surface at {@code (dx, dy)}; {@code scratch} is a reusable buffer of length {@code coeffs.length}.
+     */
+    public static double evaluate(double[] coeffs, double dx, double dy, int degree, double[] scratch) {
+        terms(dx, dy, degree, scratch);
+        var value = 0.0;
+        for (int i = 0; i < coeffs.length; i++) {
+            value += coeffs[i] * scratch[i];
+        }
+        return value;
+    }
+}

--- a/math/src/test/groovy/me/champeau/a4j/math/image/ImageMathTest.groovy
+++ b/math/src/test/groovy/me/champeau/a4j/math/image/ImageMathTest.groovy
@@ -18,6 +18,25 @@ package me.champeau.a4j.math.image
 import spock.lang.Specification
 
 class ImageMathTest extends Specification {
+
+    def "bilinear2D clamps out-of-range coordinates instead of reading negative indices"() {
+        given:
+        float[][] image = new float[][]{
+                new float[]{1, 2},
+                new float[]{3, 4}
+        }
+
+        expect: "off-image coordinates return the clamped edge value without throwing"
+        ImageMath.bilinear2D(image, x as double, y as double, 2, 2) == expected
+
+        where:
+        x    | y    || expected
+        -5d  | -5d  || 1f      // top-left corner
+        10d  | 10d  || 4f      // bottom-right corner
+        -3d  | 1d   || 3f      // off the left edge, second row
+        1d   | -3d  || 2f      // off the top edge, second column
+    }
+
     def "tests integral image (#label)"() {
         var image = new Image(5, 4, new float[][]{
                 new float[]{4, 1, 2, 2, 1},

--- a/math/src/test/groovy/me/champeau/a4j/math/regression/LeastSquaresTest.groovy
+++ b/math/src/test/groovy/me/champeau/a4j/math/regression/LeastSquaresTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.math.regression
+
+import spock.lang.Specification
+
+class LeastSquaresTest extends Specification {
+
+    def "recovers coefficients of an exact linear model"() {
+        given: "y = 3 + 2*x with basis [1, x]"
+        def fit = new LeastSquares(2)
+        [0d, 1d, 2d, 3d, 4d].each { x -> fit.add([1d, x] as double[], 3 + 2 * x) }
+
+        when:
+        double[] c = fit.solve()
+
+        then:
+        c != null
+        Math.abs(c[0] - 3) < 1e-9
+        Math.abs(c[1] - 2) < 1e-9
+    }
+
+    def "honours sample weights"() {
+        given:
+        def fit = new LeastSquares(2)
+        fit.add([1d, 0d] as double[], 1d, 2d)
+        fit.add([1d, 1d] as double[], 3d, 0.5d)
+        fit.add([1d, 2d] as double[], 5d, 1d)
+
+        when:
+        double[] c = fit.solve()
+
+        then:
+        c != null
+        Math.abs(c[0] - 1) < 1e-9
+        Math.abs(c[1] - 2) < 1e-9
+    }
+
+    def "returns null for a singular (under-determined) system"() {
+        given:
+        def fit = new LeastSquares(2)
+        fit.add([1d, 1d] as double[], 4d)
+
+        expect:
+        fit.solve() == null
+    }
+}

--- a/math/src/test/groovy/me/champeau/a4j/math/regression/Polynomial2DTest.groovy
+++ b/math/src/test/groovy/me/champeau/a4j/math/regression/Polynomial2DTest.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.math.regression
+
+import spock.lang.Specification
+
+class Polynomial2DTest extends Specification {
+
+    def "term count"() {
+        expect:
+        Polynomial2D.termCount(degree) == count
+
+        where:
+        degree | count
+        1      | 3
+        2      | 6
+        3      | 10
+    }
+
+    def "basis terms are ordered by ascending total degree"() {
+        given:
+        double[] out = new double[6]
+
+        when:
+        Polynomial2D.terms(2d, 3d, 2, out)
+
+        then: "[1, dx, dy, dx^2, dx*dy, dy^2]"
+        (out as List) == [1d, 2d, 3d, 4d, 6d, 9d]
+    }
+
+    def "evaluate reconstructs the surface value"() {
+        given:
+        double[] coeffs = [1, 2, -3, 4, 5, -6]
+        double[] scratch = new double[6]
+
+        expect: "1 + 2*2 - 3*3 + 4*4 + 5*6 - 6*9"
+        Math.abs(Polynomial2D.evaluate(coeffs, 2d, 3d, 2, scratch) - (-12)) < 1e-9
+    }
+
+    def "fitting recovers a known degree-2 surface"() {
+        given:
+        double[] truth = [1, 2, -3, 4, 5, -6]
+        double[] b = new double[6]
+        def fit = new LeastSquares(6)
+        for (int i = -3; i <= 3; i++) {
+            for (int j = -3; j <= 3; j++) {
+                Polynomial2D.terms(i, j, 2, b)
+                double z = 0
+                for (int k = 0; k < 6; k++) {
+                    z += truth[k] * b[k]
+                }
+                fit.add(b, z)
+            }
+        }
+
+        when:
+        double[] coeffs = fit.solve()
+
+        then:
+        coeffs != null
+        (0..<6).every { Math.abs(coeffs[it] - truth[it]) < 1e-6 }
+    }
+}


### PR DESCRIPTION
This function can help removing the ghost image of the solar disk that is caused by the slit. Usually this ghost image is very faint and only appears on special images such as corona imaging.