### PR TITLE
feat: Add load_sdo function to compare observations with SDO images

### DIFF
--- a/docs/src/docs/asciidoc/en/jsolex.adoc
+++ b/docs/src/docs/asciidoc/en/jsolex.adoc
@@ -859,6 +859,58 @@ This table summarizes the special variables which are exposed to ImageMath scrip
 |`keptFilesCount`|The number of files which are kept after the image review, identical to `inputFilesCount` when no image was discarded
 |===
 
+[[sdo-comparison]]
+=== Comparing with SDO images
+
+The `load_sdo` function downloads an image taken by the Solar Dynamics Observatory at the moment of your observation, which is convenient to check your own image against a space based one.
+The frame whose timestamp is the closest to the date of your observation is selected, and it is stored on your disk, so that it is only downloaded once.
+
+You have to choose the size of the frame (512, 1024, 2048 or 4096 pixels) and, optionally, the channel: `0094`, `0131`, `0171`, `0193`, `0211`, `0304`, `0335`, `1600`, `1700` and `4500` for the extreme ultraviolet and white light channels, `HMIB`, `HMIBC`, `HMII`, `HMIIC`, `HMIIF` and `HMID` for the magnetograms.
+For example, the 0094 channel shows the very hot coronal plasma, which makes it a good companion for a coronal image taken in the Fe XIV line.
+
+The position and the size of the solar disk are computed for you, so you can directly use the functions which need one, like `autocrop2`, `disk_fill`, `annulus_mask` or `radius_rescale2`.
+
+TIP: SDO images are oriented with solar north up. Your own image must therefore be rotated by the P angle, using `rotate_rad(img: your_image; angle: angleP; resize: 0)`, before the two can be compared.
+
+Here is how to lay your image and the SDO one side by side, both brought to the same disk size:
+
+[source]
+----
+[tmp]
+sdo=load_sdo(resolution: 1024; channel: "0094")
+mine=rotate_rad(img: autocrop2(img(0); 1.5); angle: angleP; resize: 0)
+
+[outputs]
+comparison=side_by_side(
+   radius_rescale2(mono(sdo); 300; 800; 800);
+   radius_rescale2(mine; 300; 800; 800)
+)
+----
+
+If you are comparing structures outside the disk, like the corona, you can hide the solar disk of the SDO image with `disk_fill(sdo; 0)`.
+
+SDO images carry their own caption in the lower left corner. To put a matching one on your own image, give `draw_text` a negative coordinate: it is then counted from the bottom, or from the right for `x`, whatever the size of the image.
+
+[source]
+----
+mine=draw_text(img: mine; x: 32; y: -32; text: "%OBSERVER% %DATETIME%"; color: "FFFFFF")
+----
+
+By default the date of your observation is used, but you can also request a particular moment, which is useful when you want to compare several observations with the same reference:
+
+[source]
+----
+sdo=load_sdo(resolution: 2048; channel: "0193"; date: "2026-07-25T10:30:00")
+----
+
+You can also pass an image instead of a date, in which case the moment it was captured is used.
+This is handy in batch mode, where each file has its own capture time:
+
+[source]
+----
+sdo=load_sdo(resolution: 1024; channel: "0171"; date: img(0))
+----
+
 [[custom-functions]]
 === Custom functions
 

--- a/docs/src/docs/asciidoc/fr/jsolex.adoc
+++ b/docs/src/docs/asciidoc/fr/jsolex.adoc
@@ -506,6 +506,58 @@ Nous avons utilisé ici une seule fonction, `range`, qui a permis de générer e
 
 Veuillez vous référer à link:imagemath.html[cette page] pour une liste complète des fonctions disponibles.
 
+[[sdo-comparison]]
+=== Comparaison avec les images de SDO
+
+La fonction `load_sdo` télécharge une image prise par le Solar Dynamics Observatory au moment de votre observation, ce qui est pratique pour confronter votre propre image à une image spatiale.
+L'image dont la date est la plus proche de celle de votre observation est sélectionnée, et elle est conservée sur votre disque, afin de n'être téléchargée qu'une seule fois.
+
+Vous devez choisir la taille de l'image (512, 1024, 2048 ou 4096 pixels) et, éventuellement, le canal : `0094`, `0131`, `0171`, `0193`, `0211`, `0304`, `0335`, `1600`, `1700` et `4500` pour les canaux en ultraviolet extrême et en lumière blanche, `HMIB`, `HMIBC`, `HMII`, `HMIIC`, `HMIIF` et `HMID` pour les magnétogrammes.
+Par exemple, le canal 0094 montre le plasma coronal très chaud, ce qui en fait un bon compagnon pour une image de la couronne prise dans la raie Fe XIV.
+
+La position et la taille du disque solaire sont calculées pour vous, vous pouvez donc utiliser directement les fonctions qui en ont besoin, comme `autocrop2`, `disk_fill`, `annulus_mask` ou `radius_rescale2`.
+
+TIP: Les images de SDO sont orientées avec le nord solaire en haut. Votre propre image doit donc être tournée de l'angle P, avec `rotate_rad(img: votre_image; angle: angleP; resize: 0)`, avant de pouvoir les comparer.
+
+Voici comment placer votre image et celle de SDO côte à côte, toutes deux ramenées à la même taille de disque :
+
+[source]
+----
+[tmp]
+sdo=load_sdo(resolution: 1024; channel: "0094")
+mienne=rotate_rad(img: autocrop2(img(0); 1.5); angle: angleP; resize: 0)
+
+[outputs]
+comparaison=side_by_side(
+   radius_rescale2(mono(sdo); 300; 800; 800);
+   radius_rescale2(mienne; 300; 800; 800)
+)
+----
+
+Si vous comparez des structures situées hors du disque, comme la couronne, vous pouvez masquer le disque solaire de l'image SDO avec `disk_fill(sdo; 0)`.
+
+Les images SDO portent leur propre légende dans le coin inférieur gauche. Pour en placer une semblable sur votre propre image, donnez une coordonnée négative à `draw_text` : elle est alors comptée depuis le bas, ou depuis la droite pour `x`, quelle que soit la taille de l'image.
+
+[source]
+----
+mienne=draw_text(img: mienne; x: 32; y: -32; text: "%OBSERVER% %DATETIME%"; color: "FFFFFF")
+----
+
+Par défaut, la date de votre observation est utilisée, mais vous pouvez aussi demander un moment particulier, ce qui est utile lorsque vous souhaitez comparer plusieurs observations à une même référence :
+
+[source]
+----
+sdo=load_sdo(resolution: 2048; channel: "0193"; date: "2026-07-25T10:30:00")
+----
+
+Vous pouvez également passer une image à la place d'une date, auquel cas le moment de sa capture est utilisé.
+C'est pratique en mode lot, où chaque fichier a sa propre heure de capture :
+
+[source]
+----
+sdo=load_sdo(resolution: 1024; channel: "0171"; date: img(0))
+----
+
 [[custom-functions]]
 === Fonctions personnalisées
 

--- a/jsolex-core/src/main/functions/draw_text.yml
+++ b/jsolex-core/src/main/functions/draw_text.yml
@@ -56,12 +56,12 @@ arguments:
     description: Image(s)
   - name: x
     description:
-      fr: "Coordonnéee X"
-      en: "X coordinate"
+      fr: "Coordonnée X, depuis la gauche. Une valeur négative est comptée depuis le bord droit, et le texte est aligné à droite."
+      en: "X coordinate, from the left. A negative value is counted from the right edge, and the text is right aligned."
   - name: y
     description:
-      fr: "Coordonnée Y"
-      en: "Y coordinate"
+      fr: "Coordonnée Y, depuis le haut. Une valeur négative est comptée depuis le bord bas, et le texte est aligné en bas."
+      en: "Y coordinate, from the top. A negative value is counted from the bottom edge, and the text is aligned to the bottom."
   - name:  text
     description:
       fr: "Texte à écrire"
@@ -80,3 +80,5 @@ arguments:
 examples:
   - 'draw_text(img(0), 100, 100, "Hello %OBSERVER%!")'
   - 'draw_text(img:img(0), x:100, y:100, text:"Hello %OBSERVER%!", fs: 20)'
+  - 'draw_text(img:img(0), x:20, y:-20, text:"%DATE%", fs: 24)'
+  - 'draw_text(img:img(0), x:-20, y:-20, text:"%OBSERVER%", fs: 24)'

--- a/jsolex-core/src/main/functions/load_sdo.yml
+++ b/jsolex-core/src/main/functions/load_sdo.yml
@@ -1,0 +1,45 @@
+name: LOAD_SDO
+category: UTILS
+description:
+  fr: "Télécharge une image du Solar Dynamics Observatory (SDO) prise au plus près d'une date donnée,
+  afin de comparer une observation avec une image spatiale du même moment.
+  L'image est mise en cache sur le disque : elle n'est téléchargée qu'une seule fois.
+  Le disque solaire détecté est renseigné automatiquement, ce qui permet d'utiliser directement
+  les fonctions qui en dépendent (autocrop2, disk_fill, annulus_mask, radius_rescale2, ...).
+  Les images SDO sont orientées avec le nord solaire en haut : pensez à faire pivoter votre image
+  de l'angle P (rotate_rad(img; angleP)) avant de les comparer."
+  en: "Downloads an image from the Solar Dynamics Observatory (SDO) taken as close as possible to a given date,
+  in order to compare an observation with a space based image of the same moment.
+  The image is cached on disk, so that it is only downloaded once.
+  The solar disk is filled in automatically, so that the functions which rely on it can be used
+  directly (autocrop2, disk_fill, annulus_mask, radius_rescale2, ...).
+  SDO images are oriented with solar north up: remember to rotate your own image by the P angle
+  (rotate_rad(img; angleP)) before comparing them."
+arguments:
+  - name: resolution
+    description:
+      fr: "Taille de l'image, en pixels : 512, 1024, 2048 ou 4096"
+      en: "Size of the image, in pixels: 512, 1024, 2048 or 4096"
+  - name: channel
+    optional: true
+    default: "0094"
+    description:
+      fr: "Canal : 0094, 0131, 0171, 0193, 0211, 0304, 0335, 1600, 1700, 4500,
+      les magnétogrammes HMIB, HMIBC, HMII, HMIIC, HMIIF, HMID,
+      ou les composites HMI171, 211193171, 304211171, 094335193"
+      en: "Channel: 0094, 0131, 0171, 0193, 0211, 0304, 0335, 1600, 1700, 4500,
+      the HMIB, HMIBC, HMII, HMIIC, HMIIF, HMID magnetograms,
+      or the HMI171, 211193171, 304211171, 094335193 composites"
+  - name: date
+    optional: true
+    default: date of the observation
+    description:
+      fr: "Date recherchée, soit au format ISO (par exemple 2026-07-25T10:30:00), soit une image dont la date de capture sera utilisée.
+      Par défaut, la date de l'observation en cours."
+      en: "Requested date, either in ISO format (for example 2026-07-25T10:30:00), or an image whose capture date will be used.
+      Defaults to the date of the current observation."
+examples:
+  - "load_sdo(1024)"
+  - 'load_sdo(resolution: 2048, channel: "0193")'
+  - 'load_sdo(resolution: 1024, channel: "HMIIC", date: "2026-07-25T10:30:00")'
+  - 'load_sdo(resolution: 1024, channel: "0171", date: img(0))'

--- a/jsolex-core/src/main/functions/radius_rescale2.yml
+++ b/jsolex-core/src/main/functions/radius_rescale2.yml
@@ -1,17 +1,37 @@
 name: RADIUS_RESCALE2
 category: ROTATION
 description:
-  fr: "Redimensionne une image pour avoir un rayon solaire spécifique (en pixels) tout en conservant les dimensions finales spécifiées. Le disque solaire est centré dans l'image résultante."
-  en: "Rescales an image to have a specific solar radius (in pixels) while maintaining the specified final dimensions. The solar disk is centered in the resulting image."
+  fr: "Redimensionne une image pour avoir un rayon solaire spécifique (en pixels) tout en conservant les dimensions finales spécifiées. Le disque solaire est centré dans l'image résultante.
+  Au lieu de donner ces valeurs, vous pouvez fournir une image de référence avec `ref` : l'image sera alors redimensionnée pour avoir le même rayon solaire et les mêmes dimensions qu'elle, sans que l'image de référence ne soit modifiée."
+  en: "Rescales an image to have a specific solar radius (in pixels) while maintaining the specified final dimensions. The solar disk is centered in the resulting image.
+  Instead of giving these values, you can supply a reference image with `ref`: the image will then be rescaled to have the same solar radius and the same dimensions as it, leaving the reference image untouched."
 arguments:
   - name: img
     description: Image to rescale
   - name: radius
-    description: Target radius in pixels
+    optional: true
+    default: radius of the reference image
+    description:
+      fr: "Rayon cible en pixels"
+      en: "Target radius in pixels"
   - name: width
-    description: Final image width
+    optional: true
+    default: width of the reference image
+    description:
+      fr: "Largeur de l'image finale"
+      en: "Final image width"
   - name: height
-    description: Final image height
+    optional: true
+    default: height of the reference image
+    description:
+      fr: "Hauteur de l'image finale"
+      en: "Final image height"
+  - name: ref
+    optional: true
+    description:
+      fr: "Image de référence dont le rayon solaire et les dimensions doivent être repris"
+      en: "Reference image whose solar radius and dimensions must be matched"
 examples:
   - "radius_rescale2(img, 500, 1024, 1024)"
   - "radius_rescale2(img: my_image, radius: 400, width: 800, height: 600)"
+  - "radius_rescale2(img: sdo_image, ref: my_image)"

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
@@ -424,6 +424,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
             case LIST -> arguments.get("list");
             case LOAD -> loader.load(arguments);
             case LOAD_MANY -> loader.loadMany(arguments);
+            case LOAD_SDO -> loader.loadSdo(arguments);
             case LOG -> math.log(arguments);
             case LOG_STATS -> imageStatistics.logStats(arguments);
             case MAX -> simpleFunctionCall.applyFunction("max", arguments, DoubleStream::max);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ImageDraw.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/ImageDraw.java
@@ -255,10 +255,14 @@ public class ImageDraw extends AbstractFunctionImpl {
             }
             message = performSubstitutions(substituteScriptVariables(message), img);
             var lines = message.split("\n");
-            double lineHeight = g.getFontMetrics().getHeight();
-            double curY = y;
+            var fontMetrics = g.getFontMetrics();
+            double lineHeight = fontMetrics.getHeight();
+            // a negative coordinate is measured from the opposite edge, and the text is
+            // aligned against it, so that it stays inside the image
+            double curY = y >= 0 ? y : image.height() + y - fontMetrics.getDescent() - lineHeight * (lines.length - 1);
             for (var line : lines) {
-                g.drawString(line, x, (int) curY);
+                var lineX = x >= 0 ? x : image.width() + x - fontMetrics.stringWidth(line);
+                g.drawString(line, lineX, (int) curY);
                 curY += lineHeight;
             }
         });

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Loader.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Loader.java
@@ -16,6 +16,7 @@
 package me.champeau.a4j.jsolex.processing.expr.impl;
 
 import me.champeau.a4j.jsolex.expr.BuiltinFunction;
+import me.champeau.a4j.jsolex.processing.params.ProcessParams;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.workflow.MetadataTable;
 import me.champeau.a4j.jsolex.processing.util.FitsUtils;
@@ -25,6 +26,9 @@ import me.champeau.a4j.jsolex.processing.util.MutableMap;
 import me.champeau.a4j.jsolex.processing.util.ProcessingException;
 import me.champeau.a4j.jsolex.processing.util.RGBImage;
 import me.champeau.a4j.jsolex.processing.util.RawImageIO;
+import me.champeau.a4j.jsolex.processing.util.SDO;
+import me.champeau.a4j.math.regression.Ellipse;
+import me.champeau.a4j.math.tuples.DoubleSextuplet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +39,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -44,6 +53,9 @@ import java.util.regex.Pattern;
 
 public class Loader extends AbstractFunctionImpl {
     private static final Logger LOGGER = LoggerFactory.getLogger(Loader.class);
+    private static final String DEFAULT_SDO_CHANNEL = "0094";
+    private static final String SDO_CHANNEL = "sdoChannel";
+    private static final String SDO_DATE = "sdoDate";
     private static final Set<String> RECOGNIZED_IMAGE_FORMATS = Set.of(
             "png",
             "jpg",
@@ -72,6 +84,83 @@ public class Loader extends AbstractFunctionImpl {
             return loadImage(file);
         }
         throw new IllegalArgumentException("Unsupported argument '" + arg + "' to load()");
+    }
+
+    /**
+     * Downloads the SDO browse image which is the closest in time to the requested date.
+     * The solar disk is computed from the plate scale of the instrument and the apparent
+     * size of the Sun at that date, and attached to the image, so that all the functions
+     * which need a solar disk can be used on the result.
+     *
+     * @param arguments function arguments containing:
+     *                  - resolution: the width of the frame, in pixels
+     *                  - channel: the channel code, defaults to 0094
+     *                  - date: the requested date, defaults to the date of the observation
+     * @return the SDO image
+     */
+    public Object loadSdo(Map<String, Object> arguments) {
+        BuiltinFunction.LOAD_SDO.validateArgs(arguments);
+        var resolution = intArg(arguments, "resolution", 0);
+        if (resolution <= 0) {
+            throw new IllegalArgumentException("load_sdo requires a resolution in pixels (512, 1024, 2048 or 4096)");
+        }
+        var channel = stringArg(arguments, "channel", DEFAULT_SDO_CHANNEL);
+        var date = sdoDate(arguments);
+        var candidate = SDO.findClosest(date, channel, resolution)
+                .orElseThrow(() -> new ProcessingException("No SDO image found for channel '" + channel + "' at resolution " + resolution + " around " + date));
+        var url = SDO.fetchCandidateImage(candidate)
+                .orElseThrow(() -> new ProcessingException("Unable to download SDO image " + candidate.fileName()));
+        BufferedImage image;
+        try (var stream = url.openStream()) {
+            image = ImageIO.read(stream);
+        } catch (IOException e) {
+            throw new ProcessingException("Unable to read SDO image " + candidate.fileName(), e);
+        }
+        if (image == null) {
+            throw new ProcessingException("Unable to decode SDO image " + candidate.fileName());
+        }
+        var properties = MutableMap.<String, String>of();
+        properties.put(MetadataTable.FILE_NAME, candidate.fileName());
+        properties.put(SDO_CHANNEL, candidate.channel());
+        properties.put(SDO_DATE, candidate.timestamp().format(DateTimeFormatter.ISO_INSTANT));
+        var metadata = MutableMap.<Class<?>, Object>of();
+        metadata.put(MetadataTable.class, new MetadataTable(properties));
+        metadata.put(Ellipse.class, solarDisk(image.getWidth(), image.getHeight(), candidate.solarDiskRadius()));
+        LOGGER.info("Using SDO {} image taken at {}", candidate.channel(), candidate.timestamp());
+        return toImageWrapper(image, metadata);
+    }
+
+    private ZonedDateTime sdoDate(Map<String, Object> arguments) {
+        var date = arguments.get("date");
+        if (date instanceof ImageWrapper image) {
+            return observationDate(image.findMetadata(ProcessParams.class).orElse(null));
+        }
+        if (date instanceof String text && !text.isBlank()) {
+            try {
+                return ZonedDateTime.parse(text);
+            } catch (DateTimeParseException e) {
+                return LocalDateTime.parse(text).atZone(ZoneId.of("UTC"));
+            }
+        }
+        return observationDate(null);
+    }
+
+    private ZonedDateTime observationDate(ProcessParams params) {
+        var resolved = params != null ? params : getFromContext(ProcessParams.class).orElse(null);
+        if (resolved == null) {
+            throw new ProcessingException("load_sdo requires a date, which could not be determined from the observation");
+        }
+        return resolved.observationDetails().date();
+    }
+
+    /**
+     * Builds the conic of a circle of the given radius, centered in an image of the
+     * given dimensions.
+     */
+    private static Ellipse solarDisk(int width, int height, double radius) {
+        var cx = (width - 1) / 2d;
+        var cy = (height - 1) / 2d;
+        return Ellipse.ofCartesian(new DoubleSextuplet(1, 0, 1, -2 * cx, -2 * cy, cx * cx + cy * cy - radius * radius));
     }
 
     /**

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Scaling.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Scaling.java
@@ -115,12 +115,24 @@ public class Scaling extends AbstractFunctionImpl {
         int targetRadius = intArg(arguments, "radius", 0);
         int width = intArg(arguments, "width", 0);
         int height = intArg(arguments, "height", 0);
+        if (arguments.get("ref") instanceof ImageWrapper reference) {
+            if (width <= 0) {
+                width = reference.width();
+            }
+            if (height <= 0) {
+                height = reference.height();
+            }
+            if (targetRadius <= 0) {
+                var referenceEllipse = withSolarDisk(reference).findMetadata(Ellipse.class).orElseThrow();
+                targetRadius = (int) Math.round(radiusOf(referenceEllipse));
+            }
+        }
 
         if (targetRadius <= 0) {
-            throw new IllegalArgumentException("Target radius must be > 0");
+            throw new IllegalArgumentException("radius_rescale2 requires a target radius, either directly or through a reference image");
         }
         if (width <= 0 || height <= 0) {
-            throw new IllegalArgumentException("Width and height must be > 0");
+            throw new IllegalArgumentException("radius_rescale2 requires a width and a height, either directly or through a reference image");
         }
 
         if (arg instanceof ImageWrapper img) {
@@ -129,17 +141,23 @@ public class Scaling extends AbstractFunctionImpl {
         throw new IllegalArgumentException("Unsupported image type");
     }
 
-    ImageWrapper performRadiusRescale2(ImageWrapper img, int targetRadius, int width, int height) {
-        ImageWrapper withEllipse = img;
-        var ellipse = img.findMetadata(Ellipse.class).orElse(null);
-        if (ellipse == null) {
-            withEllipse = (ImageWrapper) ellipseFit.fit(Map.of("img", img));
-            ellipse = withEllipse.findMetadata(Ellipse.class).orElse(null);
+    /**
+     * Returns the image along with its solar disk, detecting it if it is not already known.
+     */
+    private ImageWrapper withSolarDisk(ImageWrapper img) {
+        if (img.findMetadata(Ellipse.class).isPresent()) {
+            return img;
         }
-
-        if (ellipse == null) {
+        var fitted = (ImageWrapper) ellipseFit.fit(Map.of("img", img));
+        if (fitted.findMetadata(Ellipse.class).isEmpty()) {
             throw new IllegalArgumentException("Unable to determine ellipse fitting for the image");
         }
+        return fitted;
+    }
+
+    ImageWrapper performRadiusRescale2(ImageWrapper img, int targetRadius, int width, int height) {
+        var withEllipse = withSolarDisk(img);
+        var ellipse = withEllipse.findMetadata(Ellipse.class).orElseThrow();
 
         var currentRadius = radiusOf(ellipse);
         var scale = targetRadius / currentRadius;

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/GONG.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/GONG.java
@@ -18,16 +18,12 @@ package me.champeau.a4j.jsolex.processing.util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -39,17 +35,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
-
-import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectoriesIfNeeded;
 
 public class GONG {
     private static final Logger LOGGER = LoggerFactory.getLogger(GONG.class);
-    private static final Pattern LINK = Pattern.compile("a href=\"([^\"]*)\"");
     private static final Pattern FILENAME = Pattern.compile("(\\d{4})(\\d{2})(\\d{2})(\\d{2})(\\d{2})(\\d{2})([A-Za-z])h\\.jpg");
-    private static final Lock LOCK = new ReentrantLock();
     private static final Map<String, String> SITE_NAMES = Map.of(
         "A", "Boulder",
         "B", "Big Bear",
@@ -142,111 +132,49 @@ public class GONG {
     }
 
     private static List<GongCandidate> listGongCandidates(ZonedDateTime date, GongResolution resolution, Path targetFolder) {
+        var utcDate = date.withZoneSameInstant(ZoneId.of("UTC"));
+        var yearmoday = String.format("%04d%02d%02d", utcDate.getYear(), utcDate.getMonthValue(), utcDate.getDayOfMonth());
         try {
-            LOCK.lock();
-            var utcDate = date.withZoneSameInstant(ZoneId.of("UTC"));
-            var yearmo = String.format("%04d%02d", utcDate.getYear(), utcDate.getMonthValue());
-            var yearmoday = String.format("%04d%02d%02d", utcDate.getYear(), utcDate.getMonthValue(), utcDate.getDayOfMonth());
-            try {
-                var baseUrl = new URI(String.format("https://gong2.nso.edu/ftp/HA/%s/%s/%s/", resolution.dir(), yearmo, yearmoday)).toURL();
-                var availableLinks = listJpgLinks(utcDate, resolution, baseUrl, targetFolder);
-                var candidates = new ArrayList<GongCandidate>();
-                for (var link : availableLinks) {
-                    var parts = FILENAME.matcher(link);
-                    if (parts.find()) {
-                        var linkDate = ZonedDateTime.of(
-                            Integer.parseInt(parts.group(1)),
-                            Integer.parseInt(parts.group(2)),
-                            Integer.parseInt(parts.group(3)),
-                            Integer.parseInt(parts.group(4)),
-                            Integer.parseInt(parts.group(5)),
-                            Integer.parseInt(parts.group(6)),
-                            0,
-                            ZoneId.of("UTC"));
-                        var siteCode = parts.group(7).toUpperCase(Locale.ROOT);
-                        candidates.add(new GongCandidate(new URI(baseUrl + link).toURL(), linkDate, siteCode, link, resolution));
-                    }
-                }
-                candidates.sort(Comparator.comparingLong(c -> Math.abs(c.timestamp.toEpochSecond() - utcDate.toEpochSecond())));
-                return candidates;
-            } catch (FileNotFoundException e) {
-                // The day/resolution directory does not exist yet: GONG has no
-                // images for that date. This is an expected condition (e.g. for
-                // the current day before any image has been posted).
-                LOGGER.debug("No GONG images available for {} ({})", yearmoday, resolution.dir());
-                return List.of();
-            } catch (URISyntaxException | IOException e) {
-                LOGGER.warn("Failed to list GONG images for {}", yearmoday, e);
-                return List.of();
-            }
-        } finally {
-            LOCK.unlock();
-        }
-    }
-
-    /**
-     * Returns the {@code .jpg} links available for the requested day. For a day
-     * fully in the past (UTC), no new images can be posted any more, so the
-     * listing is immutable and is cached on disk to avoid re-fetching it from
-     * the server on every request. The current (or future) day is always
-     * fetched from the network.
-     */
-    private static List<String> listJpgLinks(ZonedDateTime utcDate, GongResolution resolution, URL baseUrl, Path targetFolder) throws IOException {
-        var listingCacheFile = targetFolder.resolve(dayCacheKey(utcDate, resolution)).resolve("listing.txt");
-        var pastDay = isPastUtcDay(utcDate);
-        if (pastDay && Files.exists(listingCacheFile)) {
-            return Files.readAllLines(listingCacheFile);
-        }
-        var links = new ArrayList<String>();
-        try (var reader = new BufferedReader(new InputStreamReader(baseUrl.openStream()))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                var matcher = LINK.matcher(line);
-                while (matcher.find()) {
-                    var link = matcher.group(1);
-                    if (link.endsWith(".jpg")) {
-                        links.add(link);
-                    }
+            var baseUrl = new URI(String.format("https://gong2.nso.edu/ftp/HA/%s/%s/%s/",
+                resolution.dir(),
+                String.format("%04d%02d", utcDate.getYear(), utcDate.getMonthValue()),
+                yearmoday)).toURL();
+            var listingCacheFile = targetFolder.resolve(dayCacheKey(utcDate, resolution)).resolve("listing.txt");
+            var availableLinks = RemoteImageCache.listJpgLinks(baseUrl, listingCacheFile, RemoteImageCache.isPastUtcDay(utcDate));
+            var candidates = new ArrayList<GongCandidate>();
+            for (var link : availableLinks) {
+                var parts = FILENAME.matcher(link);
+                if (parts.find()) {
+                    var linkDate = ZonedDateTime.of(
+                        Integer.parseInt(parts.group(1)),
+                        Integer.parseInt(parts.group(2)),
+                        Integer.parseInt(parts.group(3)),
+                        Integer.parseInt(parts.group(4)),
+                        Integer.parseInt(parts.group(5)),
+                        Integer.parseInt(parts.group(6)),
+                        0,
+                        ZoneId.of("UTC"));
+                    var siteCode = parts.group(7).toUpperCase(Locale.ROOT);
+                    candidates.add(new GongCandidate(new URI(baseUrl + link).toURL(), linkDate, siteCode, link, resolution));
                 }
             }
+            candidates.sort(Comparator.comparingLong(c -> Math.abs(c.timestamp.toEpochSecond() - utcDate.toEpochSecond())));
+            return candidates;
+        } catch (FileNotFoundException e) {
+            // The day/resolution directory does not exist yet: GONG has no
+            // images for that date. This is an expected condition (e.g. for
+            // the current day before any image has been posted).
+            LOGGER.debug("No GONG images available for {} ({})", yearmoday, resolution.dir());
+            return List.of();
+        } catch (URISyntaxException | IOException e) {
+            LOGGER.warn("Failed to list GONG images for {}", yearmoday, e);
+            return List.of();
         }
-        if (pastDay && !links.isEmpty()) {
-            createDirectoriesIfNeeded(listingCacheFile.getParent());
-            Files.write(listingCacheFile, links);
-        }
-        return links;
-    }
-
-    private static boolean isPastUtcDay(ZonedDateTime utcDate) {
-        return utcDate.toLocalDate().isBefore(ZonedDateTime.now(ZoneId.of("UTC")).toLocalDate());
     }
 
     private static Optional<URL> fetchCandidateImage(GongCandidate candidate, Path targetFolder) {
-        try {
-            LOCK.lock();
-            var cacheDir = targetFolder.resolve(cacheKey(candidate.timestamp, candidate.resolution));
-            var cachedImagePath = cacheDir.resolve(candidate.fileName);
-            if (Files.exists(cachedImagePath)) {
-                try {
-                    return Optional.of(cachedImagePath.toUri().toURL());
-                } catch (Exception e) {
-                    LOGGER.warn("Failed to create URL from cached GONG image", e);
-                }
-            }
-            try {
-                createDirectoriesIfNeeded(cacheDir);
-                LOGGER.debug("Downloading GONG image {} to cache", candidate.fileName);
-                try (var inputStream = candidate.url.openStream()) {
-                    Files.copy(inputStream, cachedImagePath, StandardCopyOption.REPLACE_EXISTING);
-                    return Optional.of(cachedImagePath.toUri().toURL());
-                }
-            } catch (IOException e) {
-                LOGGER.warn("Failed to cache GONG image, returning direct URL", e);
-                return Optional.of(candidate.url);
-            }
-        } finally {
-            LOCK.unlock();
-        }
+        var cachedImagePath = targetFolder.resolve(cacheKey(candidate.timestamp, candidate.resolution)).resolve(candidate.fileName);
+        return RemoteImageCache.fetchImage(candidate.url, cachedImagePath);
     }
 
     private static String cacheKey(ZonedDateTime utcDate, GongResolution resolution) {

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/RemoteImageCache.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/RemoteImageCache.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Pattern;
+
+import static me.champeau.a4j.jsolex.processing.util.FilesUtils.createDirectoriesIfNeeded;
+
+/**
+ * On-disk cache for images fetched from observatory archives which publish their
+ * files as browsable directory listings, such as GONG or SDO.
+ */
+public final class RemoteImageCache {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RemoteImageCache.class);
+    private static final Pattern LINK = Pattern.compile("a href=\"([^\"]*)\"");
+    private static final Lock LOCK = new ReentrantLock();
+
+    private RemoteImageCache() {
+    }
+
+    /**
+     * Returns the {@code .jpg} links found in the directory listing at the given URL.
+     * A listing which can no longer change is cached on disk, so that it is only
+     * fetched from the server once.
+     *
+     * @param listingUrl the directory listing to read
+     * @param listingCacheFile where the listing is cached
+     * @param immutable whether the listing can still change on the server
+     * @return the list of jpg file names
+     */
+    public static List<String> listJpgLinks(URL listingUrl, Path listingCacheFile, boolean immutable) throws IOException {
+        LOCK.lock();
+        try {
+            if (immutable && Files.exists(listingCacheFile)) {
+                return Files.readAllLines(listingCacheFile);
+            }
+            var links = new ArrayList<String>();
+            try (var reader = new BufferedReader(new InputStreamReader(listingUrl.openStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    var matcher = LINK.matcher(line);
+                    while (matcher.find()) {
+                        var link = matcher.group(1);
+                        if (link.endsWith(".jpg")) {
+                            links.add(link);
+                        }
+                    }
+                }
+            }
+            if (immutable && !links.isEmpty()) {
+                createDirectoriesIfNeeded(listingCacheFile.getParent());
+                Files.write(listingCacheFile, links);
+            }
+            return links;
+        } finally {
+            LOCK.unlock();
+        }
+    }
+
+    /**
+     * Downloads an image unless it is already present in the cache, and returns the
+     * URL it can be read from. If the image cannot be cached, the remote URL is
+     * returned so that callers can still use it.
+     *
+     * @param imageUrl the remote image
+     * @param cachedImagePath where the image is cached
+     * @return the URL to read the image from
+     */
+    public static Optional<URL> fetchImage(URL imageUrl, Path cachedImagePath) {
+        LOCK.lock();
+        try {
+            if (Files.exists(cachedImagePath)) {
+                try {
+                    return Optional.of(cachedImagePath.toUri().toURL());
+                } catch (Exception e) {
+                    LOGGER.warn("Failed to create URL from cached image {}", cachedImagePath, e);
+                }
+            }
+            try {
+                createDirectoriesIfNeeded(cachedImagePath.getParent());
+                LOGGER.debug("Downloading {} to cache", imageUrl);
+                try (var inputStream = imageUrl.openStream()) {
+                    Files.copy(inputStream, cachedImagePath, StandardCopyOption.REPLACE_EXISTING);
+                    return Optional.of(cachedImagePath.toUri().toURL());
+                }
+            } catch (IOException e) {
+                LOGGER.warn("Failed to cache image, returning direct URL", e);
+                return Optional.of(imageUrl);
+            }
+        } finally {
+            LOCK.unlock();
+        }
+    }
+
+    /**
+     * Returns true when the given date is on a day which is fully in the past, in
+     * which case no new image can be published for it any more.
+     */
+    public static boolean isPastUtcDay(ZonedDateTime utcDate) {
+        return utcDate.toLocalDate().isBefore(ZonedDateTime.now(ZoneId.of("UTC")).toLocalDate());
+    }
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/SDO.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/SDO.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Access to the browse images published by the Solar Dynamics Observatory, which
+ * are useful to compare an observation with a space based one taken at the same
+ * time.
+ * <p>
+ * The images are published as one directory per day, each containing the frames of
+ * every channel at several resolutions, named {@code YYYYMMDD_HHMMSS_<res>_<channel>.jpg}
+ * with timestamps in UTC.
+ */
+public class SDO {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SDO.class);
+    private static final Pattern FILENAME = Pattern.compile("(\\d{4})(\\d{2})(\\d{2})_(\\d{2})(\\d{2})(\\d{2})_(\\d+)_(\\w+)\\.jpg");
+    private static final ZoneId UTC = ZoneId.of("UTC");
+
+    /**
+     * The channels which are sampled on the HMI detector. Everything else, including
+     * the composites which blend a magnetogram with an AIA channel, is published on
+     * the AIA grid.
+     */
+    private static final Set<String> HMI_CHANNELS = Set.of("HMIB", "HMIBC", "HMII", "HMIIC", "HMIIF", "HMID");
+
+    /**
+     * Plate scale of the AIA detector, in arcseconds per pixel, for a full resolution
+     * 4096 pixels wide frame.
+     */
+    private static final double AIA_ARCSEC_PER_PIXEL = 0.600;
+
+    /**
+     * Plate scale of the HMI detector, in arcseconds per pixel, for a full resolution
+     * 4096 pixels wide frame.
+     */
+    private static final double HMI_ARCSEC_PER_PIXEL = 0.504;
+
+    private static final int FULL_RESOLUTION = 4096;
+
+    /**
+     * A single SDO browse image available on the server.
+     *
+     * @param url where the image can be downloaded from
+     * @param timestamp the UTC date and time the frame was taken
+     * @param channel the channel code, for example {@code 0094} or {@code HMIIC}
+     * @param resolution the width and height of the frame, in pixels
+     * @param fileName the name of the file on the server
+     */
+    public record SdoCandidate(URL url, ZonedDateTime timestamp, String channel, int resolution, String fileName) {
+        /**
+         * Computes the radius of the solar disk in this frame, in pixels. The browse
+         * images preserve the plate scale of the detector, so the disk grows and
+         * shrinks over the year as the Earth-Sun distance varies.
+         *
+         * @return the radius of the solar disk, in pixels
+         */
+        public double solarDiskRadius() {
+            var solarParams = SolarParametersUtils.computeSolarParams(timestamp.withZoneSameInstant(UTC).toLocalDateTime());
+            var radiusArcsec = Math.toDegrees(solarParams.apparentSize()) * 1800;
+            var arcsecPerPixel = arcsecPerPixel(channel) * FULL_RESOLUTION / resolution;
+            return radiusArcsec / arcsecPerPixel;
+        }
+    }
+
+    private SDO() {
+    }
+
+    private static double arcsecPerPixel(String channel) {
+        return HMI_CHANNELS.contains(channel.toUpperCase(Locale.ROOT)) ? HMI_ARCSEC_PER_PIXEL : AIA_ARCSEC_PER_PIXEL;
+    }
+
+    /**
+     * Returns the browse image whose timestamp is the closest to the requested date.
+     *
+     * @param date the requested date
+     * @param channel the channel code
+     * @param resolution the width of the frame, in pixels
+     * @return the closest frame, if any is available
+     */
+    public static Optional<SdoCandidate> findClosest(ZonedDateTime date, String channel, int resolution) {
+        return findClosest(date, channel, resolution, defaultCacheFolder());
+    }
+
+    public static Optional<SdoCandidate> findClosest(ZonedDateTime date, String channel, int resolution, Path targetFolder) {
+        var utcDate = date.withZoneSameInstant(UTC);
+        // the cadence of a channel can exceed the distance to the day boundary, so the
+        // neighbouring days are searched as well
+        var candidates = new ArrayList<SdoCandidate>();
+        candidates.addAll(listCandidates(utcDate.minusDays(1), channel, resolution, targetFolder));
+        candidates.addAll(listCandidates(utcDate, channel, resolution, targetFolder));
+        candidates.addAll(listCandidates(utcDate.plusDays(1), channel, resolution, targetFolder));
+        return candidates.stream()
+            .min(Comparator.comparingLong(c -> Math.abs(c.timestamp.toEpochSecond() - utcDate.toEpochSecond())));
+    }
+
+    /**
+     * Lists the browse images available for the day of the requested date, for a
+     * single channel and resolution.
+     *
+     * @param date the requested date
+     * @param channel the channel code
+     * @param resolution the width of the frame, in pixels
+     * @param targetFolder the cache folder
+     * @return the frames available that day, sorted by increasing distance to the requested date
+     */
+    public static List<SdoCandidate> listCandidates(ZonedDateTime date, String channel, int resolution, Path targetFolder) {
+        var utcDate = date.withZoneSameInstant(UTC);
+        var day = String.format("%04d/%02d/%02d", utcDate.getYear(), utcDate.getMonthValue(), utcDate.getDayOfMonth());
+        try {
+            var baseUrl = new URI("https://sdo.gsfc.nasa.gov/assets/img/browse/" + day + "/").toURL();
+            var listingCacheFile = targetFolder.resolve(day).resolve("listing.txt");
+            var availableLinks = RemoteImageCache.listJpgLinks(baseUrl, listingCacheFile, RemoteImageCache.isPastUtcDay(utcDate));
+            var candidates = new ArrayList<SdoCandidate>();
+            for (var link : availableLinks) {
+                var parts = FILENAME.matcher(link);
+                if (parts.find()) {
+                    if (Integer.parseInt(parts.group(7)) != resolution || !parts.group(8).equalsIgnoreCase(channel)) {
+                        continue;
+                    }
+                    var linkDate = ZonedDateTime.of(
+                        Integer.parseInt(parts.group(1)),
+                        Integer.parseInt(parts.group(2)),
+                        Integer.parseInt(parts.group(3)),
+                        Integer.parseInt(parts.group(4)),
+                        Integer.parseInt(parts.group(5)),
+                        Integer.parseInt(parts.group(6)),
+                        0,
+                        UTC);
+                    candidates.add(new SdoCandidate(new URI(baseUrl + link).toURL(), linkDate, parts.group(8), resolution, link));
+                }
+            }
+            candidates.sort(Comparator.comparingLong(c -> Math.abs(c.timestamp.toEpochSecond() - utcDate.toEpochSecond())));
+            return candidates;
+        } catch (FileNotFoundException e) {
+            // the day directory does not exist yet, which is expected for the current
+            // day before any image has been published
+            LOGGER.debug("No SDO images available for {}", day);
+            return List.of();
+        } catch (URISyntaxException | IOException e) {
+            LOGGER.warn("Failed to list SDO images for {}", day, e);
+            return List.of();
+        }
+    }
+
+    /**
+     * Downloads a browse image, or returns it from the cache if it was already fetched.
+     *
+     * @param candidate the image to download
+     * @return the URL the image can be read from
+     */
+    public static Optional<URL> fetchCandidateImage(SdoCandidate candidate) {
+        return fetchCandidateImage(candidate, defaultCacheFolder());
+    }
+
+    public static Optional<URL> fetchCandidateImage(SdoCandidate candidate, Path targetFolder) {
+        var utcDate = candidate.timestamp.withZoneSameInstant(UTC);
+        var cachedImagePath = targetFolder
+            .resolve(String.format("%04d/%02d/%02d", utcDate.getYear(), utcDate.getMonthValue(), utcDate.getDayOfMonth()))
+            .resolve(candidate.fileName);
+        return RemoteImageCache.fetchImage(candidate.url, cachedImagePath);
+    }
+
+    private static Path defaultCacheFolder() {
+        return VersionUtil.getJsolexDir().resolve("sdo");
+    }
+}

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/SolarParametersUtils.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/util/SolarParametersUtils.java
@@ -117,7 +117,7 @@ public final class SolarParametersUtils {
                 + (0.019993 - 0.000101 * t) * sin(2 * m)
                 + 0.000289 * sin(3 * m);
         var trueLong = geoMeanLong + c;
-        var trueAnomaly = m + c;
+        var trueAnomaly = m + toRadians(c);
         var apparentLong = trueLong - 0.00569 - 0.00478 * sin(toRadians(125.04 - 1934.136 * t));
         // Page 147
         var meanObliquity = 23.439291111d - 0.013004167d * t - 0.000000164d * t * t + 0.000000504d * t * t * t;
@@ -149,7 +149,7 @@ public final class SolarParametersUtils {
         var l0 = toRadians(l0Degrees);
 
         var eccentricity = 0.016708634 - 0.000042037 * t - 0.0000001267 * t * t;
-        var earthSunDist = 1.000001018 * (1 - eccentricity * eccentricity) / (1 + eccentricity * cos(toRadians(trueAnomaly)));
+        var earthSunDist = 1.000001018 * (1 - eccentricity * eccentricity) / (1 + eccentricity * cos(trueAnomaly));
         var sunApparentSizeDegrees = (959.63 / earthSunDist) / 1800;
         return new FullSolarParameters(
             new SolarParameters(

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/impl/DrawTextAnchorTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/impl/DrawTextAnchorTest.groovy
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.expr.impl
+
+import me.champeau.a4j.jsolex.processing.sun.Broadcaster
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32
+import me.champeau.a4j.jsolex.processing.util.RGBImage
+import spock.lang.Specification
+
+/**
+ * A negative coordinate given to {@code draw_text} is counted from the opposite edge,
+ * and the text is aligned against that edge so that it stays inside the image.
+ */
+class DrawTextAnchorTest extends Specification {
+
+    private static final int WIDTH = 400
+    private static final int HEIGHT = 300
+
+    private ImageDraw imageDraw() {
+        new ImageDraw(Map.of(), Broadcaster.NO_OP, () -> Map.of())
+    }
+
+    private static ImageWrapper32 blank() {
+        new ImageWrapper32(WIDTH, HEIGHT, new float[HEIGHT][WIDTH], [:])
+    }
+
+    /** Bounding box of the pixels which were painted, as [minX, minY, maxX, maxY]. */
+    private static List<Integer> inkBounds(RGBImage image) {
+        var minX = WIDTH, minY = HEIGHT, maxX = -1, maxY = -1
+        var data = image.r()
+        for (int y = 0; y < HEIGHT; y++) {
+            for (int x = 0; x < WIDTH; x++) {
+                if (data[y][x] > 0) {
+                    minX = Math.min(minX, x)
+                    minY = Math.min(minY, y)
+                    maxX = Math.max(maxX, x)
+                    maxY = Math.max(maxY, y)
+                }
+            }
+        }
+        [minX, minY, maxX, maxY]
+    }
+
+    private List<Integer> draw(int x, int y, String text) {
+        inkBounds((RGBImage) imageDraw().drawText(blank(), text, x, y, 'FFFFFF', 20))
+    }
+
+    def "a positive coordinate anchors to the top left"() {
+        when:
+        def (minX, minY, maxX, maxY) = draw(20, 40, "Hello")
+
+        then: "the text starts at x and sits above the baseline y"
+        minX >= 20
+        minX < 40
+        maxY <= 40
+        minY > 40 - 30
+    }
+
+    def "a negative y anchors the text to the bottom"() {
+        when:
+        def (minX, minY, maxX, maxY) = draw(20, -20, "Hello")
+
+        then: "the bottom of the text is about 20px above the bottom edge"
+        maxY < HEIGHT - 20
+        maxY > HEIGHT - 20 - 12
+
+        and: "it is still left aligned"
+        minX >= 20
+        minX < 40
+    }
+
+    def "a negative x anchors the text to the right"() {
+        when:
+        def (minX, minY, maxX, maxY) = draw(-20, 40, "Hello")
+
+        then: "the right end of the text is about 20px from the right edge"
+        maxX <= WIDTH - 20
+        maxX > WIDTH - 20 - 12
+    }
+
+    def "a multiline block anchored to the bottom stays inside the image"() {
+        when:
+        def (minX, minY, maxX, maxY) = draw(20, -20, "first\nsecond\nthird")
+
+        then:
+        minY >= 0
+        maxY < HEIGHT - 20
+
+        and: "it is taller than a single line, so all three lines were drawn"
+        (maxY - minY) > 40
+    }
+
+    def "a multiline block anchored to the bottom would overflow without the shift"() {
+        given: "the same block anchored from the top at the same distance"
+        def fromBottom = draw(20, -20, "first\nsecond\nthird")
+        def naive = draw(20, HEIGHT - 20, "first\nsecond\nthird")
+
+        expect: "anchoring from the bottom keeps everything visible"
+        fromBottom[3] < HEIGHT
+
+        and: "whereas a naive top anchor at the same place loses lines"
+        (naive[3] - naive[1]) < (fromBottom[3] - fromBottom[1])
+    }
+
+    def "both coordinates negative anchors to the bottom right"() {
+        when:
+        def (minX, minY, maxX, maxY) = draw(-20, -20, "Hello")
+
+        then:
+        maxX <= WIDTH - 20
+        maxX > WIDTH - 20 - 12
+        maxY < HEIGHT - 20
+        maxY > HEIGHT - 20 - 12
+    }
+}

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/impl/RadiusRescaleRefTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/impl/RadiusRescaleRefTest.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.expr.impl
+
+import me.champeau.a4j.jsolex.processing.sun.Broadcaster
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32
+import me.champeau.a4j.math.regression.Ellipse
+import me.champeau.a4j.math.tuples.DoubleSextuplet
+import spock.lang.Specification
+
+/**
+ * {@code radius_rescale2} can be given a reference image instead of explicit numbers,
+ * so that an image downloaded from an observatory can be brought to the scale of the
+ * observation it is compared to, without touching the observation itself.
+ */
+class RadiusRescaleRefTest extends Specification {
+
+    private Scaling scaling() {
+        var context = new HashMap<Class<?>, Object>()
+        new Scaling(context, Broadcaster.NO_OP, new Crop(context, Broadcaster.NO_OP))
+    }
+
+    private static Ellipse circle(double cx, double cy, double radius) {
+        Ellipse.ofCartesian(new DoubleSextuplet(1, 0, 1, -2 * cx, -2 * cy, cx * cx + cy * cy - radius * radius))
+    }
+
+    private static ImageWrapper32 disk(int size, double radius) {
+        var data = new float[size][size]
+        var c = (size - 1) / 2d
+        for (int y = 0; y < size; y++) {
+            for (int x = 0; x < size; x++) {
+                data[y][x] = ((x - c) * (x - c) + (y - c) * (y - c) <= radius * radius) ? 30000f : 0f
+            }
+        }
+        var metadata = new LinkedHashMap<Class<?>, Object>()
+        metadata.put(Ellipse.class, circle(c, c, radius))
+        new ImageWrapper32(size, size, data, metadata)
+    }
+
+    def "a reference image provides the target radius and dimensions"() {
+        given:
+        def source = disk(400, 160)
+        def reference = disk(600, 200)
+
+        when:
+        def result = scaling().radiusRescale2([img: source, ref: reference])
+
+        then: "the result has the dimensions of the reference"
+        result.width() == 600
+        result.height() == 600
+
+        and: "and its disk has the radius of the reference"
+        def semiAxis = result.findMetadata(Ellipse.class).get().semiAxis()
+        Math.abs(semiAxis.a() - 200) < 2
+        Math.abs(semiAxis.b() - 200) < 2
+    }
+
+    def "the reference image is left untouched"() {
+        given:
+        def source = disk(400, 160)
+        def reference = disk(600, 200)
+
+        when:
+        scaling().radiusRescale2([img: source, ref: reference])
+
+        then:
+        reference.width() == 600
+        reference.findMetadata(Ellipse.class).get().semiAxis().a() == 200
+    }
+
+    def "explicit values still win over the reference"() {
+        given:
+        def source = disk(400, 160)
+        def reference = disk(600, 200)
+
+        when:
+        def result = scaling().radiusRescale2([img: source, ref: reference, width: 256, height: 256])
+
+        then:
+        result.width() == 256
+        result.height() == 256
+        Math.abs(result.findMetadata(Ellipse.class).get().semiAxis().a() - 200) < 2
+    }
+
+    def "a missing radius is reported"() {
+        when:
+        scaling().radiusRescale2([img: disk(400, 160), width: 256, height: 256])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('radius')
+    }
+}

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/util/RemoteImageCacheTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/util/RemoteImageCacheTest.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.util
+
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class RemoteImageCacheTest extends Specification {
+
+    @TempDir
+    Path tempDir
+
+    private static final String LISTING = '''
+        <html><body>
+        <a href="20260725_001500_1024_0094.jpg">first</a>
+        <a href="20260725_002400_1024_0094.jpg">second</a>
+        <a href="listing.txt">not an image</a>
+        </body></html>
+    '''
+
+    private URL listingUrl(String content) {
+        var file = Files.createTempFile(tempDir, 'listing', '.html')
+        Files.writeString(file, content)
+        file.toUri().toURL()
+    }
+
+    private Path cacheFile() {
+        tempDir.resolve('cache').resolve('listing.txt')
+    }
+
+    def "only keeps the jpg links of a directory listing"() {
+        when:
+        var links = RemoteImageCache.listJpgLinks(listingUrl(LISTING), cacheFile(), false)
+
+        then:
+        links == ['20260725_001500_1024_0094.jpg', '20260725_002400_1024_0094.jpg']
+    }
+
+    def "an immutable listing is cached on disk and reused"() {
+        given:
+        var first = listingUrl(LISTING)
+
+        when:
+        var initial = RemoteImageCache.listJpgLinks(first, cacheFile(), true)
+
+        then:
+        initial.size() == 2
+        Files.exists(cacheFile())
+
+        when: "the server publishes a different listing"
+        var updated = listingUrl('<a href="something_else.jpg">x</a>')
+        var second = RemoteImageCache.listJpgLinks(updated, cacheFile(), true)
+
+        then: "the cached listing is returned instead"
+        second == initial
+    }
+
+    def "a listing which can still change is never cached"() {
+        given:
+        var first = listingUrl(LISTING)
+
+        when:
+        var initial = RemoteImageCache.listJpgLinks(first, cacheFile(), false)
+
+        then:
+        initial.size() == 2
+        !Files.exists(cacheFile())
+
+        when:
+        var updated = listingUrl('<a href="something_else.jpg">x</a>')
+        var second = RemoteImageCache.listJpgLinks(updated, cacheFile(), false)
+
+        then:
+        second == ['something_else.jpg']
+    }
+
+    def "an empty listing is not cached, so that it can be fetched again"() {
+        when:
+        var links = RemoteImageCache.listJpgLinks(listingUrl('<html></html>'), cacheFile(), true)
+
+        then:
+        links.isEmpty()
+        !Files.exists(cacheFile())
+    }
+
+    def "an image is downloaded once then served from the cache"() {
+        given:
+        var source = Files.writeString(tempDir.resolve('source.jpg'), 'original')
+        var target = tempDir.resolve('cache').resolve('image.jpg')
+
+        when:
+        var first = RemoteImageCache.fetchImage(source.toUri().toURL(), target)
+
+        then:
+        first.present
+        Files.readString(Path.of(first.get().toURI())) == 'original'
+
+        when: "the remote image changes but the cached copy is still present"
+        Files.writeString(source, 'updated')
+        var second = RemoteImageCache.fetchImage(source.toUri().toURL(), target)
+
+        then: "the cached copy is returned"
+        Files.readString(Path.of(second.get().toURI())) == 'original'
+    }
+
+    def "the direct url is returned when the image cannot be cached"() {
+        given:
+        var source = Files.writeString(tempDir.resolve('source.jpg'), 'original')
+        var blocker = Files.writeString(tempDir.resolve('blocker'), 'not a directory')
+        var target = blocker.resolve('image.jpg')
+
+        when:
+        var result = RemoteImageCache.fetchImage(source.toUri().toURL(), target)
+
+        then:
+        result.present
+        result.get() == source.toUri().toURL()
+    }
+
+    def "yesterday is a past day but today is not"() {
+        given:
+        var now = ZonedDateTime.now(ZoneId.of('UTC'))
+
+        expect:
+        RemoteImageCache.isPastUtcDay(now.minusDays(1))
+        !RemoteImageCache.isPastUtcDay(now)
+        !RemoteImageCache.isPastUtcDay(now.plusDays(1))
+    }
+}

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/util/SDOGeometryTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/util/SDOGeometryTest.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.util
+
+import spock.lang.Specification
+
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+/**
+ * The reference radii below were measured on the browse images published by SDO,
+ * by locating the limb on a radial brightness profile. The AIA figure comes from
+ * the 4500 white light channel and the HMI one from the HMIIC continuum, because
+ * both show the photospheric limb, unlike the EUV channels whose limb brightening
+ * ring sits about 1.6% higher.
+ */
+class SDOGeometryTest extends Specification {
+
+    private static final ZonedDateTime APHELION_SIDE = ZonedDateTime.of(2026, 7, 25, 0, 15, 0, 0, ZoneId.of('UTC'))
+    private static final ZonedDateTime PERIHELION_SIDE = ZonedDateTime.of(2026, 1, 4, 0, 15, 0, 0, ZoneId.of('UTC'))
+
+    private static SDO.SdoCandidate candidate(ZonedDateTime date, String channel, int resolution) {
+        new SDO.SdoCandidate(new URL('file:///unused.jpg'), date, channel, resolution, 'unused.jpg')
+    }
+
+    def "computes the solar disk radius of an AIA frame"() {
+        expect:
+        Math.abs(candidate(APHELION_SIDE, channel, 1024).solarDiskRadius() - 393.6) < 1.0
+
+        where:
+        channel << ['0094', '0131', '0171', '0193', '0211', '0304', '0335', '1600', '1700', '4500']
+    }
+
+    def "computes the solar disk radius of an HMI frame"() {
+        expect:
+        Math.abs(candidate(APHELION_SIDE, channel, 1024).solarDiskRadius() - 468.6) < 1.0
+
+        where:
+        channel << ['HMIB', 'HMIBC', 'HMII', 'HMIIC', 'HMIIF', 'HMID']
+    }
+
+    def "composite channels are published on the AIA grid"() {
+        expect:
+        Math.abs(candidate(APHELION_SIDE, channel, 1024).solarDiskRadius() - 393.6) < 1.0
+
+        where:
+        channel << ['HMI171', '211193171', '211193171n', '211193171rg', '304211171', '094335193']
+    }
+
+    def "channel codes are matched regardless of case"() {
+        expect:
+        candidate(APHELION_SIDE, 'hmiic', 1024).solarDiskRadius() == candidate(APHELION_SIDE, 'HMIIC', 1024).solarDiskRadius()
+    }
+
+    def "the radius scales with the resolution of the frame"() {
+        given:
+        def at1024 = candidate(APHELION_SIDE, '0094', 1024).solarDiskRadius()
+
+        expect:
+        Math.abs(candidate(APHELION_SIDE, '0094', resolution).solarDiskRadius() - at1024 * resolution / 1024) < 0.001
+
+        where:
+        resolution << [512, 2048, 4096]
+    }
+
+    def "the disk is larger near perihelion than near aphelion"() {
+        given:
+        def summer = candidate(APHELION_SIDE, '0094', 1024).solarDiskRadius()
+        def winter = candidate(PERIHELION_SIDE, '0094', 1024).solarDiskRadius()
+
+        expect:
+        Math.abs(winter - 406.6) < 1.0
+        Math.abs((winter / summer - 1) * 100 - 3.3) < 0.2
+    }
+}

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/util/SolarParametersUtilsTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/util/SolarParametersUtilsTest.groovy
@@ -92,6 +92,35 @@ class SolarParametersUtilsTest extends Specification {
         ]
     }
 
+    def "apparent solar radius follows the Earth-Sun distance over the year"() {
+        given:
+        def radiusArcsec = { LocalDateTime date ->
+            Math.toDegrees(SolarParametersUtils.computeSolarParams(date).apparentSize()) * 1800
+        }
+
+        when:
+        def atPerihelion = radiusArcsec(LocalDateTime.of(2026, 1, 3, 0, 0))
+        def atAphelion = radiusArcsec(LocalDateTime.of(2026, 7, 6, 0, 0))
+
+        then: "the Sun is largest at perihelion and smallest at aphelion"
+        Math.abs(atPerihelion - 975.9) < 1.0
+        Math.abs(atAphelion - 944.0) < 1.0
+
+        and: "the peak to peak variation is about 3.4%"
+        Math.abs((atPerihelion / atAphelion - 1) * 100 - 3.4) < 0.2
+    }
+
+    def "apparent solar radius stays within the physical bounds all year long"() {
+        when:
+        def radii = (0..364).collect {
+            Math.toDegrees(SolarParametersUtils.computeSolarParams(LocalDateTime.of(2026, 1, 1, 0, 0).plusDays(it)).apparentSize()) * 1800
+        }
+
+        then:
+        radii.min() > 943.0
+        radii.max() < 977.0
+    }
+
     def "Carrington rotation increments correctly"() {
         given:
         def startOfRotation = SolarParametersUtils.CARRINGTON_ROTATION_1_START + (2303 * SolarParametersUtils.CARRINGTON_ROTATION_PERIOD)

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -21,10 +21,14 @@
 - When sharing to SpectroSolHub, you can now choose which image is used as the reference for orientation.
 - Stacked images now keep the spectral line of the source images instead of falling back to the wrong wavelength.
 - Rotating an image now fills the corners it creates with the background level of the image instead of black, unless a fill value is given.
+- The apparent size of the Sun, stored in FITS files and available to Python scripts, no longer stays the same all year long and again grows in January and shrinks in July.
 
 ### ImageMath scripts
 
 
+- A new `load_sdo` scripting function downloads the Solar Dynamics Observatory image taken closest to your observation, with its solar disk already positioned, so that you can place it side by side with your own image.
+- The `radius_rescale2` scripting function now accepts a reference image, and resizes its argument to the same solar disk size, which avoids having to work out the numbers yourself.
+- The `draw_text` scripting function now accepts negative coordinates, counted from the right and bottom edges, which makes it possible to place a caption in the lower corners whatever the size of the image.
 - The `unsharp_mask` function no longer brightens the whole image on top of sharpening it, so its result is darker and more contrasted than before for the same strength.
 - A new `noise_sigma` scripting function measures the noise of an image, which lets a script rate the quality of each file of a batch instead of judging it by eye.
 - The `deghost` function can now remove several reflections at once, wherever they are around the disk.

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -21,10 +21,14 @@
 - Lors du partage vers SpectroSolHub, vous pouvez désormais choisir quelle image sert de référence pour l'orientation.
 - Les images empilées conservent désormais la raie spectrale des images source au lieu de revenir à une longueur d'onde incorrecte.
 - La rotation d'une image remplit désormais les coins créés avec le niveau du fond de l'image au lieu du noir, sauf si une valeur de remplissage est précisée.
+- La taille apparente du Soleil, enregistrée dans les fichiers FITS et accessible aux scripts Python, ne reste plus identique toute l'année et grossit à nouveau en janvier pour diminuer en juillet.
 
 ### Scripts ImageMath
 
 
+- Une nouvelle fonction de script `load_sdo` télécharge l'image du Solar Dynamics Observatory la plus proche de votre observation, avec son disque solaire déjà positionné, afin de la placer côte à côte avec votre propre image.
+- La fonction de script `radius_rescale2` accepte désormais une image de référence, et redimensionne son argument à la même taille de disque solaire, ce qui évite d'avoir à calculer les valeurs soi-même.
+- La fonction de script `draw_text` accepte désormais des coordonnées négatives, comptées depuis les bords droit et bas, ce qui permet de placer une légende dans les coins inférieurs quelle que soit la taille de l'image.
 - La fonction `unsharp_mask` n'éclaircit plus toute l'image en plus de l'accentuer, son résultat est donc plus sombre et plus contrasté qu'avant pour une même force.
 - Une nouvelle fonction de script `noise_sigma` mesure le bruit d'une image, ce qui permet à un script d'évaluer la qualité de chaque fichier d'un lot au lieu de la juger à l'œil.
 - La fonction `deghost` peut désormais supprimer plusieurs reflets à la fois, où qu'ils soient autour du disque.


### PR DESCRIPTION
Adds `load_sdo`, which downloads the SDO browse image closest in time to an observation and attaches its solar disk, so that it can be placed side by side with a Sol'Ex image using the existing functions. The date defaults to the observation, and can also be given explicitly or taken from another image.

NASA does not document the geometry of the browse JPEGs, so it was derived from the images themselves: the disk is centred, and the plate scale is the native one of the detector, 0.600"/px for AIA and 0.504"/px for HMI at 4096 pixels. The disk therefore has to be sized from the date. This was validated against the 4500 and HMIIC channels, which show the photospheric limb, unlike the EUV channels whose limb brightening ring sits about 1.6% higher.

This uncovered a unit mix-up in the solar ephemeris: the true anomaly added an angle in radians to one in degrees, then converted the sum again, which left the apparent size of the Sun frozen at about 944" all year long instead of varying between 944" and 976". It is stored in FITS files and exposed to Python scripts.

The GONG download and listing cache is extracted into RemoteImageCache and reused for SDO, so that both only hit the network once per image and per past day. `radius_rescale2` now accepts a reference image, and matches its solar radius and dimensions, which avoids computing them by hand and leaves the reference untouched. `draw_text` now accepts negative coordinates, counted from the right and bottom edges and aligned against them, so a caption can be placed in the lower corners whatever the image size.