### PR TITLE
fix: weighted_avg2 doesn't support single item list

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Utilities.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/Utilities.java
@@ -265,6 +265,27 @@ public class Utilities extends AbstractFunctionImpl {
         return null;
     }
 
+    /**
+     * Reads an argument which is expected to be a list, but which functions producing a single
+     * element collapse to that element, for example when a batch consists of a single file.
+     *
+     * @param arguments the function arguments
+     * @param key the argument name
+     * @param elementType the type of a single element
+     * @return the list, or null if the argument is neither a list nor a single element
+     */
+    private static List<?> asElementList(Map<String, Object> arguments, String key, Class<?> elementType) {
+        var list = tryGetList(arguments, key);
+        if (list != null) {
+            return list;
+        }
+        var value = arguments.get(key);
+        if (elementType.isInstance(value)) {
+            return List.of(value);
+        }
+        return null;
+    }
+
     public Object weightedAverage(Map<String ,Object> arguments) {
         BuiltinFunction.WEIGHTED_AVG.validateArgs(arguments);
         var inputs = weightedInputs("weighted_avg", arguments);
@@ -322,10 +343,10 @@ public class Utilities extends AbstractFunctionImpl {
     }
 
     private WeightedInputs weightedInputs(String name, Map<String, Object> arguments) {
-        if (!(tryGetList(arguments, "images") instanceof List<?> images)) {
+        if (!(asElementList(arguments, "images", ImageWrapper.class) instanceof List<?> images)) {
             throw new IllegalArgumentException(name + " expects a list of images as first argument");
         }
-        if (!(tryGetList(arguments, "weights") instanceof List<?> weights)) {
+        if (!(asElementList(arguments, "weights", Number.class) instanceof List<?> weights)) {
             throw new IllegalArgumentException(name + " expects a list of weights as second argument");
         }
         if (images.size() != weights.size()) {

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/impl/WeightedAverageTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/expr/impl/WeightedAverageTest.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.expr.impl
+
+import me.champeau.a4j.jsolex.processing.sun.Broadcaster
+import me.champeau.a4j.jsolex.processing.util.ImageWrapper32
+import spock.lang.Specification
+import spock.lang.Subject
+
+class WeightedAverageTest extends Specification {
+
+    @Subject
+    Utilities utilities = new Utilities([:], Broadcaster.NO_OP)
+
+    private static ImageWrapper32 image(float value) {
+        float[][] data = new float[2][2]
+        for (int y = 0; y < 2; y++) {
+            for (int x = 0; x < 2; x++) {
+                data[y][x] = value
+            }
+        }
+        new ImageWrapper32(2, 2, data, [:])
+    }
+
+    def "weighted_avg accepts a single image and a single weight"() {
+        when:
+        def result = utilities.weightedAverage([images: image(10f), weights: 4d])
+
+        then:
+        result instanceof ImageWrapper32
+        result.data()[0][0] == 10f
+    }
+
+    def "weighted_avg2 accepts a single image and a single weight"() {
+        when:
+        def result = utilities.weightedAverage2([images: image(10f), weights: 4d, sigma: 2.5d])
+
+        then:
+        result instanceof ImageWrapper32
+        result.data()[0][0] == 10f
+    }
+
+    def "weighted_avg2 accepts single element lists"() {
+        when:
+        def result = utilities.weightedAverage2([images: [image(10f)], weights: [4d], sigma: 2.5d])
+
+        then:
+        result instanceof ImageWrapper32
+        result.data()[0][0] == 10f
+    }
+
+    def "weighted_avg2 still averages multiple images"() {
+        when:
+        def result = utilities.weightedAverage2([images: [image(10f), image(20f)], weights: [1d, 3d], sigma: 2.5d])
+
+        then:
+        result.data()[0][0] == 17.5f
+    }
+
+    def "weighted_avg2 rejects a mismatch between images and weights"() {
+        when:
+        utilities.weightedAverage2([images: [image(10f), image(20f)], weights: 4d, sigma: 2.5d])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('same number of images and weights')
+    }
+}

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -1,5 +1,9 @@
 # Welcome to JSol'Ex {{version}}!
 
+## What's New in Version 5.4.1
+
+- Fixed the `weighted_avg` and `weighted_avg2` scripting functions failing when a batch consists of a single file.
+
 ## What's New in Version 5.4.0
 
 - **Important change for scripts**: operations between images no longer modify their result to keep it in the displayable range. A subtraction keeps negative values, instead of shifting the whole image to make it positive, and averaging images keeps values brighter than white. Scripts which subtract the continuum may therefore look different, and can use the new `lift` function to restore the previous result.

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -1,5 +1,9 @@
 # Bienvenue dans JSol'Ex {{version}} !
 
+## Nouveautés de la version 5.4.1
+
+- Correction des fonctions de script `weighted_avg` et `weighted_avg2` qui échouaient lorsqu'un lot ne contenait qu'un seul fichier.
+
 ## Nouveautés de la version 5.4.0
 
 - **Changement important pour les scripts** : les opérations entre images ne modifient plus leur résultat pour le maintenir dans la plage affichable. Une soustraction conserve les valeurs négatives, au lieu de décaler toute l'image pour la rendre positive, et la moyenne d'images conserve les valeurs plus brillantes que le blanc. Les scripts qui soustraient le continuum peuvent donc donner un résultat différent, et peuvent utiliser la nouvelle fonction `lift` pour retrouver le résultat précédent.


### PR DESCRIPTION
This commit fixes the weighted_avg2 function which didn't work with a list of a single item, which can happen when a batch contains a single entry.