### PR TITLE
fix: Fix override parameters all ignored if one had a problem

### DIFF
--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ScriptProcessParamsOverrides.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/params/ScriptProcessParamsOverrides.java
@@ -95,7 +95,9 @@ public final class ScriptProcessParamsOverrides {
      */
     public static Map<String, String> flatten(JsonObject overrides) {
         var result = new LinkedHashMap<String, String>();
-        flattenInto(overrides, "", result);
+        for (var entry : flattenValues(overrides).entrySet()) {
+            result.put(entry.getKey(), entry.getValue().getAsString());
+        }
         return result;
     }
 
@@ -122,19 +124,23 @@ public final class ScriptProcessParamsOverrides {
      */
     public static List<String> overridablePaths(ProcessParams params) {
         var gson = ProcessParamsIO.newGsonBuilder().create();
-        var flattened = new LinkedHashMap<String, String>();
-        flattenInto(gson.toJsonTree(params).getAsJsonObject(), "", flattened);
-        return List.copyOf(flattened.keySet());
+        return List.copyOf(flattenValues(gson.toJsonTree(params).getAsJsonObject()).keySet());
     }
 
-    private static void flattenInto(JsonObject source, String prefix, Map<String, String> target) {
+    private static Map<String, JsonElement> flattenValues(JsonObject source) {
+        var result = new LinkedHashMap<String, JsonElement>();
+        flattenValuesInto(source, "", result);
+        return result;
+    }
+
+    private static void flattenValuesInto(JsonObject source, String prefix, Map<String, JsonElement> target) {
         for (var entry : source.entrySet()) {
             var path = prefix.isEmpty() ? entry.getKey() : prefix + "." + entry.getKey();
             var value = entry.getValue();
             if (value.isJsonObject()) {
-                flattenInto(value.getAsJsonObject(), path, target);
+                flattenValuesInto(value.getAsJsonObject(), path, target);
             } else if (value.isJsonPrimitive()) {
-                target.put(path, value.getAsString());
+                target.put(path, value);
             }
         }
     }
@@ -149,13 +155,15 @@ public final class ScriptProcessParamsOverrides {
     public static JsonObject merge(Iterable<JsonObject> overrides) {
         var merged = new JsonObject();
         for (var override : overrides) {
-            mergeInto(merged, override.deepCopy(), "", false);
+            mergeInto(merged, override.deepCopy(), "");
         }
         return merged;
     }
 
     /**
-     * Applies the overrides to the supplied process parameters.
+     * Applies the overrides to the supplied process parameters. Each override is applied
+     * and validated independently, so that a single one which cannot be applied doesn't
+     * discard the others.
      *
      * @param params the process parameters
      * @param overrides the overrides declared by scripts
@@ -167,35 +175,46 @@ public final class ScriptProcessParamsOverrides {
         }
         var gson = ProcessParamsIO.newGsonBuilder().create();
         var tree = gson.toJsonTree(params).getAsJsonObject();
-        var applicable = new JsonObject();
-        for (var entry : overrides.entrySet()) {
-            if (tree.has(entry.getKey())) {
-                applicable.add(entry.getKey(), entry.getValue());
-            } else {
-                LOGGER.warn("Ignoring unknown process parameter override '{}'", entry.getKey());
+        var result = params;
+        for (var entry : flattenValues(overrides).entrySet()) {
+            var path = entry.getKey();
+            var candidate = tree.deepCopy();
+            putAtPath(candidate, path, entry.getValue());
+            try {
+                var updated = gson.fromJson(candidate, ProcessParams.class);
+                if (getAtPath(gson.toJsonTree(updated).getAsJsonObject(), path) == null) {
+                    LOGGER.warn("Ignoring unknown process parameter override '{}'", path);
+                    continue;
+                }
+                result = updated;
+                tree = candidate;
+            } catch (RuntimeException e) {
+                LOGGER.warn("Ignoring process parameter override '{}': {}", path, e.getMessage());
             }
         }
-        if (applicable.isEmpty()) {
-            return params;
-        }
-        mergeInto(tree, applicable, "", true);
-        try {
-            return gson.fromJson(tree, ProcessParams.class);
-        } catch (RuntimeException e) {
-            LOGGER.warn("Ignoring process parameter overrides, they could not be applied: {}", e.getMessage());
-            return params;
-        }
+        return result;
     }
 
-    private static void mergeInto(JsonObject target, JsonObject source, String prefix, boolean overwrite) {
+    private static JsonElement getAtPath(JsonObject source, String path) {
+        JsonElement current = source;
+        for (var segment : path.split("\\.")) {
+            if (current == null || !current.isJsonObject()) {
+                return null;
+            }
+            current = current.getAsJsonObject().get(segment);
+        }
+        return current;
+    }
+
+    private static void mergeInto(JsonObject target, JsonObject source, String prefix) {
         for (var entry : source.entrySet()) {
             var key = entry.getKey();
             var value = entry.getValue();
             var existing = target.get(key);
             var path = prefix.isEmpty() ? key : prefix + "." + key;
             if (existing != null && existing.isJsonObject() && value.isJsonObject()) {
-                mergeInto(existing.getAsJsonObject(), value.getAsJsonObject(), path, overwrite);
-            } else if (existing == null || overwrite) {
+                mergeInto(existing.getAsJsonObject(), value.getAsJsonObject(), path);
+            } else if (existing == null) {
                 target.add(key, value);
             } else if (!existing.equals(value)) {
                 LOGGER.warn("Conflicting override for '{}': keeping {} and ignoring {}", path, existing, value);

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/params/ScriptProcessParamsOverridesTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/params/ScriptProcessParamsOverridesTest.groovy
@@ -125,8 +125,47 @@ result = img(0)
         where:
         declaration << [
                 'notAParamsGroup { passes = 0 }',
-                'geometryParams { autocropMode = "NOT_A_MODE" }'
+                'geometryParams { autocropMode = "NOT_A_MODE" }',
+                'geometryParams { notAParameter = 0 }',
+                'enhancementParams { jaggingCorrectionParams = "false" }'
         ]
+    }
+
+    def "an override which cannot be applied doesn't discard the others"() {
+        given:
+        var params = ProcessParamsIO.createNewDefaults()
+        var overrides = new ImageMathParameterExtractor().extractParameters("""
+meta {
+    overrides {
+        bandingCorrectionParams {
+            passes = 0
+        }
+        geometryParams {
+            autocropMode = "RADIUS_1_5"
+        }
+        enhancementParams {
+            artificialFlatCorrection = "false"
+            jaggingCorrectionParams = "false"
+            oscillationCorrectionParams = "false"
+        }
+    }
+}
+
+[outputs]
+result = img(0)
+""", "script.math").processParamsOverrides
+
+        when: "the nested parameter groups are overridden with a scalar"
+        var updated = ScriptProcessParamsOverrides.apply(params, overrides)
+
+        then: "the valid overrides are still applied"
+        updated.bandingCorrectionParams().passes() == 0
+        updated.geometryParams().autocropMode() == AutocropMode.RADIUS_1_5
+        !updated.enhancementParams().artificialFlatCorrection()
+
+        and: "the invalid ones are left untouched"
+        updated.enhancementParams().jaggingCorrectionParams() == params.enhancementParams().jaggingCorrectionParams()
+        updated.enhancementParams().oscillationCorrectionParams() == params.enhancementParams().oscillationCorrectionParams()
     }
 
     def "boolean parameters can be overridden"() {

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -2,6 +2,7 @@
 
 ## What's New in Version 5.4.1
 
+- Fixed the process parameters forced by a script being all ignored as soon as one of them was invalid.
 - Fixed the `weighted_avg` and `weighted_avg2` scripting functions failing when a batch consists of a single file.
 - The labels of the prominence scale can now be rotated, so that they don't overlap prominences.
 

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -2,6 +2,7 @@
 
 ## Nouveautés de la version 5.4.1
 
+- Correction des paramètres de traitement imposés par un script qui étaient tous ignorés dès que l'un d'entre eux était invalide.
 - Correction des fonctions de script `weighted_avg` et `weighted_avg2` qui échouaient lorsqu'un lot ne contenait qu'un seul fichier.
 - Les étiquettes de l'échelle des protubérances peuvent désormais être pivotées, afin qu'elles ne se superposent pas aux protubérances.
 


### PR DESCRIPTION
In a script, if the overrides section contained an error, then all parameters defined in a script would be ignored (silently), which was confusing. Now each of them is considered independently.