### PR TITLE
feat: Add a function to reduce scattered light defect

### DIFF
--- a/jsolex-core/src/main/functions/descatter.yml
+++ b/jsolex-core/src/main/functions/descatter.yml
@@ -1,0 +1,24 @@
+name: DESCATTER
+category: BACKGROUND
+description:
+  fr: "Retire le voile de fond autour du disque solaire, dû à la lumière diffusée dans l'instrument. Il apparaît comme une bande claire s'étendant au-dessus et au-dessous du disque, et s'arrêtant à gauche et à droite de celui-ci. Le disque lui-même n'est pas modifié, et les protubérances comme la couronne sont préservées. Fonctionne aussi sur les images déjà étirées."
+  en: "Removes the background veil around the solar disk, caused by light scattered inside the instrument. It shows up as a bright band extending above and below the disk, and stopping to its left and right. The disk itself is not modified, and prominences and corona are preserved. Also works on images which have already been stretched."
+arguments:
+  - name: img
+    description: Image(s)
+  - name: strength
+    optional: true
+    default: 1
+    description:
+      fr: "Fraction du fond estimé qui est retirée. Utilisez une valeur inférieure à 1 pour une correction partielle, 0 pour n'appliquer aucune correction."
+      en: "Fraction of the estimated background which is removed. Use a value below 1 for a partial correction, 0 to apply no correction at all."
+  - name: iterations
+    optional: true
+    default: 1
+    description:
+      fr: "Nombre de passes. Une seconde passe ne retire que ce que la première a laissé. Avec 0, l'image n'est pas modifiée."
+      en: "Number of passes. A second pass only removes what the first one left behind. With 0, the image is left untouched."
+examples:
+  - "descatter(img(0))"
+  - "descatter(img: someImage; strength: 0.8)"
+  - "autocrop2(descatter(img(0)); 1.5)"

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/AbstractImageExpressionEvaluator.java
@@ -353,6 +353,7 @@ public abstract class AbstractImageExpressionEvaluator extends ExpressionEvaluat
             case BINNING -> getBinning();
             case BG_MODEL -> bgRemoval.backgroundModel(arguments);
             case COLUMN_BG_MODEL -> bgRemoval.columnBackgroundModel(arguments);
+            case DESCATTER -> bgRemoval.descatter(arguments);
             case SAVE_RAW -> loader.saveRaw(arguments);
             case BLUR -> convolution.blur(arguments);
             case CLAHE -> clahe.clahe(arguments);

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/BackgroundRemoval.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/impl/BackgroundRemoval.java
@@ -18,6 +18,7 @@ package me.champeau.a4j.jsolex.processing.expr.impl;
 import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.ColumnBackground;
+import me.champeau.a4j.jsolex.processing.sun.ScatteredLight;
 import me.champeau.a4j.jsolex.processing.sun.workflow.AnalysisUtils;
 import me.champeau.a4j.jsolex.processing.util.FileBackedImage;
 import me.champeau.a4j.jsolex.processing.util.ImageWrapper;
@@ -216,5 +217,45 @@ public class BackgroundRemoval extends AbstractFunctionImpl {
         }
 
         throw new IllegalArgumentException("column_bg_model only supports mono images");
+    }
+
+    /**
+     * Removes the background left by the light scattered inside the instrument while the slit
+     * crosses the solar disk. The shape of that background along the scan axis is the chord of the
+     * solar disk, so it is taken from the ellipse instead of being estimated from the background,
+     * and only its amplitude is fitted. The disk itself is left untouched.
+     *
+     * @param arguments function arguments containing:
+     *                  - img: the input image or list of images
+     *                  - strength: the fraction of the estimated background removed (default: 1)
+     *                  - iterations: the number of passes, 0 leaving the image untouched (default: 1)
+     * @return the corrected image or list of images
+     */
+    public Object descatter(Map<String, Object> arguments) {
+        BuiltinFunction.DESCATTER.validateArgs(arguments);
+        var arg = arguments.get("img");
+        if (arg instanceof List<?>) {
+            return expandToImageList("descatter", "img", arguments, this::descatter);
+        }
+        if (arg instanceof ImageWrapper target) {
+            var iterations = intArg(arguments, "iterations", 1);
+            if (iterations <= 0) {
+                return target;
+            }
+            var ellipse = target.findMetadata(Ellipse.class);
+            if (ellipse.isEmpty()) {
+                throw new IllegalArgumentException("Cannot remove scattered light because ellipse isn't found");
+            }
+            var strength = doubleArg(arguments, "strength", 1);
+            return monoToMonoImageTransformer("descatter", "img", arguments, src -> {
+                if (src instanceof ImageWrapper32 image) {
+                    ScatteredLight.remove(image.width(), image.height(), image.data(), ellipse.get(), strength, iterations);
+                } else {
+                    throw new IllegalArgumentException("descatter only supports mono images");
+                }
+            });
+        }
+
+        throw new IllegalArgumentException("descatter only supports mono images");
     }
 }

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/ScatteredLight.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/sun/ScatteredLight.java
@@ -1,0 +1,602 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.sun;
+
+import me.champeau.a4j.math.regression.Ellipse;
+
+import java.util.Arrays;
+
+/**
+ * Removes the excess background produced by the light scattered inside the instrument while the
+ * slit crosses the solar disk.
+ * <p>
+ * In a spectroheliograph one column of the reconstructed image comes from one frame of the video,
+ * so the amount of light scattered into a column is set by the flux entering the slit at that
+ * moment. That flux is the chord of the disk at that scan position, which the ellipse gives
+ * directly: it is exactly zero outside the column range the disk was scanned in, and it is defined
+ * even under the disk, where no background pixel can be measured. Only its amplitude is fitted, as
+ * one value per line along the slit axis.
+ * <p>
+ * Taking the shape from the geometry rather than from the background is what keeps the features
+ * safe. Just outside the limb the only pixels available to measure a background are the ones
+ * holding the prominences and the corona, so a model free to choose its own shape fits them and
+ * subtracts them. Here the shape is fixed and the correction is identically zero beyond the disk's
+ * column range, which is where the limb features sit on the east-west axis.
+ * <p>
+ * The image is not always linear, and a stretched one breaks the additivity the subtraction relies
+ * on. The transfer is therefore inverted first, as a black point and an exponent chosen from the
+ * image itself: the right pair makes the fitted amplitude vary smoothly from one line to the next,
+ * while a wrong one forces it to jump, because the distortion depends on each line's own level.
+ * The identity transfer is kept unless another beats it clearly.
+ */
+public class ScatteredLight {
+    /**
+     * Limb darkening coefficient used to weight the chord. The result is insensitive to it: it
+     * only slightly rounds the profile, and the amplitude fit absorbs the difference.
+     */
+    private static final double LIMB_DARKENING = 0.6;
+
+    /**
+     * Full scale of the image values.
+     */
+    private static final double FULL_SCALE = 65535d;
+
+    /**
+     * Radius, in solar radii, beyond which a pixel is background. Slightly above 1 so that the
+     * limb itself, blurred by seeing, stays out of the fit.
+     */
+    private static final double SKY_RADIUS = 1.06;
+
+    /**
+     * Radius beyond which the background is taken to be free of any excess, used as the reference
+     * level. Falls back to the whole background when the frame is too tight for it.
+     */
+    private static final double FAR_RADIUS = 1.45;
+
+    /**
+     * Smoothing of the amplitude profile along the slit axis, in solar radii.
+     */
+    private static final double AMPLITUDE_SMOOTHING = 0.04;
+
+    /**
+     * A line must reach this fraction of the peak flux, over enough pixels, for its amplitude to
+     * be measurable. The other lines are interpolated from their neighbours.
+     */
+    private static final double MIN_FLUX = 0.25;
+
+    private static final int MIN_LINE_PIXELS = 60;
+    private static final int REJECTION_ROUNDS = 5;
+    private static final double REJECTION_SIGMA = 1.5;
+
+    /**
+     * Upper bound on the number of samples used to estimate the reference level, so that the cost
+     * does not grow with the image size.
+     */
+    private static final int MAX_BACKGROUND_SAMPLES = 200_000;
+
+    /**
+     * Candidate black points and exponents for the transfer inverse.
+     */
+    private static final double[] BLACK_POINTS = {0, 0.02, 0.05};
+    private static final double[] EXPONENTS = {0.75, 1.0, 1.25, 1.5, 2.0};
+
+    /**
+     * A non identity transfer is only used when it beats the identity by this factor, so that an
+     * image which is already linear is left alone.
+     */
+    private static final double ACCEPTANCE_FACTOR = 1.3;
+
+    private ScatteredLight() {
+    }
+
+    /**
+     * Removes the scattered light background from an image, in place.
+     * <p>
+     * Each pass measures the amplitude again on the result of the previous one, so a second pass
+     * only acts on what the first left behind.
+     *
+     * @param width the image width
+     * @param height the image height
+     * @param data the image data, modified in place
+     * @param ellipse the solar disk
+     * @param strength the fraction of the estimated background which is subtracted
+     * @param iterations the number of passes, zero leaving the image untouched
+     */
+    public static void remove(int width, int height, float[][] data, Ellipse ellipse, double strength, int iterations) {
+        if (strength == 0 || iterations <= 0) {
+            return;
+        }
+        for (int i = 0; i < iterations; i++) {
+            removeOnce(width, height, data, ellipse, strength);
+        }
+    }
+
+    private static void removeOnce(int width, int height, float[][] data, Ellipse ellipse, double strength) {
+        var center = ellipse.center();
+        double cx = center.a();
+        double cy = center.b();
+        double radius = (ellipse.semiAxis().a() + ellipse.semiAxis().b()) / 2;
+        if (radius <= 0) {
+            return;
+        }
+        var rows = validRows(width, height, data);
+        int firstRow = rows[0];
+        int lastRow = rows[1];
+        var flux = chordFlux(width, height, cx, cy, radius);
+
+        var transfer = selectTransfer(width, height, data, flux, cx, cy, radius, firstRow, lastRow);
+        double blackPoint = transfer[0];
+        double exponent = transfer[1];
+
+        double base = referenceLevel(width, data, blackPoint, exponent, cx, cy, radius, firstRow, lastRow);
+        var amplitude = amplitudeProfile(width, height, data, blackPoint, exponent, base, flux,
+            cx, cy, radius, firstRow, lastRow);
+        smooth(amplitude, AMPLITUDE_SMOOTHING * radius, firstRow, lastRow);
+
+        for (int y = firstRow; y <= lastRow; y++) {
+            double gain = strength * amplitude[y];
+            if (gain <= 0) {
+                continue;
+            }
+            var line = data[y];
+            double dy = y - cy;
+            for (int x = 0; x < width; x++) {
+                double f = flux[x];
+                if (f <= 0) {
+                    continue;
+                }
+                double dx = x - cx;
+                if (Math.sqrt(dx * dx + dy * dy) / radius <= 1) {
+                    continue;
+                }
+                double value = line[x] / FULL_SCALE;
+                if (value <= blackPoint) {
+                    continue;
+                }
+                double corrected = linearize(value, blackPoint, exponent) - gain * f;
+                if (corrected < 0) {
+                    corrected = 0;
+                }
+                line[x] = (float) (delinearize(corrected, blackPoint, exponent) * FULL_SCALE);
+            }
+        }
+    }
+
+    /**
+     * Determines the lines which carry data. Padding added when fitting an image to a canvas is a
+     * constant fill, so it is found by looking for lines holding a single value, contiguous with
+     * the top and bottom borders. When no such line exists every line carries content and none is
+     * excluded: dropping lines which hold real signal would leave them uncorrected.
+     */
+    static int[] validRows(int width, int height, float[][] data) {
+        float min = Float.MAX_VALUE;
+        float max = -Float.MAX_VALUE;
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                float v = data[y][x];
+                min = Math.min(min, v);
+                max = Math.max(max, v);
+            }
+        }
+        double tolerance = Math.max(1e-6, 1e-3 * (max - min));
+        int first = -1;
+        int last = -1;
+        boolean anyConstant = false;
+        for (int y = 0; y < height; y++) {
+            float lineMin = Float.MAX_VALUE;
+            float lineMax = -Float.MAX_VALUE;
+            for (int x = 0; x < width; x++) {
+                float v = data[y][x];
+                lineMin = Math.min(lineMin, v);
+                lineMax = Math.max(lineMax, v);
+            }
+            if (lineMax - lineMin <= tolerance) {
+                anyConstant = true;
+            } else {
+                if (first < 0) {
+                    first = y;
+                }
+                last = y;
+            }
+        }
+        if (!anyConstant || first < 0) {
+            return new int[]{0, height - 1};
+        }
+        return new int[]{first, last};
+    }
+
+    /**
+     * The flux entering the slit at each scan position, normalized to its maximum. This is the
+     * limb darkened chord of the disk, so it falls to zero exactly where the slit stops crossing
+     * the disk.
+     */
+    static double[] chordFlux(int width, int height, double cx, double cy, double radius) {
+        var flux = new double[width];
+        double max = 0;
+        for (int x = 0; x < width; x++) {
+            double dx = (x - cx) / radius;
+            double sum = 0;
+            for (int y = 0; y < height; y++) {
+                double dy = (y - cy) / radius;
+                double rho2 = dx * dx + dy * dy;
+                if (rho2 <= 1) {
+                    sum += 1 - LIMB_DARKENING * (1 - Math.sqrt(1 - rho2));
+                }
+            }
+            flux[x] = sum;
+            max = Math.max(max, sum);
+        }
+        if (max > 0) {
+            for (int x = 0; x < width; x++) {
+                flux[x] /= max;
+            }
+        }
+        return flux;
+    }
+
+    private static double linearize(double value, double blackPoint, double exponent) {
+        double scaled = (value - blackPoint) / (1 - blackPoint);
+        if (scaled <= 0) {
+            return 0;
+        }
+        return exponent == 1 ? scaled : Math.pow(scaled, exponent);
+    }
+
+    private static double delinearize(double value, double blackPoint, double exponent) {
+        if (value <= 0) {
+            return blackPoint;
+        }
+        double scaled = exponent == 1 ? value : Math.pow(value, 1 / exponent);
+        return scaled * (1 - blackPoint) + blackPoint;
+    }
+
+    private static double linearizeAt(float[][] data, int x, int y, double blackPoint, double exponent) {
+        return linearize(data[y][x] / FULL_SCALE, blackPoint, exponent);
+    }
+
+    /**
+     * Chooses the black point and exponent which make the fitted amplitude vary smoothly from one
+     * line to the next. Under a wrong transfer each line needs a different effective amplitude,
+     * because the distortion depends on that line's own level, and the profile jumps.
+     */
+    private static double[] selectTransfer(int width, int height, float[][] data, double[] flux,
+                                           double cx, double cy, double radius, int firstRow, int lastRow) {
+        double bestScore = Double.MAX_VALUE;
+        double bestBlack = 0;
+        double bestExponent = 1;
+        double identityScore = Double.MAX_VALUE;
+        for (var blackPoint : BLACK_POINTS) {
+            for (var exponent : EXPONENTS) {
+                double base = referenceLevel(width, data, blackPoint, exponent, cx, cy, radius, firstRow, lastRow);
+                var raw = rawAmplitudes(width, height, data, blackPoint, exponent, base, flux,
+                    cx, cy, radius, firstRow, lastRow, 2);
+                double score = roughness(raw);
+                if (Double.isNaN(score)) {
+                    continue;
+                }
+                if (blackPoint == 0 && exponent == 1) {
+                    identityScore = score;
+                }
+                if (score < bestScore) {
+                    bestScore = score;
+                    bestBlack = blackPoint;
+                    bestExponent = exponent;
+                }
+            }
+        }
+        if (identityScore == Double.MAX_VALUE || bestScore * ACCEPTANCE_FACTOR >= identityScore) {
+            return new double[]{0, 1};
+        }
+        return new double[]{bestBlack, bestExponent};
+    }
+
+    /**
+     * Median absolute step of the amplitude from one measured line to the next, relative to its
+     * own level, so that transfers which simply shrink everything are not favoured.
+     */
+    private static double roughness(double[] raw) {
+        var measured = Arrays.stream(raw).filter(v -> !Double.isNaN(v)).toArray();
+        if (measured.length < 30) {
+            return Double.NaN;
+        }
+        var magnitudes = Arrays.stream(measured).map(Math::abs).toArray();
+        double level = median(magnitudes);
+        if (level <= 0) {
+            return Double.NaN;
+        }
+        var steps = new double[measured.length - 1];
+        for (int i = 0; i < steps.length; i++) {
+            steps[i] = Math.abs(measured[i + 1] - measured[i]);
+        }
+        return median(steps) / level;
+    }
+
+    private static double referenceLevel(int width, float[][] data, double blackPoint, double exponent,
+                                         double cx, double cy, double radius, int firstRow, int lastRow) {
+        var far = collectBackground(width, data, blackPoint, exponent, cx, cy, radius, firstRow, lastRow, FAR_RADIUS);
+        if (far.length < 500) {
+            far = collectBackground(width, data, blackPoint, exponent, cx, cy, radius, firstRow, lastRow, SKY_RADIUS);
+        }
+        return far.length == 0 ? 0 : median(far);
+    }
+
+    private static double[] collectBackground(int width, float[][] data, double blackPoint, double exponent,
+                                              double cx, double cy, double radius,
+                                              int firstRow, int lastRow, double minRadius) {
+        long candidates = (long) (lastRow - firstRow + 1) * width;
+        int step = (int) Math.max(1, Math.sqrt((double) candidates / MAX_BACKGROUND_SAMPLES));
+        var collected = new double[MAX_BACKGROUND_SAMPLES];
+        int count = 0;
+        for (int y = firstRow; y <= lastRow && count < collected.length; y += step) {
+            double dy = y - cy;
+            for (int x = 0; x < width && count < collected.length; x += step) {
+                double dx = x - cx;
+                if (Math.sqrt(dx * dx + dy * dy) / radius > minRadius) {
+                    collected[count++] = linearizeAt(data, x, y, blackPoint, exponent);
+                }
+            }
+        }
+        return Arrays.copyOf(collected, count);
+    }
+
+    private static double[] amplitudeProfile(int width, int height, float[][] data,
+                                             double blackPoint, double exponent, double base, double[] flux,
+                                             double cx, double cy, double radius, int firstRow, int lastRow) {
+        var raw = rawAmplitudes(width, height, data, blackPoint, exponent, base, flux,
+            cx, cy, radius, firstRow, lastRow, 1);
+        interpolate(raw, firstRow, lastRow);
+        for (int y = 0; y < raw.length; y++) {
+            if (Double.isNaN(raw[y]) || raw[y] < 0) {
+                raw[y] = 0;
+            }
+        }
+        return raw;
+    }
+
+    /**
+     * Fits, for every line, the amplitude of a background shaped like the chord. The background of
+     * the line itself is absorbed by a constant and a quadratic in radius, and the pixels sitting
+     * well above the fit are rejected, so that a prominence crossing the line cannot pull it up.
+     */
+    private static double[] rawAmplitudes(int width, int height, float[][] data,
+                                          double blackPoint, double exponent, double base, double[] flux,
+                                          double cx, double cy, double radius,
+                                          int firstRow, int lastRow, int step) {
+        var amplitudes = new double[height];
+        Arrays.fill(amplitudes, Double.NaN);
+        var radii = new double[width];
+        var fluxes = new double[width];
+        var samples = new double[width];
+        for (int y = firstRow; y <= lastRow; y += step) {
+            double dy = y - cy;
+            int count = 0;
+            double maxFlux = 0;
+            int aboveThreshold = 0;
+            for (int x = 0; x < width; x++) {
+                double dx = x - cx;
+                double r = Math.sqrt(dx * dx + dy * dy) / radius;
+                if (r <= SKY_RADIUS) {
+                    continue;
+                }
+                radii[count] = r;
+                fluxes[count] = flux[x];
+                samples[count] = linearizeAt(data, x, y, blackPoint, exponent) - base;
+                maxFlux = Math.max(maxFlux, flux[x]);
+                if (flux[x] > 0.15) {
+                    aboveThreshold++;
+                }
+                count++;
+            }
+            if (count < MIN_LINE_PIXELS || maxFlux < MIN_FLUX || aboveThreshold < MIN_LINE_PIXELS / 2) {
+                continue;
+            }
+            var value = fitLine(radii, fluxes, samples, count);
+            if (!Double.isNaN(value)) {
+                amplitudes[y] = value;
+            }
+        }
+        return amplitudes;
+    }
+
+    private static double fitLine(double[] radii, double[] fluxes, double[] samples, int count) {
+        var keep = new boolean[count];
+        Arrays.fill(keep, 0, count, true);
+        double result = Double.NaN;
+        var residuals = new double[count];
+        for (int round = 0; round < REJECTION_ROUNDS; round++) {
+            var coefficients = solveLeastSquares(radii, fluxes, samples, keep, count);
+            if (coefficients == null) {
+                return result;
+            }
+            result = coefficients[3];
+            int kept = 0;
+            for (int i = 0; i < count; i++) {
+                double r = radii[i];
+                double model = coefficients[0] + coefficients[1] * r + coefficients[2] * r * r
+                               + coefficients[3] * fluxes[i];
+                residuals[i] = samples[i] - model;
+                if (keep[i]) {
+                    kept++;
+                }
+            }
+            if (kept < 30) {
+                return result;
+            }
+            double sigma = 1.4826 * medianAbsoluteDeviation(residuals, keep, count);
+            if (sigma <= 0) {
+                return result;
+            }
+            for (int i = 0; i < count; i++) {
+                keep[i] = residuals[i] < REJECTION_SIGMA * sigma;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Solves the four parameter model by normal equations. The design is small and well scaled, so
+     * a direct elimination is enough.
+     */
+    private static double[] solveLeastSquares(double[] radii, double[] fluxes, double[] samples,
+                                              boolean[] keep, int count) {
+        var normal = new double[4][5];
+        var terms = new double[4];
+        for (int i = 0; i < count; i++) {
+            if (!keep[i]) {
+                continue;
+            }
+            double r = radii[i];
+            terms[0] = 1;
+            terms[1] = r;
+            terms[2] = r * r;
+            terms[3] = fluxes[i];
+            for (int a = 0; a < 4; a++) {
+                for (int b = 0; b < 4; b++) {
+                    normal[a][b] += terms[a] * terms[b];
+                }
+                normal[a][4] += terms[a] * samples[i];
+            }
+        }
+        for (int col = 0; col < 4; col++) {
+            int pivot = col;
+            for (int row = col + 1; row < 4; row++) {
+                if (Math.abs(normal[row][col]) > Math.abs(normal[pivot][col])) {
+                    pivot = row;
+                }
+            }
+            if (Math.abs(normal[pivot][col]) < 1e-12) {
+                return null;
+            }
+            var tmp = normal[col];
+            normal[col] = normal[pivot];
+            normal[pivot] = tmp;
+            for (int row = 0; row < 4; row++) {
+                if (row == col) {
+                    continue;
+                }
+                double factor = normal[row][col] / normal[col][col];
+                for (int c = col; c < 5; c++) {
+                    normal[row][c] -= factor * normal[col][c];
+                }
+            }
+        }
+        var solution = new double[4];
+        for (int i = 0; i < 4; i++) {
+            solution[i] = normal[i][4] / normal[i][i];
+        }
+        return solution;
+    }
+
+    private static double medianAbsoluteDeviation(double[] residuals, boolean[] keep, int count) {
+        int kept = 0;
+        for (int i = 0; i < count; i++) {
+            if (keep[i]) {
+                kept++;
+            }
+        }
+        if (kept == 0) {
+            return 0;
+        }
+        var values = new double[kept];
+        int index = 0;
+        for (int i = 0; i < count; i++) {
+            if (keep[i]) {
+                values[index++] = residuals[i];
+            }
+        }
+        double center = median(values);
+        for (int i = 0; i < values.length; i++) {
+            values[i] = Math.abs(values[i] - center);
+        }
+        return median(values);
+    }
+
+    private static void interpolate(double[] values, int firstRow, int lastRow) {
+        int previous = -1;
+        for (int y = firstRow; y <= lastRow; y++) {
+            if (Double.isNaN(values[y])) {
+                continue;
+            }
+            if (previous >= 0 && y - previous > 1) {
+                double start = values[previous];
+                double end = values[y];
+                for (int k = previous + 1; k < y; k++) {
+                    values[k] = start + (end - start) * (k - previous) / (double) (y - previous);
+                }
+            }
+            previous = y;
+        }
+        int firstMeasured = -1;
+        int lastMeasured = -1;
+        for (int y = firstRow; y <= lastRow; y++) {
+            if (!Double.isNaN(values[y])) {
+                if (firstMeasured < 0) {
+                    firstMeasured = y;
+                }
+                lastMeasured = y;
+            }
+        }
+        if (firstMeasured < 0) {
+            Arrays.fill(values, 0);
+            return;
+        }
+        for (int y = 0; y < firstMeasured; y++) {
+            values[y] = values[firstMeasured];
+        }
+        for (int y = lastMeasured + 1; y < values.length; y++) {
+            values[y] = values[lastMeasured];
+        }
+    }
+
+    private static void smooth(double[] values, double sigma, int firstRow, int lastRow) {
+        if (sigma < 1) {
+            return;
+        }
+        int radius = (int) Math.ceil(3 * sigma);
+        var kernel = new double[2 * radius + 1];
+        double sum = 0;
+        for (int i = -radius; i <= radius; i++) {
+            double w = Math.exp(-0.5 * (i / sigma) * (i / sigma));
+            kernel[i + radius] = w;
+            sum += w;
+        }
+        for (int i = 0; i < kernel.length; i++) {
+            kernel[i] /= sum;
+        }
+        var source = values.clone();
+        for (int y = 0; y < values.length; y++) {
+            double acc = 0;
+            for (int i = -radius; i <= radius; i++) {
+                int index = Math.min(Math.max(y + i, firstRow), lastRow);
+                acc += kernel[i + radius] * source[index];
+            }
+            values[y] = acc;
+        }
+    }
+
+    private static double median(double[] values) {
+        if (values.length == 0) {
+            return 0;
+        }
+        var copy = values.clone();
+        Arrays.sort(copy);
+        int middle = copy.length / 2;
+        if (copy.length % 2 == 1) {
+            return copy[middle];
+        }
+        return (copy[middle - 1] + copy[middle]) / 2;
+    }
+}

--- a/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/sun/ScatteredLightTest.groovy
+++ b/jsolex-core/src/test/groovy/me/champeau/a4j/jsolex/processing/sun/ScatteredLightTest.groovy
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.a4j.jsolex.processing.sun
+
+import me.champeau.a4j.math.regression.Ellipse
+import me.champeau.a4j.math.tuples.DoubleSextuplet
+import spock.lang.Specification
+
+class ScatteredLightTest extends Specification {
+    private static final int SIZE = 400
+    private static final double RADIUS = 130
+    private static final double SKY = 2000
+    private static final double DISK = 40000
+
+    def "removes a background shaped like the disk chord"() {
+        given: "a disk over a uniform sky, with a chord shaped background added outside it"
+        def ellipse = ellipse()
+        def flux = ScatteredLight.chordFlux(SIZE, SIZE, SIZE / 2.0d, SIZE / 2.0d, RADIUS)
+        def data = scene()
+        addScatteredLight(data, flux, 6000)
+        def outsideBefore = data[20][5]
+
+        when:
+        ScatteredLight.remove(SIZE, SIZE, data, ellipse, 1.0d, 1)
+
+        then: "the sky is brought back to a uniform level"
+        def deviation = maxSkyDeviation(data)
+        deviation < 400
+
+        and: "the correction is exactly zero where the disk never entered the slit"
+        data[20][5] == outsideBefore
+    }
+
+    def "leaves the solar disk untouched"() {
+        given:
+        def ellipse = ellipse()
+        def flux = ScatteredLight.chordFlux(SIZE, SIZE, SIZE / 2.0d, SIZE / 2.0d, RADIUS)
+        def data = scene()
+        addScatteredLight(data, flux, 6000)
+        def before = data.collect { it.clone() }
+
+        when:
+        ScatteredLight.remove(SIZE, SIZE, data, ellipse, 1.0d, 1)
+
+        then: "every pixel inside the limb keeps its exact value"
+        double worst = 0
+        for (int y = 0; y < SIZE; y++) {
+            for (int x = 0; x < SIZE; x++) {
+                def dx = (x - SIZE / 2.0d) / RADIUS
+                def dy = (y - SIZE / 2.0d) / RADIUS
+                if (Math.sqrt(dx * dx + dy * dy) <= 1) {
+                    worst = Math.max(worst, Math.abs(data[y][x] - before[y][x]))
+                }
+            }
+        }
+        worst == 0
+    }
+
+    def "preserves a prominence sitting on the background"() {
+        given: "a bright feature just outside the limb, on top of the scattered background"
+        def ellipse = ellipse()
+        def flux = ScatteredLight.chordFlux(SIZE, SIZE, SIZE / 2.0d, SIZE / 2.0d, RADIUS)
+        def data = scene()
+        addScatteredLight(data, flux, 6000)
+        def featureRow = (int) (SIZE / 2)
+        def featureColumn = (int) (SIZE / 2 + RADIUS * 1.12)
+        for (int y = featureRow - 6; y <= featureRow + 6; y++) {
+            for (int x = featureColumn - 6; x <= featureColumn + 6; x++) {
+                data[y][x] += 9000
+            }
+        }
+        def featureBefore = data[featureRow][featureColumn] - data[featureRow - 40][featureColumn]
+
+        when:
+        ScatteredLight.remove(SIZE, SIZE, data, ellipse, 1.0d, 1)
+
+        then: "the feature keeps its contrast against its surroundings"
+        def featureAfter = data[featureRow][featureColumn] - data[featureRow - 40][featureColumn]
+        featureAfter > 0.9 * featureBefore
+    }
+
+    def "does nothing when there are no iterations"() {
+        given:
+        def ellipse = ellipse()
+        def flux = ScatteredLight.chordFlux(SIZE, SIZE, SIZE / 2.0d, SIZE / 2.0d, RADIUS)
+        def data = scene()
+        addScatteredLight(data, flux, 6000)
+        def before = data.collect { it.clone() }
+
+        when:
+        ScatteredLight.remove(SIZE, SIZE, data, ellipse, 1.0d, 0)
+
+        then:
+        for (int y = 0; y < SIZE; y++) {
+            assert Arrays.equals(data[y], before[y])
+        }
+    }
+
+    def "a second pass only removes what the first left behind"() {
+        given:
+        def ellipse = ellipse()
+        def flux = ScatteredLight.chordFlux(SIZE, SIZE, SIZE / 2.0d, SIZE / 2.0d, RADIUS)
+        def once = scene()
+        addScatteredLight(once, flux, 6000)
+        def twice = once.collect { it.clone() } as float[][]
+
+        when:
+        ScatteredLight.remove(SIZE, SIZE, once, ellipse, 1.0d, 1)
+        ScatteredLight.remove(SIZE, SIZE, twice, ellipse, 1.0d, 2)
+
+        then: "the extra pass does not make the background worse"
+        maxSkyDeviation(twice) <= 1.2 * maxSkyDeviation(once)
+    }
+
+    def "does nothing when strength is zero"() {
+        given:
+        def ellipse = ellipse()
+        def flux = ScatteredLight.chordFlux(SIZE, SIZE, SIZE / 2.0d, SIZE / 2.0d, RADIUS)
+        def data = scene()
+        addScatteredLight(data, flux, 6000)
+        def before = data.collect { it.clone() }
+
+        when:
+        ScatteredLight.remove(SIZE, SIZE, data, ellipse, 0d, 1)
+
+        then:
+        for (int y = 0; y < SIZE; y++) {
+            assert Arrays.equals(data[y], before[y])
+        }
+    }
+
+    def "detects the padding added when fitting a canvas"() {
+        given: "an image padded with a constant fill at the top and bottom"
+        def data = scene()
+        for (int y = 0; y < 30; y++) {
+            Arrays.fill(data[y], 1234f)
+            Arrays.fill(data[SIZE - 1 - y], 1234f)
+        }
+
+        when:
+        def rows = ScatteredLight.validRows(SIZE, SIZE, data)
+
+        then:
+        rows[0] == 30
+        rows[1] == SIZE - 31
+    }
+
+    def "treats every line as valid when there is no padding"() {
+        when:
+        def rows = ScatteredLight.validRows(SIZE, SIZE, scene())
+
+        then:
+        rows[0] == 0
+        rows[1] == SIZE - 1
+    }
+
+    def "the chord flux vanishes outside the disk column range"() {
+        when:
+        def flux = ScatteredLight.chordFlux(SIZE, SIZE, SIZE / 2.0d, SIZE / 2.0d, RADIUS)
+
+        then: "it peaks at the centre of the disk and is zero beyond its edges"
+        flux[(int) (SIZE / 2)] == 1.0d
+        flux[(int) (SIZE / 2 - RADIUS - 2)] == 0d
+        flux[(int) (SIZE / 2 + RADIUS + 2)] == 0d
+        flux[(int) (SIZE / 2 + RADIUS * 0.5)] > 0.5d
+    }
+
+    private static float[][] scene() {
+        def data = new float[SIZE][SIZE]
+        def random = new Random(42)
+        for (int y = 0; y < SIZE; y++) {
+            for (int x = 0; x < SIZE; x++) {
+                def dx = (x - SIZE / 2.0d) / RADIUS
+                def dy = (y - SIZE / 2.0d) / RADIUS
+                def level = Math.sqrt(dx * dx + dy * dy) <= 1 ? DISK : SKY
+                // real images are never noiseless: without this a sky-only line would be
+                // exactly constant and would look like the padding added around a canvas
+                data[y][x] = (float) (level + random.nextGaussian() * 30)
+            }
+        }
+        return data
+    }
+
+    private static void addScatteredLight(float[][] data, double[] flux, double amplitude) {
+        for (int y = 0; y < SIZE; y++) {
+            def dy = (y - SIZE / 2.0d) / RADIUS
+            for (int x = 0; x < SIZE; x++) {
+                def dx = (x - SIZE / 2.0d) / RADIUS
+                if (Math.sqrt(dx * dx + dy * dy) > 1) {
+                    data[y][x] += (float) (amplitude * flux[x])
+                }
+            }
+        }
+    }
+
+    private static double maxSkyDeviation(float[][] data) {
+        double worst = 0
+        for (int y = 0; y < SIZE; y++) {
+            def dy = (y - SIZE / 2.0d) / RADIUS
+            for (int x = 0; x < SIZE; x++) {
+                def dx = (x - SIZE / 2.0d) / RADIUS
+                if (Math.sqrt(dx * dx + dy * dy) > 1.1) {
+                    worst = Math.max(worst, Math.abs(data[y][x] - SKY))
+                }
+            }
+        }
+        return worst
+    }
+
+    private static Ellipse ellipse() {
+        double c = SIZE / 2.0d
+        double a = 1.0d / (RADIUS * RADIUS)
+        double d = -2.0d * c / (RADIUS * RADIUS)
+        double f = 2 * c * c / (RADIUS * RADIUS) - 1.0d
+        return Ellipse.ofCartesian(new DoubleSextuplet(a, 0, a, d, d, f))
+    }
+}

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -2,6 +2,7 @@
 
 ## What's New in Version 5.4.1
 
+- New `descatter` ImageMath function, which removes the excess background left around the disk by the light scattered inside the instrument.
 - New "Automatic search on full spectrum" line detection, used by default, which recognizes lines that are not in your list.
 - When you select a spectral line, JSol'Ex now checks that the line it detected really is that one, and corrects itself when a neighbouring line is darker.
 - Added the Iron (Fe I 5302) line, used as a reference for corona imaging.

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -2,6 +2,7 @@
 
 ## Nouveautés de la version 5.4.1
 
+- Nouvelle fonction ImageMath `descatter`, qui retire l'excès de fond laissé autour du disque par la lumière diffusée dans l'instrument.
 - Nouvelle détection « Recherche automatique sur tout le spectre », utilisée par défaut, qui reconnaît des raies qui ne figurent pas dans votre liste.
 - Lorsque vous sélectionnez une raie spectrale, JSol'Ex vérifie maintenant que la raie détectée est bien celle-ci, et se corrige lorsqu'une raie voisine est plus sombre.
 - Ajout de la raie du fer (Fe I 5302), utilisée comme référence pour l'imagerie de la couronne.


### PR DESCRIPTION
This commit introduces a `descatter` function. This function aims at reducing scattered light effect, which is the rectangle bright light visible on the background of some images, corresponding to the solar disk. This is a physical phenomenon of light dispersion that is due to light entering the slit, which is more or less visible depending on the level of the real signal.