### PR TITLE
fix: Let `emit` support file outputs

### DIFF
--- a/build-logic/src/main/java/me/champeau/astro4j/PythonStubsGenerator.java
+++ b/build-logic/src/main/java/me/champeau/astro4j/PythonStubsGenerator.java
@@ -224,14 +224,15 @@ public abstract class PythonStubsGenerator extends AbstractBuiltinFunctionGenera
         out.println("    ...");
         out.println();
 
-        out.println("def emit(img: ImageWrapper, title: str, name: str = None, category: str = None, description: str = None) -> None:");
+        out.println("def emit(value: Any, title: str, name: str = None, category: str = None, description: str = None) -> None:");
         out.println("    \"\"\"");
-        out.println("    Emit an image to the JSol'Ex UI during script execution.");
-        out.println("    The image will be displayed in the image viewer as a script-generated image.");
+        out.println("    Emit an image or a file output (e.g. an animation) to the JSol'Ex UI during script execution.");
+        out.println("    Images are displayed in the image viewer as script-generated images, file outputs are saved");
+        out.println("    to the output directory and displayed like ImageMath file outputs.");
         out.println();
         out.println("    Args:");
-        out.println("        img: The image to emit");
-        out.println("        title: The display title for the image");
+        out.println("        value: The image or file output to emit");
+        out.println("        title: The display title");
         out.println("        name: The file name (optional, defaults to title)");
         out.println("        category: The category (optional)");
         out.println("        description: The description (optional)");

--- a/docs/src/docs/asciidoc/en/python-scripting.adoc
+++ b/docs/src/docs/asciidoc/en/python-scripting.adoc
@@ -211,7 +211,7 @@ jsolex.vars.my_result = processed_image
 |Function|Description
 |`load(path)`|Loads an image from a file
 |`save(img, path)`|Saves an image to a FITS file
-|`emit(img, title, ...)`|Emits an image to the JSol'Ex UI during execution
+|`emit(value, title, ...)`|Emits an image or a file output (e.g. an animation) to the JSol'Ex UI during execution
 |`getVariable(name)`|Gets a script parameter or variable by name
 |`getProcessParams()`|Gets the current processing parameters
 |`getSourceInfo()`|Returns `{fileName, parentDir, dateTime, width, height}` for the source SER file
@@ -233,6 +233,10 @@ jsolex.emit(img, "Enhanced",
             name="enhanced_v1",
             category="Processing",
             description="1.5x brightness")
+
+# Animations can be emitted too
+film = jsolex.funcs.anim([img0, img1, img2], 50)
+jsolex.emit(film, "My animation")
 ----
 
 == Standalone Python Scripts

--- a/docs/src/docs/asciidoc/fr/python-scripting.adoc
+++ b/docs/src/docs/asciidoc/fr/python-scripting.adoc
@@ -211,7 +211,7 @@ jsolex.vars.my_result = processed_image
 |Fonction|Description
 |`load(path)`|Charge une image depuis un fichier
 |`save(img, path)`|Sauvegarde une image en fichier FITS
-|`emit(img, title, ...)`|Émet une image vers l'interface JSol'Ex pendant l'exécution
+|`emit(value, title, ...)`|Émet une image ou un fichier généré (par exemple une animation) vers l'interface JSol'Ex pendant l'exécution
 |`getVariable(name)`|Récupère un paramètre de script ou une variable par son nom
 |`getProcessParams()`|Récupère les paramètres de traitement courants
 |`getSourceInfo()`|Retourne `{fileName, parentDir, dateTime, width, height}` pour le fichier SER source
@@ -233,6 +233,10 @@ jsolex.emit(img, "Améliorée",
             name="amelioree_v1",
             category="Traitement",
             description="Luminosité x1.5")
+
+# Les animations peuvent aussi être émises
+film = jsolex.funcs.anim([img0, img1, img2], 50)
+jsolex.emit(film, "Mon animation")
 ----
 
 == Scripts Python autonomes

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/python/PythonImageMathBridge.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/python/PythonImageMathBridge.java
@@ -17,6 +17,7 @@ package me.champeau.a4j.jsolex.processing.expr.python;
 
 import me.champeau.a4j.jsolex.expr.BuiltinFunction;
 import me.champeau.a4j.jsolex.processing.expr.AbstractImageExpressionEvaluator;
+import me.champeau.a4j.jsolex.processing.expr.FileOutputResult;
 import me.champeau.a4j.jsolex.processing.params.ProcessParams;
 import me.champeau.a4j.jsolex.processing.sun.Broadcaster;
 import me.champeau.a4j.jsolex.processing.sun.workflow.GeneratedImageKind;
@@ -145,33 +146,45 @@ public class PythonImageMathBridge implements AutoCloseable {
     }
 
     /**
-     * Emits an image to the JSol'Ex UI during script execution.
-     * The image will be displayed in the image viewer as a script-generated image.
+     * Emits an image or a file output (e.g. an animation) to the JSol'Ex UI during script execution.
+     * Images are displayed in the image viewer as script-generated images, file outputs are saved
+     * to the output directory and displayed like ImageMath file outputs.
      *
-     * @param img         the image to emit
-     * @param title       the display title for the image
+     * @param value       the image or file output to emit
+     * @param title       the display title
      * @param name        the file name (optional, defaults to title)
      * @param category    the category (optional)
      * @param description the description (optional)
      */
     @HostAccess.Export
-    public void emit(ImageWrapper img, String title, String name, String category, String description) {
+    public void emit(Object value, String title, String name, String category, String description) {
         var imageEmitter = (ImageEmitter) context.get(ImageEmitter.class);
         if (imageEmitter == null) {
-            LOGGER.warn("No ImageEmitter in context, cannot emit image: {}", title);
+            LOGGER.warn("No ImageEmitter in context, cannot emit: {}", title);
             return;
         }
-        var unwrapped = unwrap(img);
         var effectiveName = name != null ? name : title;
-        if (unwrapped instanceof ImageWrapper32 mono) {
-            imageEmitter.newMonoImage(GeneratedImageKind.IMAGE_MATH, category, title, effectiveName, description, mono);
-        } else if (unwrapped instanceof RGBImage rgb) {
-            imageEmitter.newColorImage(GeneratedImageKind.IMAGE_MATH, category, title, effectiveName, description,
-                    rgb.width(), rgb.height(), rgb.metadata(), () -> new float[][][]{rgb.r(), rgb.g(), rgb.b()});
-        } else {
-            LOGGER.warn("Unsupported image type for emit: {}", unwrapped.getClass().getName());
+        switch (value) {
+            case ImageWrapper img -> {
+                var unwrapped = unwrap(img);
+                if (unwrapped instanceof ImageWrapper32 mono) {
+                    imageEmitter.newMonoImage(GeneratedImageKind.IMAGE_MATH, category, title, effectiveName, description, mono);
+                } else if (unwrapped instanceof RGBImage rgb) {
+                    imageEmitter.newColorImage(GeneratedImageKind.IMAGE_MATH, category, title, effectiveName, description,
+                            rgb.width(), rgb.height(), rgb.metadata(), () -> new float[][][]{rgb.r(), rgb.g(), rgb.b()});
+                } else {
+                    LOGGER.warn("Unsupported image type for emit: {}", unwrapped.getClass().getName());
+                }
+            }
+            case FileOutputResult fileOutput -> {
+                for (var file : fileOutput.allFiles()) {
+                    imageEmitter.newGenericFile(GeneratedImageKind.IMAGE_MATH, category, title, effectiveName, description, file);
+                }
+            }
+            case null, default ->
+                    LOGGER.warn("Unsupported type for emit: {}", value == null ? "null" : value.getClass().getName());
         }
-        LOGGER.debug("Emitted image: {}", title);
+        LOGGER.debug("Emitted: {}", title);
     }
 
     /**

--- a/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/python/PythonScriptExecutor.java
+++ b/jsolex-core/src/main/java/me/champeau/a4j/jsolex/processing/expr/python/PythonScriptExecutor.java
@@ -290,9 +290,9 @@ public class PythonScriptExecutor {
                     _jsolex_module.load = _java_bridge.load
                     _jsolex_module.save = _java_bridge.save
                     
-                    def _emit(img, title, name=None, category=None, description=None):
-                        # Emit an image to the JSol'Ex UI during script execution
-                        _java_bridge.emit(img, title, name, category, description)
+                    def _emit(value, title, name=None, category=None, description=None):
+                        # Emit an image or file output (e.g. an animation) to the JSol'Ex UI during script execution
+                        _java_bridge.emit(value, title, name, category, description)
                     _jsolex_module.emit = _emit
                     
                     _jsolex_module.call = _java_bridge.call

--- a/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
+++ b/jsolex/src/main/java/me/champeau/a4j/jsolex/app/JSolEx.java
@@ -1586,7 +1586,6 @@ public class JSolEx implements JSolExInterface, BatchProcessingHelper.BatchConte
                     FilesUtils.writeString(imageMathScript.getText(), file.toPath());
                     imageMathScript.setIncludesDir(file.getParentFile().toPath());
                     imageMathSave.setDisable(true);
-                    scriptLanguageChoice.setDisable(true);
                     config.rememberDirectoryFor(file.toPath(), Configuration.DirectoryKind.IMAGE_MATH);
                 } catch (IOException e) {
                     // ignore
@@ -1608,7 +1607,6 @@ public class JSolEx implements JSolExInterface, BatchProcessingHelper.BatchConte
             FxUtils.runLater(() -> {
                 imageMathScript.setIncludesDir(file.getParentFile().toPath());
                 scriptLanguageChoice.setValue(language);
-                scriptLanguageChoice.setDisable(true);
                 imageMathScript.setHighlightingMode(language.getHighlightingMode());
                 imageMathScript.setText(script);
                 imageMathSave.setDisable(true);

--- a/jsolex/src/main/resources/whats-new.md
+++ b/jsolex/src/main/resources/whats-new.md
@@ -1,5 +1,10 @@
 # Welcome to JSol'Ex {{version}}!
 
+## What's New in Version 5.4.2
+
+- Python scripts can now emit animations with `jsolex.emit`.
+- Fixed the script language selector of the main window staying locked once a script had been loaded or saved.
+
 ## What's New in Version 5.4.1
 
 - More precise detection of the spectral line curvature, resulting in more accurate geometry of the reconstructed images.

--- a/jsolex/src/main/resources/whats-new_FR.md
+++ b/jsolex/src/main/resources/whats-new_FR.md
@@ -1,5 +1,10 @@
 # Bienvenue dans JSol'Ex {{version}} !
 
+## Nouveautés de la version 5.4.2
+
+- Les scripts Python peuvent désormais émettre des animations avec `jsolex.emit`.
+- Correction du sélecteur de langage de script de la fenêtre principale qui restait bloqué une fois un script chargé ou enregistré.
+
 ## Nouveautés de la version 5.4.1
 
 - Détection plus précise de la courbure de la raie spectrale, pour une géométrie plus fidèle des images reconstruites.


### PR DESCRIPTION
This commit adds support for calling the `emit` function either with images as before, or animations (new).